### PR TITLE
Add dedupe and throttle for official stats channel interval refreshes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -424,6 +424,10 @@ import { theme } from "./ui/theme.js";
   const officialStatsChannelRefreshIntervalMs = Number.isFinite(officialStatsChannelRefreshIntervalRaw)
     ? Math.max(60_000, Math.floor(officialStatsChannelRefreshIntervalRaw))
     : 10 * 60 * 1000;
+  const officialStatsMinIntervalRaw = Number(process.env.NOODLE_OFFICIAL_STATS_MIN_INTERVAL_MS || officialStatsChannelRefreshIntervalMs);
+  const officialStatsMinIntervalMs = Number.isFinite(officialStatsMinIntervalRaw) && officialStatsMinIntervalRaw >= 30_000
+    ? Math.floor(officialStatsMinIntervalRaw)
+    : officialStatsChannelRefreshIntervalMs;
   let officialStatsChannelRefreshHandle = null;
   const devAlertChannelId = process.env.NOODLE_DEV_ALERT_CHANNEL_ID || "";
   const devAlertUserId = process.env.NOODLE_DEV_ALERT_USER_ID || "";
@@ -591,6 +595,7 @@ import { theme } from "./ui/theme.js";
   const invalidStatsCategoryLogged = new Set();
   const lastBotListStatsPushBySource = new Map();
   const nextStatsSyncAllowedAtBySource = new Map();
+  let lastOfficialStatsPush = null;
   const officialWelcomeAutoReactChannels = new Set(parseCsvValues(process.env.NOODLE_OFFICIAL_WELCOME_CHANNEL_IDS));
   const officialLevelAutoReactChannels = new Set(parseCsvValues(process.env.NOODLE_OFFICIAL_LEVEL_CHANNEL_IDS));
   const officialWelcomeKeywords = parseCsvValues(process.env.NOODLE_OFFICIAL_WELCOME_KEYWORDS || "welcome,joined the server")
@@ -600,6 +605,7 @@ import { theme } from "./ui/theme.js";
   let shardNearThresholdAlertSent = false;
   let shardRecommendedAlertSent = false;
   let botListStatsHeartbeatHandle = null;
+  let nextOfficialStatsSyncAllowedAt = 0;
   if (!token) {
     console.error("❌ Missing DISCORD_TOKEN in .env");
     process.exit(1);
@@ -1512,6 +1518,22 @@ import { theme } from "./ui/theme.js";
       const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
       const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
       const officialMemberCount = Math.max(0, Number(officialGuild?.memberCount || 0));
+      const nowMs = Date.now();
+      const isIntervalReason = reason === "interval";
+
+      if (isIntervalReason && nextOfficialStatsSyncAllowedAt > nowMs) {
+        return false;
+      }
+
+      if (
+        isIntervalReason
+        && lastOfficialStatsPush
+        && lastOfficialStatsPush.serverCount === serverCount
+        && lastOfficialStatsPush.shopsCount === shopsCount
+        && lastOfficialStatsPush.officialMemberCount === officialMemberCount
+      ) {
+        return false;
+      }
 
       const serverChannel = await ensureOfficialReadonlyStatsChannel(
         officialGuild,
@@ -1550,6 +1572,14 @@ import { theme } from "./ui/theme.js";
         console.warn("⚠️ Official stats channels skipped: configure explicit NOODLE_OFFICIAL_*_CHANNEL_ID values.");
         return false;
       }
+
+      lastOfficialStatsPush = {
+        serverCount,
+        shopsCount,
+        officialMemberCount,
+        sentAt: nowMs
+      };
+      nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
 
       console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannels.length}/3`);
       return true;

--- a/src/index.js
+++ b/src/index.js
@@ -1593,13 +1593,27 @@ import { theme } from "./ui/theme.js";
         if (memberResult?.channel?.id) officialMemberCountChannelId = memberResult.channel.id;
 
         if (resolvedChannelCount === 0) {
+          lastOfficialStatsPush = {
+            serverCount,
+            shopsCount,
+            officialMemberCount,
+            sentAt: nowMs,
+            fullySynchronized: false
+          };
           console.warn("⚠️ Official stats channels skipped: configure explicit NOODLE_OFFICIAL_*_CHANNEL_ID values.");
           return false;
         }
 
         if (synchronizedResolvedChannelCount === 0) {
+          lastOfficialStatsPush = {
+            serverCount,
+            shopsCount,
+            officialMemberCount,
+            sentAt: nowMs,
+            fullySynchronized: false
+          };
           console.error(
-            `❌ Official stats channel sync had no successful channel updates (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannelCount}/3`
+            `❌ Official stats channel sync had no fully successful channel synchronizations (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannelCount}/3`
           );
           return false;
         }
@@ -1616,6 +1630,14 @@ import { theme } from "./ui/theme.js";
             fullySynchronized: true
           };
           nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
+        } else {
+          lastOfficialStatsPush = {
+            serverCount,
+            shopsCount,
+            officialMemberCount,
+            sentAt: nowMs,
+            fullySynchronized: false
+          };
         }
 
         console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannelCount}/3, synchronized=${synchronizedResolvedChannelCount}/${resolvedChannelCount}`);

