### PR TITLE
Fix discord.js imports for CommonJS and add `noodle dev reset_tutorial`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,15 @@ import "dotenv/config";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import {
+import discordPkg from "discord.js";
+
+const {
   Client,
   GatewayIntentBits,
   Partials,
   Events,
   MessageFlags
-} from "discord.js";
+} = discordPkg;
 import { commandMap } from "./commands/index.js";
 import { startDailyResetScheduler } from "./jobs/dailyReset.js";
 import { loadContentBundle, loadSettingsCatalog } from "./content/index.js";

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -1,5 +1,7 @@
 import "dotenv/config";
-import { REST, Routes } from "discord.js";
+import discordPkg from "discord.js";
+
+const { REST, Routes } = discordPkg;
 import { commands } from "./commands/index.js";
 
 const token = process.env.DISCORD_TOKEN;


### PR DESCRIPTION
### Motivation
- Fix runtime import errors caused by named `discord.js` exports in a CommonJS runtime by switching to a default import with destructuring. 
- Provide a developer-safe way to reset a player’s tutorial state and centralize tutorial initialization so the tutorial module state is used consistently.

### Description
- Replace named `discord.js` imports with a default import and destructuring in `src/commands/noodle.js`, `src/index.js`, and `src/register-commands.js` to avoid `Named export ... not found` errors. 
- Import and use `ensureTutorial` from `src/game/tutorial.js`, add `resetTutorialState(player)` which sets `player.tutorial = null` and calls `ensureTutorial(player)`. 
- Add a `dev` subcommand group and a `reset_tutorial` subcommand on the `noodle` command, and implement its handler to lock the target user with `withLock`, call `resetTutorialState`, persist via `upsertPlayer`, and reply with the formatted tutorial message using `formatTutorialMessage`. 
- Adjust command flow to skip normal player lookup for `dev` group commands and to include the tutorial message where appropriate by using `getCurrentTutorialStep`/`formatTutorialMessage`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697058f34d40832d877cfb279923532e)