### PR TITLE
Fix tutorial first cook failure and news-only season/event buttons

### DIFF
--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1574,8 +1574,7 @@ function noodleFeatureInfoRow(userId, {
 
 function noodleSecondaryMenuRow(userId, { questsAvailable = false } = {}) {
 return new ActionRowBuilder().addComponents(
-new ButtonBuilder().setCustomId(`noodle:nav:quests:${userId}`).setLabel("Quests").setEmoji(getButtonEmoji("quests")).setStyle(questsAvailable ? ButtonStyle.Success : ButtonStyle.Secondary),
-new ButtonBuilder().setCustomId(`noodle:nav:event:${userId}`).setLabel("Event").setEmoji(getButtonEmoji("event")).setStyle(ButtonStyle.Secondary)
+new ButtonBuilder().setCustomId(`noodle:nav:quests:${userId}`).setLabel("Quests").setEmoji(getButtonEmoji("quests")).setStyle(questsAvailable ? ButtonStyle.Success : ButtonStyle.Secondary)
 );
 }
 
@@ -7996,13 +7995,16 @@ ${lines.join("\n")}`;
     }
 
     const blessing = getActiveBlessing(p);
+    const tutorialStep = getCurrentTutorialStep(p);
+    const disableFailures = tutorialStep?.id === "intro_cook";
     const outcome = rollCookBatchOutcome({
       quantity: batchOutput,
       tier: r.tier,
       player: p,
       effects: combinedEffects,
       rng: cookRng,
-      blessing
+      blessing,
+      disableFailures
     });
 
     const doubleCrafted = combinedEffects.double_craft_chance > 0 && rollDoubleCraft(combinedEffects, cookRng);

--- a/src/game/cooking.js
+++ b/src/game/cooking.js
@@ -85,10 +85,9 @@ export function rollCookBatchOutcome({ quantity, tier, player, effects, rng, ble
 
   const failChance = getCookFailChance(tier, player, effects);
   let failed = 0;
-  if (!disableFailures) {
-    for (let i = 0; i < total; i += 1) {
-      if (rng() < failChance) failed += 1;
-    }
+  for (let i = 0; i < total; i += 1) {
+    const roll = rng();
+    if (!disableFailures && roll < failChance) failed += 1;
   }
 
   const success = Math.max(0, total - failed);

--- a/src/game/cooking.js
+++ b/src/game/cooking.js
@@ -77,7 +77,7 @@ export function getFailBowlYield() {
   return Math.max(0, Math.min(1, Number(rules.failure?.fail_bowl_yield) || 0.25));
 }
 
-export function rollCookBatchOutcome({ quantity, tier, player, effects, rng, blessing }) {
+export function rollCookBatchOutcome({ quantity, tier, player, effects, rng, blessing, disableFailures = false }) {
   const total = Math.max(0, Number(quantity) || 0);
   if (total <= 0) {
     return { success: 0, failed: 0, salvage: 0, qualityCounts: {} };
@@ -85,8 +85,10 @@ export function rollCookBatchOutcome({ quantity, tier, player, effects, rng, ble
 
   const failChance = getCookFailChance(tier, player, effects);
   let failed = 0;
-  for (let i = 0; i < total; i += 1) {
-    if (rng() < failChance) failed += 1;
+  if (!disableFailures) {
+    for (let i = 0; i < total; i += 1) {
+      if (rng() < failChance) failed += 1;
+    }
   }
 
   const success = Math.max(0, total - failed);

--- a/test/cook-inventory-outcome-invariants.test.js
+++ b/test/cook-inventory-outcome-invariants.test.js
@@ -15,7 +15,7 @@ function makeSeqRng(values, fallback = 0.99) {
   };
 }
 
-function simulateCookCore({ player, recipe, qtyToCook, effects = {}, rng }) {
+function simulateCookCore({ player, recipe, qtyToCook, effects = {}, rng, disableFailures = false }) {
   const batchOutput = getCookBatchOutput(qtyToCook, player, effects);
   const ingredientsToUse = [];
   const consumedByItem = {};
@@ -48,7 +48,8 @@ function simulateCookCore({ player, recipe, qtyToCook, effects = {}, rng }) {
     player,
     effects,
     rng,
-    blessing: null
+    blessing: null,
+    disableFailures
   });
 
   const qualityCounts = outcome.qualityCounts ?? {};
@@ -171,4 +172,36 @@ test("Cook invariants: quality buckets and salvage totals stay consistent with b
   assert.ok(result.outcome.salvage >= 1);
   assert.equal(result.consumedByItem.noodles_wheat, 8);
   assert.equal(result.consumedByItem.broth_soy, 8);
+});
+
+test("Cook invariants: disableFailures prevents failed bowls", () => {
+  const player = {
+    inv_ingredients: {
+      noodles_wheat: 20,
+      broth_soy: 20
+    },
+    upgrades: { u_prep: 0 }
+  };
+
+  const recipe = {
+    tier: "common",
+    ingredients: [
+      { item_id: "noodles_wheat", qty: 1 },
+      { item_id: "broth_soy", qty: 1 }
+    ]
+  };
+
+  const result = simulateCookCore({
+    player,
+    recipe,
+    qtyToCook: 5,
+    rng: makeSeqRng([0.0, 0.0, 0.0, 0.0, 0.0]),
+    disableFailures: true
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.outcome.failed, 0);
+  assert.equal(result.outcome.salvage, 0);
+  assert.equal(result.outcome.success, result.batchOutput);
+  assert.equal(result.qualityBucketTotal, result.batchOutput);
 });

--- a/test/cook-inventory-outcome-invariants.test.js
+++ b/test/cook-inventory-outcome-invariants.test.js
@@ -205,3 +205,26 @@ test("Cook invariants: disableFailures prevents failed bowls", () => {
   assert.equal(result.outcome.success, result.batchOutput);
   assert.equal(result.qualityBucketTotal, result.batchOutput);
 });
+
+test("Cook invariants: disableFailures still consumes failure RNG rolls", () => {
+  const player = { upgrades: { u_prep: 0 } };
+  let calls = 0;
+  const rng = () => {
+    calls += 1;
+    return 0.99;
+  };
+
+  const outcome = rollCookBatchOutcome({
+    quantity: 3,
+    tier: "common",
+    player,
+    effects: {},
+    rng,
+    blessing: null,
+    disableFailures: true
+  });
+
+  assert.equal(outcome.failed, 0);
+  assert.equal(outcome.success, 3);
+  assert.equal(calls, 6);
+});


### PR DESCRIPTION
## Summary
- prevent failures during the intro tutorial cook step (intro_cook)
- keep season and event navigation buttons scoped to the News navigation row
- add regression coverage for the disableFailures cook outcome behavior

## Target Branch (Required)
- [ ] Target is develop (feature/integration testing)
- [x] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (cleanstart / syncmain).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [ ] I rebased this branch on latest origin/develop.
- [ ] This PR is intended for integration/QA testing, not direct production release.
- [ ] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [x] I rebased this branch on latest origin/main.
- [x] This change is release-ready and already validated at appropriate level.
- [x] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [x] Lint/type checks pass (if applicable).

Commands run:
```bash
git fetch origin
git rebase origin/main
git rev-list --left-right --count origin/main...HEAD   # 0 1
node --test test/cook-inventory-outcome-invariants.test.js   # pass
node --test test/tutorial-major-actions.test.js              # pass
node --test test/smoke.test.js                               # pass
npx eslint src/commands/noodle.js src/game/cooking.js test/cook-inventory-outcome-invariants.test.js   # pass
```

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

## Reviewer Notes
- Areas to focus on:
  - Tutorial cook path in noodle command flow, specifically intro_cook failure behavior.
  - Button row composition outside News and About/News nav row consistency.
- Known limitations:
  - disableFailures is an explicit parameter path; behavior depends on caller intent.
- Follow-up work (if any):
  - Optional: add a dedicated UI row regression test that asserts Event/Season are absent from non-news menu rows.

---

### Review Gate
Do not request review until all required checkboxes are complete.
If any box is intentionally unchecked, explain why in this PR description.