--- a/src/index.js
+++ b/src/index.js
@@ -607,6 +607,7 @@ import { theme } from "./ui/theme.js";
   let botListStatsHeartbeatHandle = null;
   let nextOfficialStatsSyncAllowedAt = 0;
   let officialStatsUpdateQueue = Promise.resolve(false);
+  let officialStatsUpdateInFlight = false;
   if (!token) {
     console.error("❌ Missing DISCORD_TOKEN in .env");
     process.exit(1);
@@ -1511,10 +1512,14 @@ import { theme } from "./ui/theme.js";
 
   async function updateOfficialStatsChannels(precomputedCounts = null, { reason = "event" } = {}) {
     if (!officialStatsChannelsEnabled || !officialGuildId) return false;
+    const isIntervalReason = reason === "interval";
+
+    if (isIntervalReason && officialStatsUpdateInFlight) {
+      return false;
+    }
 
     const runUpdate = async () => {
       const nowMs = Date.now();
-      const isIntervalReason = reason === "interval";
       if (isIntervalReason && nextOfficialStatsSyncAllowedAt > nowMs) {
         return false;
       }
@@ -1537,6 +1542,7 @@ import { theme } from "./ui/theme.js";
         if (
           isIntervalReason
           && lastOfficialStatsPush
+          && lastOfficialStatsPush.fullySynchronized === true
           && lastOfficialStatsPush.serverCount === serverCount
           && lastOfficialStatsPush.shopsCount === shopsCount
           && lastOfficialStatsPush.officialMemberCount === officialMemberCount
@@ -1580,6 +1586,7 @@ import { theme } from "./ui/theme.js";
         const synchronizedResolvedChannelCount = channelResults.filter(
           (result) => Boolean(result?.channel) && result?.synchronized === true
         ).length;
+        const expectedChannelCount = 3;
 
         if (serverResult?.channel?.id) officialServerCountChannelId = serverResult.channel.id;
         if (shopsResult?.channel?.id) officialShopCountChannelId = shopsResult.channel.id;
@@ -1597,12 +1604,16 @@ import { theme } from "./ui/theme.js";
           return false;
         }
 
-        if (synchronizedResolvedChannelCount === resolvedChannelCount) {
+        if (
+          resolvedChannelCount === expectedChannelCount
+          && synchronizedResolvedChannelCount === expectedChannelCount
+        ) {
           lastOfficialStatsPush = {
             serverCount,
             shopsCount,
             officialMemberCount,
-            sentAt: nowMs
+            sentAt: nowMs,
+            fullySynchronized: true
           };
           nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
         }
@@ -1617,7 +1628,14 @@ import { theme } from "./ui/theme.js";
 
     const queuedRun = officialStatsUpdateQueue
       .catch(() => false)
-      .then(runUpdate);
+      .then(async () => {
+        officialStatsUpdateInFlight = true;
+        try {
+          return await runUpdate();
+        } finally {
+          officialStatsUpdateInFlight = false;
+        }
+      });
     officialStatsUpdateQueue = queuedRun.then(() => false, () => false);
     return queuedRun;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1405,6 +1405,7 @@ import { theme } from "./ui/theme.js";
     );
 
     let channel = null;
+    let hadSyncError = false;
     const existingId = String(channelId || "").trim();
     const lockPermissionNames = [
       "CONNECT",
@@ -1474,6 +1475,7 @@ import { theme } from "./ui/theme.js";
         const currentParentId = String(channel.parentId || channel.parent?.id || "");
         if (currentParentId !== configuredCategory.id) {
           await channel.setParent(configuredCategory.id, { lockPermissions: false }).catch((error) => {
+            hadSyncError = true;
             console.error(`❌ Failed to move stats channel to configured category (${marker}):`, error?.message ?? error);
           });
         }
@@ -1490,6 +1492,7 @@ import { theme } from "./ui/theme.js";
 
       if (!alreadyLocked) {
         await channel.permissionOverwrites.edit(everyoneRoleId, lockPermissionOptions).catch((error) => {
+          hadSyncError = true;
           console.error(`❌ Failed to apply official stats lock permissions (${marker}):`, error?.message ?? error);
         });
       }
@@ -1498,14 +1501,21 @@ import { theme } from "./ui/theme.js";
     const nextName = buildStatChannelName(label, count);
     if (channel.name !== nextName) {
       await channel.setName(nextName).catch((error) => {
+        hadSyncError = true;
         console.error(`❌ Failed to rename official stats channel (${marker}):`, error?.message ?? error);
       });
     }
-    return channel;
+    return { channel, synchronized: !hadSyncError };
   }
 
   async function updateOfficialStatsChannels(precomputedCounts = null, { reason = "event" } = {}) {
     if (!officialStatsChannelsEnabled || !officialGuildId) return false;
+
+    const nowMs = Date.now();
+    const isIntervalReason = reason === "interval";
+    if (isIntervalReason && nextOfficialStatsSyncAllowedAt > nowMs) {
+      return false;
+    }
 
     try {
       const officialGuild = client.guilds.cache.get(officialGuildId)
@@ -1518,12 +1528,6 @@ import { theme } from "./ui/theme.js";
       const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
       const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
       const officialMemberCount = Math.max(0, Number(officialGuild?.memberCount || 0));
-      const nowMs = Date.now();
-      const isIntervalReason = reason === "interval";
-
-      if (isIntervalReason && nextOfficialStatsSyncAllowedAt > nowMs) {
-        return false;
-      }
 
       if (
         isIntervalReason
@@ -1535,7 +1539,7 @@ import { theme } from "./ui/theme.js";
         return false;
       }
 
-      const serverChannel = await ensureOfficialReadonlyStatsChannel(
+      const serverResult = await ensureOfficialReadonlyStatsChannel(
         officialGuild,
         officialServerCountChannelId,
         {
@@ -1544,7 +1548,7 @@ import { theme } from "./ui/theme.js";
           count: serverCount
         }
       );
-      const shopsChannel = await ensureOfficialReadonlyStatsChannel(
+      const shopsResult = await ensureOfficialReadonlyStatsChannel(
         officialGuild,
         officialShopCountChannelId,
         {
@@ -1553,7 +1557,7 @@ import { theme } from "./ui/theme.js";
           count: shopsCount
         }
       );
-      const memberChannel = await ensureOfficialReadonlyStatsChannel(
+      const memberResult = await ensureOfficialReadonlyStatsChannel(
         officialGuild,
         officialMemberCountChannelId,
         {
@@ -1563,23 +1567,31 @@ import { theme } from "./ui/theme.js";
         }
       );
 
-      if (serverChannel?.id) officialServerCountChannelId = serverChannel.id;
-      if (shopsChannel?.id) officialShopCountChannelId = shopsChannel.id;
-      if (memberChannel?.id) officialMemberCountChannelId = memberChannel.id;
+      const channelResults = [serverResult, shopsResult, memberResult];
+      const resolvedChannels = channelResults
+        .map((result) => result?.channel || null)
+        .filter(Boolean);
+      const allChannelsResolved = channelResults.every((result) => Boolean(result?.channel));
+      const allChannelsSynchronized = channelResults.every((result) => Boolean(result?.channel) && result?.synchronized === true);
 
-      const resolvedChannels = [serverChannel, shopsChannel, memberChannel].filter(Boolean);
+      if (serverResult?.channel?.id) officialServerCountChannelId = serverResult.channel.id;
+      if (shopsResult?.channel?.id) officialShopCountChannelId = shopsResult.channel.id;
+      if (memberResult?.channel?.id) officialMemberCountChannelId = memberResult.channel.id;
+
       if (resolvedChannels.length === 0) {
         console.warn("⚠️ Official stats channels skipped: configure explicit NOODLE_OFFICIAL_*_CHANNEL_ID values.");
         return false;
       }
 
-      lastOfficialStatsPush = {
-        serverCount,
-        shopsCount,
-        officialMemberCount,
-        sentAt: nowMs
-      };
-      nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
+      if (allChannelsResolved && allChannelsSynchronized) {
+        lastOfficialStatsPush = {
+          serverCount,
+          shopsCount,
+          officialMemberCount,
+          sentAt: nowMs
+        };
+        nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
+      }
 
       console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannels.length}/3`);
       return true;

--- a/src/index.js
+++ b/src/index.js
@@ -606,6 +606,7 @@ import { theme } from "./ui/theme.js";
   let shardRecommendedAlertSent = false;
   let botListStatsHeartbeatHandle = null;
   let nextOfficialStatsSyncAllowedAt = 0;
+  let officialStatsUpdateQueue = Promise.resolve(false);
   if (!token) {
     console.error("❌ Missing DISCORD_TOKEN in .env");
     process.exit(1);
@@ -1511,94 +1512,102 @@ import { theme } from "./ui/theme.js";
   async function updateOfficialStatsChannels(precomputedCounts = null, { reason = "event" } = {}) {
     if (!officialStatsChannelsEnabled || !officialGuildId) return false;
 
-    const nowMs = Date.now();
-    const isIntervalReason = reason === "interval";
-    if (isIntervalReason && nextOfficialStatsSyncAllowedAt > nowMs) {
-      return false;
-    }
-
-    try {
-      const officialGuild = client.guilds.cache.get(officialGuildId)
-        || await client.guilds.fetch(officialGuildId).catch(() => null);
-      if (!officialGuild) return false;
-
-      const counts = precomputedCounts && typeof precomputedCounts === "object"
-        ? precomputedCounts
-        : getCurrentBotListCounts();
-      const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
-      const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
-      const officialMemberCount = Math.max(0, Number(officialGuild?.memberCount || 0));
-
-      if (
-        isIntervalReason
-        && lastOfficialStatsPush
-        && lastOfficialStatsPush.serverCount === serverCount
-        && lastOfficialStatsPush.shopsCount === shopsCount
-        && lastOfficialStatsPush.officialMemberCount === officialMemberCount
-      ) {
+    const runUpdate = async () => {
+      const nowMs = Date.now();
+      const isIntervalReason = reason === "interval";
+      if (isIntervalReason && nextOfficialStatsSyncAllowedAt > nowMs) {
         return false;
       }
 
-      const serverResult = await ensureOfficialReadonlyStatsChannel(
-        officialGuild,
-        officialServerCountChannelId,
-        {
-          marker: "noodle:stats:servers",
-          label: officialServerCountLabel,
-          count: serverCount
-        }
-      );
-      const shopsResult = await ensureOfficialReadonlyStatsChannel(
-        officialGuild,
-        officialShopCountChannelId,
-        {
-          marker: "noodle:stats:shops",
-          label: officialShopCountLabel,
-          count: shopsCount
-        }
-      );
-      const memberResult = await ensureOfficialReadonlyStatsChannel(
-        officialGuild,
-        officialMemberCountChannelId,
-        {
-          marker: "noodle:stats:official-members",
-          label: officialMemberCountLabel,
-          count: officialMemberCount
-        }
-      );
+      try {
+        const officialGuild = client.guilds.cache.get(officialGuildId)
+          || await client.guilds.fetch(officialGuildId).catch(() => null);
+        if (!officialGuild) return false;
 
-      const channelResults = [serverResult, shopsResult, memberResult];
-      const resolvedChannels = channelResults
-        .map((result) => result?.channel || null)
-        .filter(Boolean);
-      const allChannelsResolved = channelResults.every((result) => Boolean(result?.channel));
-      const allChannelsSynchronized = channelResults.every((result) => Boolean(result?.channel) && result?.synchronized === true);
+        const counts = precomputedCounts && typeof precomputedCounts === "object"
+          ? precomputedCounts
+          : getCurrentBotListCounts();
+        const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
+        const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
+        const officialMemberCount = Math.max(0, Number(officialGuild?.memberCount || 0));
 
-      if (serverResult?.channel?.id) officialServerCountChannelId = serverResult.channel.id;
-      if (shopsResult?.channel?.id) officialShopCountChannelId = shopsResult.channel.id;
-      if (memberResult?.channel?.id) officialMemberCountChannelId = memberResult.channel.id;
+        if (
+          isIntervalReason
+          && lastOfficialStatsPush
+          && lastOfficialStatsPush.serverCount === serverCount
+          && lastOfficialStatsPush.shopsCount === shopsCount
+          && lastOfficialStatsPush.officialMemberCount === officialMemberCount
+        ) {
+          return false;
+        }
 
-      if (resolvedChannels.length === 0) {
-        console.warn("⚠️ Official stats channels skipped: configure explicit NOODLE_OFFICIAL_*_CHANNEL_ID values.");
+        const serverResult = await ensureOfficialReadonlyStatsChannel(
+          officialGuild,
+          officialServerCountChannelId,
+          {
+            marker: "noodle:stats:servers",
+            label: officialServerCountLabel,
+            count: serverCount
+          }
+        );
+        const shopsResult = await ensureOfficialReadonlyStatsChannel(
+          officialGuild,
+          officialShopCountChannelId,
+          {
+            marker: "noodle:stats:shops",
+            label: officialShopCountLabel,
+            count: shopsCount
+          }
+        );
+        const memberResult = await ensureOfficialReadonlyStatsChannel(
+          officialGuild,
+          officialMemberCountChannelId,
+          {
+            marker: "noodle:stats:official-members",
+            label: officialMemberCountLabel,
+            count: officialMemberCount
+          }
+        );
+
+        const channelResults = [serverResult, shopsResult, memberResult];
+        const resolvedChannels = channelResults
+          .map((result) => result?.channel || null)
+          .filter(Boolean);
+        const allChannelsResolved = channelResults.every((result) => Boolean(result?.channel));
+        const allChannelsSynchronized = channelResults.every((result) => Boolean(result?.channel) && result?.synchronized === true);
+
+        if (serverResult?.channel?.id) officialServerCountChannelId = serverResult.channel.id;
+        if (shopsResult?.channel?.id) officialShopCountChannelId = shopsResult.channel.id;
+        if (memberResult?.channel?.id) officialMemberCountChannelId = memberResult.channel.id;
+
+        if (resolvedChannels.length === 0) {
+          console.warn("⚠️ Official stats channels skipped: configure explicit NOODLE_OFFICIAL_*_CHANNEL_ID values.");
+          return false;
+        }
+
+        if (allChannelsResolved && allChannelsSynchronized) {
+          lastOfficialStatsPush = {
+            serverCount,
+            shopsCount,
+            officialMemberCount,
+            sentAt: nowMs
+          };
+          nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
+        }
+
+        console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannels.length}/3`);
+        return true;
+      } catch (error) {
+        console.error("❌ Failed to update official stats channels:", error?.stack ?? error);
         return false;
       }
+    };
 
-      if (allChannelsResolved && allChannelsSynchronized) {
-        lastOfficialStatsPush = {
-          serverCount,
-          shopsCount,
-          officialMemberCount,
-          sentAt: nowMs
-        };
-        nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
-      }
-
-      console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannels.length}/3`);
-      return true;
-    } catch (error) {
-      console.error("❌ Failed to update official stats channels:", error?.stack ?? error);
-      return false;
-    }
+    const queuedRun = officialStatsUpdateQueue
+      .catch(() => false)
+      .then(runUpdate);
+    officialStatsUpdateQueue = queuedRun.then(() => false, () => false);
+    return queuedRun;
   }
 
   function getMessageSearchBlob(message) {

--- a/src/index.js
+++ b/src/index.js
@@ -1573,8 +1573,9 @@ import { theme } from "./ui/theme.js";
         const resolvedChannels = channelResults
           .map((result) => result?.channel || null)
           .filter(Boolean);
-        const allChannelsResolved = channelResults.every((result) => Boolean(result?.channel));
-        const allChannelsSynchronized = channelResults.every((result) => Boolean(result?.channel) && result?.synchronized === true);
+        const synchronizedResolvedChannelCount = channelResults.filter(
+          (result) => Boolean(result?.channel) && result?.synchronized === true
+        ).length;
 
         if (serverResult?.channel?.id) officialServerCountChannelId = serverResult.channel.id;
         if (shopsResult?.channel?.id) officialShopCountChannelId = shopsResult.channel.id;
@@ -1585,7 +1586,7 @@ import { theme } from "./ui/theme.js";
           return false;
         }
 
-        if (allChannelsResolved && allChannelsSynchronized) {
+        if (synchronizedResolvedChannelCount > 0) {
           lastOfficialStatsPush = {
             serverCount,
             shopsCount,

--- a/src/index.js
+++ b/src/index.js
@@ -1518,6 +1518,9 @@ import { theme } from "./ui/theme.js";
       if (isIntervalReason && nextOfficialStatsSyncAllowedAt > nowMs) {
         return false;
       }
+      if (isIntervalReason) {
+        nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
+      }
 
       try {
         const officialGuild = client.guilds.cache.get(officialGuildId)

--- a/src/index.js
+++ b/src/index.js
@@ -1576,6 +1576,7 @@ import { theme } from "./ui/theme.js";
         const resolvedChannels = channelResults
           .map((result) => result?.channel || null)
           .filter(Boolean);
+        const resolvedChannelCount = resolvedChannels.length;
         const synchronizedResolvedChannelCount = channelResults.filter(
           (result) => Boolean(result?.channel) && result?.synchronized === true
         ).length;
@@ -1584,12 +1585,19 @@ import { theme } from "./ui/theme.js";
         if (shopsResult?.channel?.id) officialShopCountChannelId = shopsResult.channel.id;
         if (memberResult?.channel?.id) officialMemberCountChannelId = memberResult.channel.id;
 
-        if (resolvedChannels.length === 0) {
+        if (resolvedChannelCount === 0) {
           console.warn("⚠️ Official stats channels skipped: configure explicit NOODLE_OFFICIAL_*_CHANNEL_ID values.");
           return false;
         }
 
-        if (synchronizedResolvedChannelCount > 0) {
+        if (synchronizedResolvedChannelCount === 0) {
+          console.error(
+            `❌ Official stats channel sync had no successful channel updates (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannelCount}/3`
+          );
+          return false;
+        }
+
+        if (synchronizedResolvedChannelCount === resolvedChannelCount) {
           lastOfficialStatsPush = {
             serverCount,
             shopsCount,
@@ -1599,7 +1607,7 @@ import { theme } from "./ui/theme.js";
           nextOfficialStatsSyncAllowedAt = nowMs + officialStatsMinIntervalMs;
         }
 
-        console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannels.length}/3`);
+        console.log(`✅ Official stats channels updated (${reason}): servers=${serverCount}, shops=${shopsCount}, members=${officialMemberCount}, resolved=${resolvedChannelCount}/3, synchronized=${synchronizedResolvedChannelCount}/${resolvedChannelCount}`);
         return true;
       } catch (error) {
         console.error("❌ Failed to update official stats channels:", error?.stack ?? error);


### PR DESCRIPTION
## Summary
- add dedupe logic for official stats channel interval updates
- skip interval refresh work when server, user, and official member counts have not changed
- add a throttle gate for interval refreshes via NOODLE_OFFICIAL_STATS_MIN_INTERVAL_MS (defaults to refresh interval)

## Target Branch (Required)
- [ ] Target is develop (feature/integration testing)
- [x] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (cleanstart / syncmain).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [ ] I rebased this branch on latest origin/develop.
- [ ] This PR is intended for integration/QA testing, not direct production release.
- [ ] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [x] I rebased this branch on latest origin/main.
- [x] This change is release-ready and already validated at appropriate level.
- [x] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [x] Lint/type checks pass (if applicable).

Commands run:
- npm test (pre-push hook): 222 passed, 0 failed
- node scripts/pre-review-guard.js (pre-push hook): passed
- git fetch origin main && git rebase origin/main: up to date

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

Risk notes:
- Low risk: behavior change is constrained to interval-triggered official stats channel refresh logic.
- Ready and guild lifecycle update paths remain unchanged.

Rollback:
- Revert PR #95 commit.

## Reviewer Notes
- Areas to focus on:
  - interval gating in updateOfficialStatsChannels (reason=interval)
  - lastOfficialStatsPush and nextOfficialStatsSyncAllowedAt interactions
- Known limitations:
  - interval dedupe keys on counts; if channel names drift while counts are unchanged, reconciliation waits for another eligible update trigger
- Follow-up work (if any):
  - optional: periodic forced reconciliation mode if you want interval-based drift correction independent of count changes
