### PR TITLE
Gate feature-specific staff upgrades by shop unlock level

### DIFF
--- a/src/commands/noodleStaff.js
+++ b/src/commands/noodleStaff.js
@@ -12,7 +12,9 @@ import {
   getMaxStaffCapacity,
   getStaffSlotsUsed,
   calculateStaffCost,
-  getStaffUnlockStatus
+  getStaffUnlockStatus,
+  filterUnlockedStaffEffects,
+  isStaffEffectUnlocked
 } from "../game/staff.js";
 import { calculateUpgradeEffects } from "../game/upgrades.js";
 import { theme } from "../ui/theme.js";
@@ -130,6 +132,7 @@ function formatEffects(effects) {
     else if (key === "forage_seed_chance") lines.push(`+${(value * 100).toFixed(2)}% seed find chance`);
     else if (key === "garden_autoharvest") lines.push(`Auto-harvest garden plots`);
     else if (key === "garden_harvest_seed_chance") lines.push(`+${(value * 100).toFixed(0)}% harvest seed chance`);
+    else if (key === "harvest_cooldown_reduction") lines.push(`-${(value * 100).toFixed(0)}% harvest cooldown`);
     else if (key === "market_discount") lines.push(`${(value * 100).toFixed(0)}% market discount`);
     else if (key === "sxp_bonus_percent") lines.push(`+${(value * 100).toFixed(0)}% SXP`);
     else if (key === "rare_epic_rep_bonus") lines.push(`+${formatTwoDecimals(value)} rep on rare/epic`);
@@ -231,6 +234,7 @@ export function buildStaffOverviewEmbed(player, server, user) {
     if (key === "forage_seed_chance") return `+${(value * 100).toFixed(2)}% seed find chance`;
     if (key === "garden_autoharvest") return `Auto-harvests garden plots`;
     if (key === "garden_harvest_seed_chance") return `+${(value * 100).toFixed(0)}% seed chance on harvest`;
+    if (key === "harvest_cooldown_reduction") return `-${(value * 100).toFixed(0)}% harvest cooldown`;
     if (key === "market_discount") return `${(value * 100).toFixed(0)}% market discount`;
     if (key === "sxp_bonus_percent") return `+${(value * 100).toFixed(0)}% SXP`;
     if (key === "rare_epic_rep_bonus") return `+${formatTwoDecimals(value)} rep on rare/epic`;
@@ -268,9 +272,14 @@ export function buildStaffOverviewEmbed(player, server, user) {
       const seedPerLevel = Number(effectsPerLevel.forage_seed_chance ?? 0);
       const bonusTotal = bonusPerLevel * level * staffMultiplier;
       const seedTotal = seedPerLevel * level * staffMultiplier;
-      effectSummary = `+${bonusTotal.toFixed(2)} forage items, +${(seedTotal * 100).toFixed(2)}% seed find chance`;
+      const parts = [`+${bonusTotal.toFixed(2)} forage items`];
+      if (isStaffEffectUnlocked(player, "forage_seed_chance")) {
+        parts.push(`+${(seedTotal * 100).toFixed(2)}% seed find chance`);
+      }
+      effectSummary = parts.join(", ");
     } else {
-      const effectPieces = Object.entries(effectsPerLevel)
+      const visibleEffects = filterUnlockedStaffEffects(player, effectsPerLevel);
+      const effectPieces = Object.entries(visibleEffects)
         .map(([effectKey, perLevel]) => {
           const total = perLevel * level * staffMultiplier;
           return formatStaffEffectValue(effectKey, total);
@@ -315,7 +324,8 @@ function buildStaffComponents(userId, player, server) {
       if (!unlockStatus.unlocked) return null;
 
       const cost = calculateStaffCost(staff, currentLevel);
-      const effectStr = formatEffects(staff.effects_per_level);
+      const visibleEffects = filterUnlockedStaffEffects(player, staff.effects_per_level);
+      const effectStr = formatEffects(visibleEffects);
       const description = `Lv${currentLevel}→${currentLevel + 1}: ${effectStr}`.substring(0, 100);
 
       return {

--- a/src/commands/noodleStaff.js
+++ b/src/commands/noodleStaff.js
@@ -11,7 +11,8 @@ import {
   getStaffLevels,
   getMaxStaffCapacity,
   getStaffSlotsUsed,
-  calculateStaffCost
+  calculateStaffCost,
+  getStaffUnlockStatus
 } from "../game/staff.js";
 import { calculateUpgradeEffects } from "../game/upgrades.js";
 import { theme } from "../ui/theme.js";
@@ -310,6 +311,8 @@ function buildStaffComponents(userId, player, server) {
     .map(staff => {
       const currentLevel = player.staff_levels?.[staff.staff_id] || 0;
       if (currentLevel >= staff.max_level) return null; // Already maxed
+      const unlockStatus = getStaffUnlockStatus(player, staff);
+      if (!unlockStatus.unlocked) return null;
 
       const cost = calculateStaffCost(staff, currentLevel);
       const effectStr = formatEffects(staff.effects_per_level);

--- a/src/commands/noodleUpgrades.js
+++ b/src/commands/noodleUpgrades.js
@@ -473,11 +473,18 @@ function buildUpgradesCategoryEmbed(player, user, categoryId, { staffRarity = "c
       })
       .map((staff) => {
         const currentLevel = player.staff_levels?.[staff.staff_id] || 0;
+        const unlockStatus = getStaffUnlockStatus(player, staff);
+        const isLocked = !unlockStatus.unlocked;
         const cost = calculateStaffCost(staff, currentLevel);
-        const status = currentLevel >= staff.max_level ? `${getIcon("status_complete")} MAX` : `${cost}c`;
+        const status = isLocked
+          ? `${getIcon("lock")} ${unlockStatus.requirementLabel}`
+          : (currentLevel >= staff.max_level ? `${getIcon("status_complete")} MAX` : `${cost}c`);
         const emoji = shouldHideRarityEmoji(staff) ? "" : `${rarityEmoji(staff.rarity)} `;
         const visibleEffects = filterUnlockedStaffEffects(player, staff.effects_per_level ?? {});
-        const effectSummary = formatEffects(visibleEffects);
+        let effectSummary = formatEffects(visibleEffects);
+        if (!effectSummary && staff.staff_id === "prep_chef") {
+          effectSummary = "auto-buy missing ingredients (+1 order per level)";
+        }
         const description = effectSummary ? `\n  _${effectSummary}_` : "";
         return `• ${emoji}**${staff.name}** (${currentLevel}/${staff.max_level}) — ${status}${description}`.trim();
       })

--- a/src/commands/noodleUpgrades.js
+++ b/src/commands/noodleUpgrades.js
@@ -16,7 +16,7 @@ import {
   getUpgradesByCategory,
   calculateUpgradeEffects
 } from "../game/upgrades.js";
-import { calculateStaffCost, levelUpStaff } from "../game/staff.js";
+import { calculateStaffCost, levelUpStaff, getStaffUnlockStatus } from "../game/staff.js";
 import { theme } from "../ui/theme.js";
 import { getIcon, getButtonEmoji, resolveIcon } from "../ui/icons.js";
 
@@ -563,6 +563,8 @@ function buildUpgradesComponents(userId, player, { categoryId = null, staffRarit
         .map((staff) => {
           const currentLevel = player.staff_levels?.[staff.staff_id] || 0;
           if (currentLevel >= staff.max_level) return null;
+          const unlockStatus = getStaffUnlockStatus(player, staff);
+          if (!unlockStatus.unlocked) return null;
           const cost = calculateStaffCost(staff, currentLevel);
           let effectStr = formatEffects(staff.effects_per_level);
           if (!effectStr && staff.staff_id === "prep_chef") {

--- a/src/commands/noodleUpgrades.js
+++ b/src/commands/noodleUpgrades.js
@@ -485,6 +485,9 @@ function buildUpgradesCategoryEmbed(player, user, categoryId, { staffRarity = "c
         if (!effectSummary && staff.staff_id === "prep_chef") {
           effectSummary = "auto-buy missing ingredients (+1 order per level)";
         }
+        if (!effectSummary) {
+          effectSummary = staff.description || "";
+        }
         const description = effectSummary ? `\n  _${effectSummary}_` : "";
         return `• ${emoji}**${staff.name}** (${currentLevel}/${staff.max_level}) — ${status}${description}`.trim();
       })

--- a/src/commands/noodleUpgrades.js
+++ b/src/commands/noodleUpgrades.js
@@ -16,7 +16,7 @@ import {
   getUpgradesByCategory,
   calculateUpgradeEffects
 } from "../game/upgrades.js";
-import { calculateStaffCost, levelUpStaff, getStaffUnlockStatus } from "../game/staff.js";
+import { calculateStaffCost, levelUpStaff, getStaffUnlockStatus, filterUnlockedStaffEffects } from "../game/staff.js";
 import { theme } from "../ui/theme.js";
 import { getIcon, getButtonEmoji, resolveIcon } from "../ui/icons.js";
 
@@ -134,6 +134,7 @@ function formatEffects(effects) {
     else if (key === "fishing_cooldown_reduction") lines.push(`-${(value * 100).toFixed(2)}% fishing cooldown`);
     else if (key === "fishing_rare_weight_bonus") lines.push(`+${(value * 100).toFixed(2)}% rare catch weight`);
     else if (key === "fishing_bonus_items") lines.push(`+${formatTwoDecimals(value)} bonus catch per trip`);
+    else if (key === "harvest_cooldown_reduction") lines.push(`-${(value * 100).toFixed(2)}% harvest cooldown`);
   }
   return lines.join(", ");
 }
@@ -475,7 +476,9 @@ function buildUpgradesCategoryEmbed(player, user, categoryId, { staffRarity = "c
         const cost = calculateStaffCost(staff, currentLevel);
         const status = currentLevel >= staff.max_level ? `${getIcon("status_complete")} MAX` : `${cost}c`;
         const emoji = shouldHideRarityEmoji(staff) ? "" : `${rarityEmoji(staff.rarity)} `;
-        const description = staff.description ? `\n  _${staff.description}_` : "";
+        const visibleEffects = filterUnlockedStaffEffects(player, staff.effects_per_level ?? {});
+        const effectSummary = formatEffects(visibleEffects);
+        const description = effectSummary ? `\n  _${effectSummary}_` : "";
         return `• ${emoji}**${staff.name}** (${currentLevel}/${staff.max_level}) — ${status}${description}`.trim();
       })
       .filter(Boolean);
@@ -566,7 +569,8 @@ function buildUpgradesComponents(userId, player, { categoryId = null, staffRarit
           const unlockStatus = getStaffUnlockStatus(player, staff);
           if (!unlockStatus.unlocked) return null;
           const cost = calculateStaffCost(staff, currentLevel);
-          let effectStr = formatEffects(staff.effects_per_level);
+          const visibleEffects = filterUnlockedStaffEffects(player, staff.effects_per_level ?? {});
+          let effectStr = formatEffects(visibleEffects);
           if (!effectStr && staff.staff_id === "prep_chef") {
             effectStr = "auto-buy missing ingredients (+1 order per level)";
           }

--- a/src/game/staff.js
+++ b/src/game/staff.js
@@ -10,7 +10,7 @@ const STAFF_UNLOCK_RULES = [
   {
     featureName: "Garden",
     requiredLevel: GARDEN_UNLOCK_LEVEL,
-    effectKeys: new Set(["garden_autoharvest", "garden_harvest_seed_chance", "harvest_cooldown_reduction"]),
+    effectKeys: new Set(["forage_seed_chance", "garden_autoharvest", "garden_harvest_seed_chance", "harvest_cooldown_reduction"]),
     isUnlocked: isGardenUnlocked
   },
   {
@@ -27,19 +27,49 @@ const STAFF_UNLOCK_RULES = [
   }
 ];
 
+function getStaffUnlockRuleForEffect(effectKey) {
+  if (!effectKey) return null;
+  return STAFF_UNLOCK_RULES.find((rule) => rule.effectKeys.has(effectKey)) || null;
+}
+
+export function isStaffEffectUnlocked(player, effectKey) {
+  const rule = getStaffUnlockRuleForEffect(effectKey);
+  if (!rule) return true;
+  return rule.isUnlocked(player);
+}
+
+export function filterUnlockedStaffEffects(player, effectsPerLevel = {}) {
+  const visible = {};
+  for (const [effectKey, value] of Object.entries(effectsPerLevel || {})) {
+    if (!isStaffEffectUnlocked(player, effectKey)) continue;
+    visible[effectKey] = value;
+  }
+  return visible;
+}
+
 export function getStaffUnlockStatus(player, staff) {
   const effects = staff?.effects_per_level ?? {};
-  for (const rule of STAFF_UNLOCK_RULES) {
-    const gatedByRule = Object.keys(effects).some((key) => rule.effectKeys.has(key));
-    if (!gatedByRule) continue;
-    const unlocked = rule.isUnlocked(player);
+  const effectKeys = Object.keys(effects);
+  if (!effectKeys.length) {
+    return { unlocked: true, featureName: null, requiredLevel: null, requirementLabel: null };
+  }
+
+  const hasAnyActiveEffect = effectKeys.some((effectKey) => isStaffEffectUnlocked(player, effectKey));
+  if (hasAnyActiveEffect) {
+    return { unlocked: true, featureName: null, requiredLevel: null, requirementLabel: null };
+  }
+
+  for (const effectKey of effectKeys) {
+    const rule = getStaffUnlockRuleForEffect(effectKey);
+    if (!rule || rule.isUnlocked(player)) continue;
     return {
-      unlocked,
+      unlocked: false,
       featureName: rule.featureName,
       requiredLevel: rule.requiredLevel,
       requirementLabel: `Unlocks at shop level ${rule.requiredLevel}`
     };
   }
+
   return { unlocked: true, featureName: null, requiredLevel: null, requirementLabel: null };
 }
 
@@ -203,6 +233,7 @@ export function calculateStaffEffects(player, staffContent) {
     if (!staff || !staff.effects_per_level) continue;
     
     for (const [effectKey, effectPerLevel] of Object.entries(staff.effects_per_level)) {
+      if (!isStaffEffectUnlocked(player, effectKey)) continue;
       if (effects.hasOwnProperty(effectKey)) {
         effects[effectKey] += effectPerLevel * level * staffMultiplier;
       }

--- a/src/game/staff.js
+++ b/src/game/staff.js
@@ -1,7 +1,6 @@
 import { loadUpgradesContent } from "../content/index.js";
 import { calculateUpgradeEffects } from "./upgrades.js";
 import { isGardenUnlocked, GARDEN_UNLOCK_LEVEL } from "./garden.js";
-import { isKitchenUnlocked, KITCHEN_UNLOCK_LEVEL } from "./kitchen.js";
 import { isFishingUnlocked, FISHING_UNLOCK_LEVEL } from "./fishing.js";
 
 const upgradesContent = loadUpgradesContent();
@@ -12,12 +11,6 @@ const STAFF_UNLOCK_RULES = [
     requiredLevel: GARDEN_UNLOCK_LEVEL,
     effectKeys: new Set(["forage_seed_chance", "garden_autoharvest", "garden_harvest_seed_chance", "harvest_cooldown_reduction"]),
     isUnlocked: isGardenUnlocked
-  },
-  {
-    featureName: "Kitchen",
-    requiredLevel: KITCHEN_UNLOCK_LEVEL,
-    effectKeys: new Set(["kitchen_simmer_capacity", "kitchen_simmer_time_reduction"]),
-    isUnlocked: isKitchenUnlocked
   },
   {
     featureName: "Fishing",

--- a/src/game/staff.js
+++ b/src/game/staff.js
@@ -1,7 +1,47 @@
 import { loadUpgradesContent } from "../content/index.js";
 import { calculateUpgradeEffects } from "./upgrades.js";
+import { isGardenUnlocked, GARDEN_UNLOCK_LEVEL } from "./garden.js";
+import { isKitchenUnlocked, KITCHEN_UNLOCK_LEVEL } from "./kitchen.js";
+import { isFishingUnlocked, FISHING_UNLOCK_LEVEL } from "./fishing.js";
 
 const upgradesContent = loadUpgradesContent();
+
+const STAFF_UNLOCK_RULES = [
+  {
+    featureName: "Garden",
+    requiredLevel: GARDEN_UNLOCK_LEVEL,
+    effectKeys: new Set(["garden_autoharvest", "garden_harvest_seed_chance", "harvest_cooldown_reduction"]),
+    isUnlocked: isGardenUnlocked
+  },
+  {
+    featureName: "Kitchen",
+    requiredLevel: KITCHEN_UNLOCK_LEVEL,
+    effectKeys: new Set(["kitchen_simmer_capacity", "kitchen_simmer_time_reduction"]),
+    isUnlocked: isKitchenUnlocked
+  },
+  {
+    featureName: "Fishing",
+    requiredLevel: FISHING_UNLOCK_LEVEL,
+    effectKeys: new Set(["fishing_bonus_items"]),
+    isUnlocked: isFishingUnlocked
+  }
+];
+
+export function getStaffUnlockStatus(player, staff) {
+  const effects = staff?.effects_per_level ?? {};
+  for (const rule of STAFF_UNLOCK_RULES) {
+    const gatedByRule = Object.keys(effects).some((key) => rule.effectKeys.has(key));
+    if (!gatedByRule) continue;
+    const unlocked = rule.isUnlocked(player);
+    return {
+      unlocked,
+      featureName: rule.featureName,
+      requiredLevel: rule.requiredLevel,
+      requirementLabel: `Unlocks at shop level ${rule.requiredLevel}`
+    };
+  }
+  return { unlocked: true, featureName: null, requiredLevel: null, requirementLabel: null };
+}
 
 /**
  * Roll a daily staff pool for a server
@@ -39,6 +79,16 @@ export function levelUpStaff(player, staffId, staffContent) {
   const staff = staffContent.staff_members?.[staffId];
   if (!staff) {
     return { success: false, message: "Staff member not found.", cost: 0, newLevel: 0 };
+  }
+
+  const unlockStatus = getStaffUnlockStatus(player, staff);
+  if (!unlockStatus.unlocked) {
+    return {
+      success: false,
+      message: `${unlockStatus.requirementLabel}.`,
+      cost: 0,
+      newLevel: 0
+    };
   }
   
   // Ensure staff_levels object exists

--- a/test/staff.test.js
+++ b/test/staff.test.js
@@ -85,7 +85,7 @@ test("Staff: Garden staff stay locked until garden unlock level", () => {
   assert.strictEqual(player.staff_levels.gardener, 1);
 });
 
-test("Staff: kitchen-effect staff are gated by kitchen unlock level", () => {
+test("Staff: kitchen-effect staff are not staff-gated", () => {
   const player = makeTestPlayer();
   player.shop_level = 44;
 
@@ -96,13 +96,8 @@ test("Staff: kitchen-effect staff are gated by kitchen unlock level", () => {
     effects_per_level: { kitchen_simmer_time_reduction: 0.05 }
   };
 
-  const locked = getStaffUnlockStatus(player, kitchenOnlyStaff);
-  assert.strictEqual(locked.unlocked, false);
-  assert.strictEqual(locked.requiredLevel, 45);
-
-  player.shop_level = 45;
-  const unlocked = getStaffUnlockStatus(player, kitchenOnlyStaff);
-  assert.strictEqual(unlocked.unlocked, true);
+  const status = getStaffUnlockStatus(player, kitchenOnlyStaff);
+  assert.strictEqual(status.unlocked, true);
 });
 
 test("Staff: Forager remains upgradeable before garden but seed effect is locked", () => {

--- a/test/staff.test.js
+++ b/test/staff.test.js
@@ -105,6 +105,48 @@ test("Staff: kitchen-effect staff are gated by kitchen unlock level", () => {
   assert.strictEqual(unlocked.unlocked, true);
 });
 
+test("Staff: Forager remains upgradeable before garden but seed effect is locked", () => {
+  const player = makeTestPlayer();
+  player.shop_level = 10;
+  player.coins = 999999;
+
+  const status = getStaffUnlockStatus(player, staffContent.staff_members.forager);
+  assert.strictEqual(status.unlocked, true);
+
+  const result = levelUpStaff(player, "forager", staffContent);
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(player.staff_levels.forager, 1);
+
+  const preGarden = calculateStaffEffects(player, staffContent);
+  assert.strictEqual(preGarden.forage_bonus_items, 1);
+  assert.strictEqual(preGarden.forage_seed_chance, 0);
+
+  player.shop_level = 25;
+  const postGarden = calculateStaffEffects(player, staffContent);
+  assert.ok(postGarden.forage_seed_chance > 0);
+});
+
+test("Staff: Forage Manager remains upgradeable before garden but harvest cooldown effect is locked", () => {
+  const player = makeTestPlayer();
+  player.shop_level = 10;
+  player.coins = 999999;
+
+  const status = getStaffUnlockStatus(player, staffContent.staff_members.manager);
+  assert.strictEqual(status.unlocked, true);
+
+  const result = levelUpStaff(player, "manager", staffContent);
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(player.staff_levels.manager, 1);
+
+  const preGarden = calculateStaffEffects(player, staffContent);
+  assert.ok(preGarden.cooldown_reduction > 0);
+  assert.strictEqual(preGarden.harvest_cooldown_reduction, 0);
+
+  player.shop_level = 25;
+  const postGarden = calculateStaffEffects(player, staffContent);
+  assert.ok(postGarden.harvest_cooldown_reduction > 0);
+});
+
 test("Staff: levelUpStaff fails at max level", () => {
   const player = makeTestPlayer();
   player.coins = 999999;

--- a/test/staff.test.js
+++ b/test/staff.test.js
@@ -5,7 +5,8 @@ import {
   getMaxStaffCapacity,
   calculateStaffEffects,
   getStaffLevels,
-  calculateStaffCost
+  calculateStaffCost,
+  getStaffUnlockStatus
 } from "../src/game/staff.js";
 import { loadStaffContent } from "../src/content/index.js";
 
@@ -43,6 +44,65 @@ test("Staff: levelUpStaff fails when insufficient coins", () => {
   assert.strictEqual(result.success, false);
   assert.strictEqual(player.staff_levels["prep_chef"], undefined);
   assert.strictEqual(player.coins, 100); // No change
+});
+
+test("Staff: Fisher Crew stays locked until fishing unlock level", () => {
+  const player = makeTestPlayer();
+  player.shop_level = 10;
+  player.coins = 999999;
+
+  const fisherCrew = staffContent.staff_members.fisher_crew;
+  const lockStatus = getStaffUnlockStatus(player, fisherCrew);
+  assert.strictEqual(lockStatus.unlocked, false);
+
+  const lockedResult = levelUpStaff(player, "fisher_crew", staffContent);
+  assert.strictEqual(lockedResult.success, false);
+  assert.match(lockedResult.message, /Unlocks at shop level 65/i);
+  assert.strictEqual(player.staff_levels.fisher_crew, undefined);
+
+  player.shop_level = 65;
+  const unlockedStatus = getStaffUnlockStatus(player, fisherCrew);
+  assert.strictEqual(unlockedStatus.unlocked, true);
+
+  const unlockedResult = levelUpStaff(player, "fisher_crew", staffContent);
+  assert.strictEqual(unlockedResult.success, true);
+  assert.strictEqual(player.staff_levels.fisher_crew, 1);
+});
+
+test("Staff: Garden staff stay locked until garden unlock level", () => {
+  const player = makeTestPlayer();
+  player.shop_level = 5;
+  player.coins = 999999;
+
+  const result = levelUpStaff(player, "gardener", staffContent);
+  assert.strictEqual(result.success, false);
+  assert.match(result.message, /Unlocks at shop level 25/i);
+  assert.strictEqual(player.staff_levels.gardener, undefined);
+
+  player.shop_level = 25;
+  const unlockedResult = levelUpStaff(player, "gardener", staffContent);
+  assert.strictEqual(unlockedResult.success, true);
+  assert.strictEqual(player.staff_levels.gardener, 1);
+});
+
+test("Staff: kitchen-effect staff are gated by kitchen unlock level", () => {
+  const player = makeTestPlayer();
+  player.shop_level = 44;
+
+  const kitchenOnlyStaff = {
+    staff_id: "kitchen_tester",
+    name: "Kitchen Tester",
+    max_level: 1,
+    effects_per_level: { kitchen_simmer_time_reduction: 0.05 }
+  };
+
+  const locked = getStaffUnlockStatus(player, kitchenOnlyStaff);
+  assert.strictEqual(locked.unlocked, false);
+  assert.strictEqual(locked.requiredLevel, 45);
+
+  player.shop_level = 45;
+  const unlocked = getStaffUnlockStatus(player, kitchenOnlyStaff);
+  assert.strictEqual(unlocked.unlocked, true);
 });
 
 test("Staff: levelUpStaff fails at max level", () => {


### PR DESCRIPTION
## Summary
- gate staff level-up by feature unlock shop level for fishing/garden-aligned effects
- kitchen staff effects are intentionally not staff-gated (covered by tests)
- hide locked staff from both `/noodle-staff` and staff picker in `/noodle-upgrades`
- align lock messaging format with shop upgrades (`Unlocks at shop level X`)
- keep staff list descriptions visible by falling back to staff description when no currently-visible effects are available
- add staff tests for fishing, garden, mixed-effect behavior, and kitchen non-gating

## Validation
- `npm test -- test/staff.test.js`
