### PR TITLE
Reset tutorial using shared formatter

### DIFF
--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7,6 +7,7 @@ FORAGE_ITEM_IDS
 } from "../game/forage.js";
 import {
 advanceTutorial,
+ensureTutorial,
 getCurrentTutorialStep,
 formatTutorialMessage,
 formatTutorialCompletionMessage
@@ -123,6 +124,11 @@ return new EmbedBuilder()
 { name: "Coins", value: `${player.coins}c`, inline: true }
 )
 .setFooter({ text: `Owner: ${displayName}` });
+}
+
+function resetTutorialState(player) {
+player.tutorial = null;
+ensureTutorial(player);
 }
 
 function tutorialSuffix(player) {
@@ -383,7 +389,29 @@ const settings = buildSettingsMap(settingsCatalog, server.settings);
 server.season = computeActiveSeason(settings);
 rollMarket({ serverId, content, serverState: server });
 
-const needsPlayer = !["help", "season", "event"].includes(sub);
+if (group === "dev" && sub === "reset_tutorial") {
+  const target = opt.getUser("user");
+  if (!target) {
+    return commit({ content: "Pick a user to reset.", ephemeral: true });
+  }
+
+  return withLock(db, `lock:user:${target.id}`, owner, 8000, async () => {
+    const p = ensurePlayer(serverId, target.id);
+    resetTutorialState(p);
+    upsertPlayer(db, serverId, target.id, p, null, p.schema_version);
+
+    const step = getCurrentTutorialStep(p);
+    const tut = formatTutorialMessage(step);
+    const mention = `<@${target.id}>`;
+
+    return commit({
+      content: `🔧 Reset tutorial for ${mention}.${tut ? `\n\n${tut}` : ""}`,
+      ephemeral: true
+    });
+  });
+}
+
+const needsPlayer = group !== "dev" && !["help", "season", "event"].includes(sub);
 const player = needsPlayer ? ensurePlayer(serverId, userId) : null;
 
 /* ---------------- START ---------------- */
@@ -1482,6 +1510,17 @@ export const noodleCommand = {
     )
     .addSubcommand((sc) => sc.setName("season").setDescription("Show the current season."))
     .addSubcommand((sc) => sc.setName("event").setDescription("Show the current event (if any)."))
+    .addSubcommandGroup((group) =>
+      group
+        .setName("dev")
+        .setDescription("Developer tools.")
+        .addSubcommand((sc) =>
+          sc
+            .setName("reset_tutorial")
+            .setDescription("Reset a user’s tutorial progress.")
+            .addUserOption((o) => o.setName("user").setDescription("User to reset").setRequired(true))
+        )
+    )
     .addSubcommand((sc) =>
       sc
         .setName("buy")


### PR DESCRIPTION
### Motivation
- Ensure tutorial text is rendered consistently by using the shared formatter across flows. 
- Centralize tutorial initialization to rely on the tutorial module state instead of duplicating logic. 
- Provide a developer-safe command to reset a user’s tutorial progress.

### Description
- Import `ensureTutorial` and `formatTutorialMessage` from `src/game/tutorial.js` and remove the local `buildTutorialMessage` helper. 
- Implement `resetTutorialState(player)` to set `player.tutorial = null` and call `ensureTutorial(player)`. 
- Replace usages of the local formatter with `formatTutorialMessage` in `tutorialSuffix`, `/noodle start`, and the reset flow. 
- Add a `dev` subcommand group with a `reset_tutorial` subcommand on the `noodle` command and implement a handler that locks the target user, calls `resetTutorialState`, persists via `upsertPlayer`, and replies with the formatted tutorial message.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697058f34d40832d877cfb279923532e)