### PR TITLE
Add official-server auto-react and locked stats channels

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -262,6 +262,22 @@ import { theme } from "./ui/theme.js";
 
   const token = process.env.DISCORD_TOKEN;
   const officialGuildId = process.env.NOODLE_OFFICIAL_GUILD_ID || process.env.DISCORD_GUILD_ID || "";
+  const parseCsvValues = (value) => String(value || "")
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const officialAutoReactEnabled = String(process.env.NOODLE_OFFICIAL_AUTOREACT_ENABLED || "1") !== "0";
+  const officialAutoReactBotsOnly = String(process.env.NOODLE_OFFICIAL_AUTOREACT_BOTS_ONLY || "1") !== "0";
+  const officialWelcomeAutoReactEmojis = parseCsvValues(process.env.NOODLE_OFFICIAL_WELCOME_REACT_EMOJI || "👋");
+  const officialLevelAutoReactEmojis = parseCsvValues(process.env.NOODLE_OFFICIAL_LEVEL_REACT_EMOJI || "🎉");
+  const officialStatsChannelsEnabled = String(process.env.NOODLE_OFFICIAL_STATS_CHANNELS_ENABLED || "1") !== "0";
+  let officialServerCountChannelId = String(process.env.NOODLE_OFFICIAL_SERVER_COUNT_CHANNEL_ID || "").trim();
+  let officialShopCountChannelId = String(process.env.NOODLE_OFFICIAL_SHOP_COUNT_CHANNEL_ID || "").trim();
+  const officialStatsChannelRefreshIntervalRaw = Number(process.env.NOODLE_OFFICIAL_STATS_CHANNEL_REFRESH_INTERVAL_MS || 10 * 60 * 1000);
+  const officialStatsChannelRefreshIntervalMs = Number.isFinite(officialStatsChannelRefreshIntervalRaw)
+    ? Math.max(60_000, Math.floor(officialStatsChannelRefreshIntervalRaw))
+    : 10 * 60 * 1000;
+  let officialStatsChannelRefreshHandle = null;
   const devAlertChannelId = process.env.NOODLE_DEV_ALERT_CHANNEL_ID || "";
   const devAlertUserId = process.env.NOODLE_DEV_ALERT_USER_ID || "";
   const sharedBotId = process.env.NOODLE_BOT_ID || process.env.TOPGG_BOT_ID || "1460058511802105976";
@@ -423,6 +439,12 @@ import { theme } from "./ui/theme.js";
   const disabledStatsSyncLogged = new Set();
   const lastBotListStatsPushBySource = new Map();
   const nextStatsSyncAllowedAtBySource = new Map();
+  const officialWelcomeAutoReactChannels = new Set(parseCsvValues(process.env.NOODLE_OFFICIAL_WELCOME_CHANNEL_IDS));
+  const officialLevelAutoReactChannels = new Set(parseCsvValues(process.env.NOODLE_OFFICIAL_LEVEL_CHANNEL_IDS));
+  const officialWelcomeKeywords = parseCsvValues(process.env.NOODLE_OFFICIAL_WELCOME_KEYWORDS || "welcome,joined the server")
+    .map((value) => value.toLowerCase());
+  const officialLevelKeywords = parseCsvValues(process.env.NOODLE_OFFICIAL_LEVEL_KEYWORDS || "level up,leveled up,reached level,is now level")
+    .map((value) => value.toLowerCase());
   let shardNearThresholdAlertSent = false;
   let shardRecommendedAlertSent = false;
   let botListStatsHeartbeatHandle = null;
@@ -431,13 +453,16 @@ import { theme } from "./ui/theme.js";
     process.exit(1);
   }
 
-  const client = new Client({
-    intents: [
-      Intents.FLAGS.GUILDS,
-      Intents.FLAGS.GUILD_MESSAGES,
-      Intents.FLAGS.DIRECT_MESSAGES
-    ]
-  });
+  const clientIntents = [
+    Intents.FLAGS.GUILDS,
+    Intents.FLAGS.GUILD_MESSAGES,
+    Intents.FLAGS.DIRECT_MESSAGES
+  ];
+  if (Intents.FLAGS.MESSAGE_CONTENT) {
+    clientIntents.push(Intents.FLAGS.MESSAGE_CONTENT);
+  }
+
+  const client = new Client({ intents: clientIntents });
 
   client.noodleShardHealth = {
     guildCount: 0,
@@ -1190,6 +1215,176 @@ import { theme } from "./ui/theme.js";
     return anyUpdated;
   }
 
+  function buildStatChannelName(prefix, count) {
+    const safePrefix = String(prefix || "stats")
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 70) || "stats";
+    const safeCount = Math.max(0, Number(count) || 0).toLocaleString("en-US").replace(/,/g, "-");
+    return `${safePrefix}-${safeCount}`.slice(0, 100);
+  }
+
+  async function ensureOfficialReadonlyStatsChannel(officialGuild, channelId, { marker, prefix, count, topic }) {
+    let channel = null;
+    const existingId = String(channelId || "").trim();
+
+    if (existingId) {
+      channel = officialGuild.channels.cache.get(existingId)
+        || await officialGuild.channels.fetch(existingId).catch(() => null);
+    }
+
+    if (!channel) {
+      channel = officialGuild.channels.cache.find((candidate) =>
+        candidate?.type === "GUILD_TEXT"
+        && String(candidate?.topic || "").includes(marker)
+      ) || null;
+    }
+
+    if (!channel) {
+      const denied = [
+        "SEND_MESSAGES",
+        "ADD_REACTIONS",
+        "CREATE_PUBLIC_THREADS",
+        "CREATE_PRIVATE_THREADS",
+        "SEND_MESSAGES_IN_THREADS"
+      ].filter((perm) => Boolean(Discord.Permissions?.FLAGS?.[perm]));
+
+      channel = await officialGuild.channels.create(buildStatChannelName(prefix, count), {
+        type: "GUILD_TEXT",
+        topic: `${marker} | ${topic}`.slice(0, 1024),
+        permissionOverwrites: [
+          {
+            id: officialGuild.roles.everyone.id,
+            deny: denied
+          }
+        ]
+      });
+    }
+
+    const nextName = buildStatChannelName(prefix, count);
+    const nextTopic = `${marker} | ${topic}`.slice(0, 1024);
+    if (channel.name !== nextName) {
+      await channel.setName(nextName).catch((error) => {
+        console.error(`❌ Failed to rename official stats channel (${marker}):`, error?.message ?? error);
+      });
+    }
+    if (channel.topic !== nextTopic) {
+      await channel.setTopic(nextTopic).catch((error) => {
+        console.error(`❌ Failed to update official stats topic (${marker}):`, error?.message ?? error);
+      });
+    }
+
+    return channel;
+  }
+
+  async function updateOfficialStatsChannels({ reason = "event" } = {}) {
+    if (!officialStatsChannelsEnabled || !officialGuildId) return false;
+
+    try {
+      const officialGuild = client.guilds.cache.get(officialGuildId)
+        || await client.guilds.fetch(officialGuildId).catch(() => null);
+      if (!officialGuild) return false;
+
+      const { serverCount, userCount } = getCurrentBotListCounts();
+      const shopsCount = Math.max(0, Number(userCount) || 0);
+
+      const serverChannel = await ensureOfficialReadonlyStatsChannel(
+        officialGuild,
+        officialServerCountChannelId,
+        {
+          marker: "noodle:stats:servers",
+          prefix: "servers",
+          count: serverCount,
+          topic: `Global server count (updated: ${new Date().toISOString()})`
+        }
+      );
+      const shopsChannel = await ensureOfficialReadonlyStatsChannel(
+        officialGuild,
+        officialShopCountChannelId,
+        {
+          marker: "noodle:stats:shops",
+          prefix: "noodle-shops",
+          count: shopsCount,
+          topic: `Global noodle shops count from DB players table (updated: ${new Date().toISOString()})`
+        }
+      );
+
+      if (serverChannel?.id) officialServerCountChannelId = serverChannel.id;
+      if (shopsChannel?.id) officialShopCountChannelId = shopsChannel.id;
+
+      console.log(`✅ Official stats channels updated (${reason}): servers=${Number(serverCount) || 0}, shops=${shopsCount}`);
+      return true;
+    } catch (error) {
+      console.error("❌ Failed to update official stats channels:", error?.stack ?? error);
+      return false;
+    }
+  }
+
+  function getMessageSearchBlob(message) {
+    const embedParts = (message?.embeds || []).flatMap((embed) => {
+      const fieldParts = (embed?.fields || []).flatMap((field) => [field?.name, field?.value]);
+      return [embed?.title, embed?.description, ...fieldParts];
+    });
+    return [message?.content || "", ...embedParts]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+  }
+
+  function parseReactionEmoji(emoji) {
+    const value = String(emoji || "").trim();
+    if (!value) return null;
+
+    const bracketCustom = value.match(/^<a?:([a-zA-Z0-9_]+):(\d{15,25})>$/);
+    if (bracketCustom) {
+      const name = bracketCustom[1];
+      const id = bracketCustom[2];
+      return { raw: value, id, isCustom: true, reactValue: `${name}:${id}` };
+    }
+
+    const plainCustom = value.match(/^[a-zA-Z0-9_]+:(\d{15,25})$/);
+    if (plainCustom) {
+      return { raw: value, id: plainCustom[1], isCustom: true, reactValue: value };
+    }
+
+    const idOnlyCustom = value.match(/^(\d{15,25})$/);
+    if (idOnlyCustom) {
+      return { raw: value, id: idOnlyCustom[1], isCustom: true, reactValue: value };
+    }
+
+    return { raw: value, id: null, isCustom: false, reactValue: value };
+  }
+
+  function emojiMatchesReaction(parsed, reactionEmoji) {
+    if (!parsed || !reactionEmoji) return false;
+    if (parsed.isCustom && parsed.id) {
+      return String(reactionEmoji.id || "") === parsed.id;
+    }
+
+    const rendered = typeof reactionEmoji.toString === "function" ? reactionEmoji.toString() : "";
+    return reactionEmoji.name === parsed.raw || rendered === parsed.raw;
+  }
+
+  async function tryAutoReact(message, emoji) {
+    const parsed = parseReactionEmoji(emoji);
+    if (!parsed) return false;
+
+    const alreadyReacted = message.reactions?.cache?.some((reaction) => {
+      return reaction?.me && emojiMatchesReaction(parsed, reaction?.emoji);
+    });
+    if (alreadyReacted) return false;
+
+    try {
+      await message.react(parsed.reactValue);
+      return true;
+    } catch (error) {
+      console.error(`❌ Failed to auto-react with ${parsed.raw}:`, error?.message ?? error);
+      return false;
+    }
+  }
+
   function toProviderCommand(command) {
     const normalized = {
       name: String(command?.name || "").trim(),
@@ -1906,6 +2101,14 @@ import { theme } from "./ui/theme.js";
   client.once("ready", async (c) => {
     console.log(`✅ Logged in as ${c.user.tag}`);
 
+    await c.user.setPresence({
+      status: "online",
+      activities: [{
+        name: "/noodle help | /noodle start",
+        type: "PLAYING"
+      }]
+    });
+
     const customEmojis = getCustomEmojiEntries();
     const { ids: accessibleEmojiIds, applicationEmojiCount } = await resolveAccessibleEmojiIds(client, token);
     await refreshShardHealth({ reason: "ready" });
@@ -1940,9 +2143,17 @@ import { theme } from "./ui/theme.js";
     } else {
       console.log("INFO: Skipping bot-list stats sync on ready (no providers configured with both URL and token).");
     }
+    await updateOfficialStatsChannels({ reason: "ready" });
     await syncDiscordBotListCommands({ reason: "ready" });
     await syncRadarCpdvCommands({ reason: "ready" });
     startBotListStatsHeartbeat();
+
+    if (officialStatsChannelsEnabled && !officialStatsChannelRefreshHandle) {
+      officialStatsChannelRefreshHandle = setInterval(() => {
+        updateOfficialStatsChannels({ reason: "interval" });
+      }, officialStatsChannelRefreshIntervalMs);
+      officialStatsChannelRefreshHandle.unref?.();
+    }
 
     startDailyResetScheduler(getKnownServerIds);
     startDailyRewardReminderScheduler(client, getKnownServerIds);
@@ -1962,6 +2173,7 @@ import { theme } from "./ui/theme.js";
     try {
       const currentCounts = getCurrentBotListCounts();
       await updateAllBotListServerCounts(currentCounts, { reason: "guildCreate" });
+      await updateOfficialStatsChannels({ reason: "guildCreate" });
       await refreshShardHealth({ reason: "guildCreate" });
 
       if (guild?.id === officialGuildId) return;
@@ -1984,6 +2196,7 @@ import { theme } from "./ui/theme.js";
     try {
       const currentCounts = getCurrentBotListCounts();
       await updateAllBotListServerCounts(currentCounts, { reason: "guildDelete" });
+      await updateOfficialStatsChannels({ reason: "guildDelete" });
       await refreshShardHealth({ reason: "guildDelete" });
 
       if (guild?.id === officialGuildId) return;
@@ -1996,6 +2209,38 @@ import { theme } from "./ui/theme.js";
       });
     } catch (error) {
       console.error("❌ Failed to send guild leave alert:", error?.stack ?? error);
+    }
+  });
+
+  client.on("messageCreate", async (message) => {
+    try {
+      if (!officialAutoReactEnabled || !officialGuildId) return;
+      if (!message?.guildId || message.guildId !== officialGuildId) return;
+      if (message.author?.id === client.user?.id) return;
+      if (officialAutoReactBotsOnly && !message.author?.bot) return;
+
+      const channelId = String(message.channelId || "");
+      const searchBlob = getMessageSearchBlob(message);
+
+      const isWelcomeMatch = officialWelcomeAutoReactChannels.has(channelId)
+        || officialWelcomeKeywords.some((keyword) => searchBlob.includes(keyword));
+      const isLevelMatch = officialLevelAutoReactChannels.has(channelId)
+        || officialLevelKeywords.some((keyword) => searchBlob.includes(keyword));
+
+      if (!isWelcomeMatch && !isLevelMatch) return;
+
+      if (isWelcomeMatch) {
+        for (const emoji of officialWelcomeAutoReactEmojis) {
+          await tryAutoReact(message, emoji);
+        }
+      }
+      if (isLevelMatch) {
+        for (const emoji of officialLevelAutoReactEmojis) {
+          await tryAutoReact(message, emoji);
+        }
+      }
+    } catch (error) {
+      console.error("❌ Official auto-react handler failed:", error?.stack ?? error);
     }
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1339,18 +1339,7 @@ import { theme } from "./ui/theme.js";
         ? precomputedCounts
         : getCurrentBotListCounts();
       const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
-      let shopsCount = null;
-      if (db) {
-        try {
-          const row = db.prepare("SELECT COUNT(DISTINCT user_id) AS count FROM players").get();
-          shopsCount = Math.max(0, Number(row?.count || 0));
-        } catch (error) {
-          console.error("❌ Failed to query DB shop count for official stats channels:", error?.stack ?? error);
-        }
-      }
-      if (!Number.isFinite(shopsCount) || shopsCount == null) {
-        shopsCount = 0;
-      }
+      const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
 
       const serverChannel = await ensureOfficialReadonlyStatsChannel(
         officialGuild,
@@ -1369,7 +1358,7 @@ import { theme } from "./ui/theme.js";
           marker: "noodle:stats:shops",
           prefix: "noodle-shops",
           count: shopsCount,
-          topic: "Global noodle shops count from DB players table"
+          topic: "Global noodle shops count (same metric as unique players)"
         }
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -460,14 +460,19 @@ import { theme } from "./ui/theme.js";
     Intents.FLAGS.GUILD_MESSAGES,
     Intents.FLAGS.DIRECT_MESSAGES
   ];
-  const messageContentIntentApplied = Boolean(
+  const messageContentIntentBit = Intents.FLAGS.MESSAGE_CONTENT ?? (1 << 15);
+  const messageContentIntentRequested = Boolean(
     officialAutoReactEnabled
     && officialAutoReactKeywordMatchEnabled
     && officialMessageContentIntentEnabled
-    && Intents.FLAGS.MESSAGE_CONTENT
+  );
+  const messageContentIntentApplied = Boolean(
+    messageContentIntentRequested
+    && Number.isInteger(messageContentIntentBit)
+    && messageContentIntentBit > 0
   );
   if (messageContentIntentApplied) {
-    clientIntents.push(Intents.FLAGS.MESSAGE_CONTENT);
+    clientIntents.push(messageContentIntentBit);
   }
 
   const client = new Client({ intents: clientIntents });
@@ -1334,8 +1339,18 @@ import { theme } from "./ui/theme.js";
         ? precomputedCounts
         : getCurrentBotListCounts();
       const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
-      const userCount = Math.max(0, Number(counts?.userCount) || 0);
-      const shopsCount = Math.max(0, Number(userCount) || 0);
+      let shopsCount = null;
+      if (db) {
+        try {
+          const row = db.prepare("SELECT COUNT(DISTINCT user_id) AS count FROM players").get();
+          shopsCount = Math.max(0, Number(row?.count || 0));
+        } catch (error) {
+          console.error("❌ Failed to query DB shop count for official stats channels:", error?.stack ?? error);
+        }
+      }
+      if (!Number.isFinite(shopsCount) || shopsCount == null) {
+        shopsCount = 0;
+      }
 
       const serverChannel = await ensureOfficialReadonlyStatsChannel(
         officialGuild,
@@ -2151,18 +2166,22 @@ import { theme } from "./ui/theme.js";
     if (officialAutoReactEnabled && officialAutoReactKeywordMatchEnabled) {
       if (!officialMessageContentIntentEnabled) {
         console.warn("⚠️ Official auto-react keyword matching is enabled but NOODLE_OFFICIAL_ENABLE_MESSAGE_CONTENT_INTENT is not set to 1. Keyword matching may not work in production; channel-id matching will still work.");
-      } else if (!Intents.FLAGS.MESSAGE_CONTENT || !messageContentIntentApplied) {
+      } else if (!messageContentIntentApplied) {
         console.warn("⚠️ Official auto-react keyword matching is enabled and intent is requested, but MESSAGE_CONTENT is unavailable in this discord.js/runtime environment. Keyword matching may not work; channel-id matching will still work.");
       }
     }
 
-    await c.user.setPresence({
-      status: "online",
-      activities: [{
-        name: "/noodle help | /noodle start",
-        type: "PLAYING"
-      }]
-    });
+    try {
+      await c.user.setPresence({
+        status: "online",
+        activities: [{
+          name: "/noodle help | /noodle start",
+          type: "PLAYING"
+        }]
+      });
+    } catch (error) {
+      console.error("⚠️ Failed to set bot presence:", error?.message ?? error);
+    }
 
     const customEmojis = getCustomEmojiEntries();
     const { ids: accessibleEmojiIds, applicationEmojiCount } = await resolveAccessibleEmojiIds(client, token);

--- a/src/index.js
+++ b/src/index.js
@@ -460,12 +460,13 @@ import { theme } from "./ui/theme.js";
     Intents.FLAGS.GUILD_MESSAGES,
     Intents.FLAGS.DIRECT_MESSAGES
   ];
-  if (
+  const messageContentIntentApplied = Boolean(
     officialAutoReactEnabled
     && officialAutoReactKeywordMatchEnabled
     && officialMessageContentIntentEnabled
     && Intents.FLAGS.MESSAGE_CONTENT
-  ) {
+  );
+  if (messageContentIntentApplied) {
     clientIntents.push(Intents.FLAGS.MESSAGE_CONTENT);
   }
 
@@ -2147,8 +2148,12 @@ import { theme } from "./ui/theme.js";
   client.once("ready", async (c) => {
     console.log(`✅ Logged in as ${c.user.tag}`);
 
-    if (officialAutoReactEnabled && officialAutoReactKeywordMatchEnabled && !officialMessageContentIntentEnabled) {
-      console.warn("⚠️ Official auto-react keyword matching is enabled but NOODLE_OFFICIAL_ENABLE_MESSAGE_CONTENT_INTENT is not set to 1. Keyword matching may not work in production; channel-id matching will still work.");
+    if (officialAutoReactEnabled && officialAutoReactKeywordMatchEnabled) {
+      if (!officialMessageContentIntentEnabled) {
+        console.warn("⚠️ Official auto-react keyword matching is enabled but NOODLE_OFFICIAL_ENABLE_MESSAGE_CONTENT_INTENT is not set to 1. Keyword matching may not work in production; channel-id matching will still work.");
+      } else if (!Intents.FLAGS.MESSAGE_CONTENT || !messageContentIntentApplied) {
+        console.warn("⚠️ Official auto-react keyword matching is enabled and intent is requested, but MESSAGE_CONTENT is unavailable in this discord.js/runtime environment. Keyword matching may not work; channel-id matching will still work.");
+      }
     }
 
     await c.user.setPresence({
@@ -2200,7 +2205,7 @@ import { theme } from "./ui/theme.js";
 
     if (officialStatsChannelsEnabled && officialGuildId && !officialStatsChannelRefreshHandle) {
       officialStatsChannelRefreshHandle = setInterval(() => {
-        updateOfficialStatsChannels({ reason: "interval" });
+        updateOfficialStatsChannels(null, { reason: "interval" });
       }, officialStatsChannelRefreshIntervalMs);
       officialStatsChannelRefreshHandle.unref?.();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -268,6 +268,8 @@ import { theme } from "./ui/theme.js";
     .filter(Boolean);
   const officialAutoReactEnabled = String(process.env.NOODLE_OFFICIAL_AUTOREACT_ENABLED || "1") !== "0";
   const officialAutoReactBotsOnly = String(process.env.NOODLE_OFFICIAL_AUTOREACT_BOTS_ONLY || "1") !== "0";
+  const officialAutoReactKeywordMatchEnabled = String(process.env.NOODLE_OFFICIAL_AUTOREACT_MATCH_KEYWORDS || "0") === "1";
+  const officialMessageContentIntentEnabled = String(process.env.NOODLE_OFFICIAL_ENABLE_MESSAGE_CONTENT_INTENT || "0") === "1";
   const officialWelcomeAutoReactEmojis = parseCsvValues(process.env.NOODLE_OFFICIAL_WELCOME_REACT_EMOJI || "👋");
   const officialLevelAutoReactEmojis = parseCsvValues(process.env.NOODLE_OFFICIAL_LEVEL_REACT_EMOJI || "🎉");
   const officialStatsChannelsEnabled = String(process.env.NOODLE_OFFICIAL_STATS_CHANNELS_ENABLED || "1") !== "0";
@@ -458,7 +460,12 @@ import { theme } from "./ui/theme.js";
     Intents.FLAGS.GUILD_MESSAGES,
     Intents.FLAGS.DIRECT_MESSAGES
   ];
-  if (Intents.FLAGS.MESSAGE_CONTENT) {
+  if (
+    officialAutoReactEnabled
+    && officialAutoReactKeywordMatchEnabled
+    && officialMessageContentIntentEnabled
+    && Intents.FLAGS.MESSAGE_CONTENT
+  ) {
     clientIntents.push(Intents.FLAGS.MESSAGE_CONTENT);
   }
 
@@ -1229,6 +1236,14 @@ import { theme } from "./ui/theme.js";
   async function ensureOfficialReadonlyStatsChannel(officialGuild, channelId, { marker, prefix, count, topic }) {
     let channel = null;
     const existingId = String(channelId || "").trim();
+    const lockPermissionNames = [
+      "SEND_MESSAGES",
+      "ADD_REACTIONS",
+      "CREATE_PUBLIC_THREADS",
+      "CREATE_PRIVATE_THREADS",
+      "SEND_MESSAGES_IN_THREADS"
+    ].filter((perm) => Boolean(Discord.Permissions?.FLAGS?.[perm]));
+    const lockPermissionOptions = Object.fromEntries(lockPermissionNames.map((perm) => [perm, false]));
 
     if (existingId) {
       channel = officialGuild.channels.cache.get(existingId)
@@ -1243,23 +1258,21 @@ import { theme } from "./ui/theme.js";
     }
 
     if (!channel) {
-      const denied = [
-        "SEND_MESSAGES",
-        "ADD_REACTIONS",
-        "CREATE_PUBLIC_THREADS",
-        "CREATE_PRIVATE_THREADS",
-        "SEND_MESSAGES_IN_THREADS"
-      ].filter((perm) => Boolean(Discord.Permissions?.FLAGS?.[perm]));
-
       channel = await officialGuild.channels.create(buildStatChannelName(prefix, count), {
         type: "GUILD_TEXT",
         topic: `${marker} | ${topic}`.slice(0, 1024),
         permissionOverwrites: [
           {
             id: officialGuild.roles.everyone.id,
-            deny: denied
+            deny: lockPermissionNames
           }
         ]
+      });
+    }
+
+    if (channel?.permissionOverwrites?.edit && Object.keys(lockPermissionOptions).length > 0) {
+      await channel.permissionOverwrites.edit(officialGuild.roles.everyone, lockPermissionOptions).catch((error) => {
+        console.error(`❌ Failed to apply official stats lock permissions (${marker}):`, error?.message ?? error);
       });
     }
 
@@ -2101,6 +2114,10 @@ import { theme } from "./ui/theme.js";
   client.once("ready", async (c) => {
     console.log(`✅ Logged in as ${c.user.tag}`);
 
+    if (officialAutoReactEnabled && officialAutoReactKeywordMatchEnabled && !officialMessageContentIntentEnabled) {
+      console.warn("⚠️ Official auto-react keyword matching is enabled but NOODLE_OFFICIAL_ENABLE_MESSAGE_CONTENT_INTENT is not set to 1. Keyword matching may not work in production; channel-id matching will still work.");
+    }
+
     await c.user.setPresence({
       status: "online",
       activities: [{
@@ -2220,12 +2237,12 @@ import { theme } from "./ui/theme.js";
       if (officialAutoReactBotsOnly && !message.author?.bot) return;
 
       const channelId = String(message.channelId || "");
-      const searchBlob = getMessageSearchBlob(message);
+      const searchBlob = officialAutoReactKeywordMatchEnabled ? getMessageSearchBlob(message) : "";
 
       const isWelcomeMatch = officialWelcomeAutoReactChannels.has(channelId)
-        || officialWelcomeKeywords.some((keyword) => searchBlob.includes(keyword));
+        || (officialAutoReactKeywordMatchEnabled && officialWelcomeKeywords.some((keyword) => searchBlob.includes(keyword)));
       const isLevelMatch = officialLevelAutoReactChannels.has(channelId)
-        || officialLevelKeywords.some((keyword) => searchBlob.includes(keyword));
+        || (officialAutoReactKeywordMatchEnabled && officialLevelKeywords.some((keyword) => searchBlob.includes(keyword)));
 
       if (!isWelcomeMatch && !isLevelMatch) return;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1234,11 +1234,22 @@ import { theme } from "./ui/theme.js";
   }
 
   async function ensureOfficialReadonlyStatsChannel(officialGuild, channelId, { marker, prefix, count, topic }) {
+    const isSupportedStatsTextChannel = (candidate) => (
+      candidate?.type === "GUILD_TEXT"
+      && typeof candidate?.setName === "function"
+      && typeof candidate?.setTopic === "function"
+      && typeof candidate?.permissionOverwrites?.edit === "function"
+    );
+
     let channel = null;
     const existingId = String(channelId || "").trim();
     const lockPermissionNames = [
       "SEND_MESSAGES",
+      "SEND_TTS_MESSAGES",
+      "ATTACH_FILES",
+      "EMBED_LINKS",
       "ADD_REACTIONS",
+      "USE_APPLICATION_COMMANDS",
       "CREATE_PUBLIC_THREADS",
       "CREATE_PRIVATE_THREADS",
       "SEND_MESSAGES_IN_THREADS"
@@ -1248,11 +1259,15 @@ import { theme } from "./ui/theme.js";
     if (existingId) {
       channel = officialGuild.channels.cache.get(existingId)
         || await officialGuild.channels.fetch(existingId).catch(() => null);
+      if (channel && !isSupportedStatsTextChannel(channel)) {
+        console.warn(`⚠️ Ignoring configured stats channel ${existingId} for ${marker}: not a guild text channel.`);
+        channel = null;
+      }
     }
 
     if (!channel) {
       channel = officialGuild.channels.cache.find((candidate) =>
-        candidate?.type === "GUILD_TEXT"
+        isSupportedStatsTextChannel(candidate)
         && String(candidate?.topic || "").includes(marker)
       ) || null;
     }
@@ -1270,7 +1285,12 @@ import { theme } from "./ui/theme.js";
       });
     }
 
-    if (channel?.permissionOverwrites?.edit && Object.keys(lockPermissionOptions).length > 0) {
+    if (!isSupportedStatsTextChannel(channel)) {
+      console.error(`❌ Failed to resolve a valid guild text channel for ${marker}.`);
+      return null;
+    }
+
+    if (Object.keys(lockPermissionOptions).length > 0) {
       await channel.permissionOverwrites.edit(officialGuild.roles.everyone, lockPermissionOptions).catch((error) => {
         console.error(`❌ Failed to apply official stats lock permissions (${marker}):`, error?.message ?? error);
       });
@@ -1310,7 +1330,7 @@ import { theme } from "./ui/theme.js";
           marker: "noodle:stats:servers",
           prefix: "servers",
           count: serverCount,
-          topic: `Global server count (updated: ${new Date().toISOString()})`
+          topic: "Global server count"
         }
       );
       const shopsChannel = await ensureOfficialReadonlyStatsChannel(
@@ -1320,7 +1340,7 @@ import { theme } from "./ui/theme.js";
           marker: "noodle:stats:shops",
           prefix: "noodle-shops",
           count: shopsCount,
-          topic: `Global noodle shops count from DB players table (updated: ${new Date().toISOString()})`
+          topic: "Global noodle shops count from DB players table"
         }
       );
 
@@ -2165,7 +2185,7 @@ import { theme } from "./ui/theme.js";
     await syncRadarCpdvCommands({ reason: "ready" });
     startBotListStatsHeartbeat();
 
-    if (officialStatsChannelsEnabled && !officialStatsChannelRefreshHandle) {
+    if (officialStatsChannelsEnabled && officialGuildId && !officialStatsChannelRefreshHandle) {
       officialStatsChannelRefreshHandle = setInterval(() => {
         updateOfficialStatsChannels({ reason: "interval" });
       }, officialStatsChannelRefreshIntervalMs);

--- a/src/index.js
+++ b/src/index.js
@@ -1291,9 +1291,18 @@ import { theme } from "./ui/theme.js";
     }
 
     if (Object.keys(lockPermissionOptions).length > 0) {
-      await channel.permissionOverwrites.edit(officialGuild.roles.everyone, lockPermissionOptions).catch((error) => {
-        console.error(`❌ Failed to apply official stats lock permissions (${marker}):`, error?.message ?? error);
+      const everyoneRoleId = officialGuild.roles.everyone.id;
+      const overwrite = channel.permissionOverwrites?.cache?.get(everyoneRoleId) || null;
+      const alreadyLocked = lockPermissionNames.every((perm) => {
+        const permFlag = Discord.Permissions?.FLAGS?.[perm];
+        return permFlag ? overwrite?.deny?.has?.(permFlag) : true;
       });
+
+      if (!alreadyLocked) {
+        await channel.permissionOverwrites.edit(everyoneRoleId, lockPermissionOptions).catch((error) => {
+          console.error(`❌ Failed to apply official stats lock permissions (${marker}):`, error?.message ?? error);
+        });
+      }
     }
 
     const nextName = buildStatChannelName(prefix, count);
@@ -1312,7 +1321,7 @@ import { theme } from "./ui/theme.js";
     return channel;
   }
 
-  async function updateOfficialStatsChannels({ reason = "event" } = {}) {
+  async function updateOfficialStatsChannels(precomputedCounts = null, { reason = "event" } = {}) {
     if (!officialStatsChannelsEnabled || !officialGuildId) return false;
 
     try {
@@ -1320,7 +1329,11 @@ import { theme } from "./ui/theme.js";
         || await client.guilds.fetch(officialGuildId).catch(() => null);
       if (!officialGuild) return false;
 
-      const { serverCount, userCount } = getCurrentBotListCounts();
+      const counts = precomputedCounts && typeof precomputedCounts === "object"
+        ? precomputedCounts
+        : getCurrentBotListCounts();
+      const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
+      const userCount = Math.max(0, Number(counts?.userCount) || 0);
       const shopsCount = Math.max(0, Number(userCount) || 0);
 
       const serverChannel = await ensureOfficialReadonlyStatsChannel(
@@ -1347,7 +1360,7 @@ import { theme } from "./ui/theme.js";
       if (serverChannel?.id) officialServerCountChannelId = serverChannel.id;
       if (shopsChannel?.id) officialShopCountChannelId = shopsChannel.id;
 
-      console.log(`✅ Official stats channels updated (${reason}): servers=${Number(serverCount) || 0}, shops=${shopsCount}`);
+      console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}`);
       return true;
     } catch (error) {
       console.error("❌ Failed to update official stats channels:", error?.stack ?? error);
@@ -2174,13 +2187,13 @@ import { theme } from "./ui/theme.js";
       console.error("❌ Failed to write boot marker:", e?.stack ?? e);
     }
 
+    const startupCounts = getCurrentBotListCounts();
     if (hasAnyConfiguredBotListStatsSync()) {
-      const startupCounts = getCurrentBotListCounts();
       await updateAllBotListServerCounts(startupCounts, { reason: "ready" });
     } else {
       console.log("INFO: Skipping bot-list stats sync on ready (no providers configured with both URL and token).");
     }
-    await updateOfficialStatsChannels({ reason: "ready" });
+    await updateOfficialStatsChannels(startupCounts, { reason: "ready" });
     await syncDiscordBotListCommands({ reason: "ready" });
     await syncRadarCpdvCommands({ reason: "ready" });
     startBotListStatsHeartbeat();
@@ -2210,7 +2223,7 @@ import { theme } from "./ui/theme.js";
     try {
       const currentCounts = getCurrentBotListCounts();
       await updateAllBotListServerCounts(currentCounts, { reason: "guildCreate" });
-      await updateOfficialStatsChannels({ reason: "guildCreate" });
+      await updateOfficialStatsChannels(currentCounts, { reason: "guildCreate" });
       await refreshShardHealth({ reason: "guildCreate" });
 
       if (guild?.id === officialGuildId) return;
@@ -2233,7 +2246,7 @@ import { theme } from "./ui/theme.js";
     try {
       const currentCounts = getCurrentBotListCounts();
       await updateAllBotListServerCounts(currentCounts, { reason: "guildDelete" });
-      await updateOfficialStatsChannels({ reason: "guildDelete" });
+      await updateOfficialStatsChannels(currentCounts, { reason: "guildDelete" });
       await refreshShardHealth({ reason: "guildDelete" });
 
       if (guild?.id === officialGuildId) return;


### PR DESCRIPTION
## Summary
- Set bot presence on ready to `/noodle help | /noodle start`.
- Add official-server-only auto-reaction handling for welcome/level messages.
- Support multiple configured emojis (including custom server emojis) via comma-separated env values.
- Add auto-managed locked text channels for global server count and noodle shop count.
- Update stats channels on ready, guild join/leave, and a refresh interval.

## Target Branch (Required)
- [ ] Target is develop (feature/integration testing)
- [x] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (`cleanstart` / `syncmain`).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [ ] I rebased this branch on latest origin/develop.
- [ ] This PR is intended for integration/QA testing, not direct production release.
- [ ] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [x] I rebased this branch on latest origin/main.
- [x] This change is release-ready and already validated at appropriate level.
- [x] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [x] Lint/type checks pass (if applicable).

Commands run:
```bash
node --check src/index.js
```

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

## Reviewer Notes
- Areas to focus on: official-guild-only message matching, emoji parsing for custom emojis, and locked stats channel behavior.
- Known limitations: keyword matching depends on message/embed text emitted by the external welcome/level bot.
- Follow-up work (if any): optional manual validation in official server channels after deploy.

---

### Review Gate
Do not request review until all required checkboxes are complete.
If any box is intentionally unchecked, explain why in this PR description.
