### PR TITLE
feat: add subscription perks and takeout idle shifts

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -96,6 +96,7 @@ For variables that accept file paths, absolute paths are honored, and relative p
 - `NOODLE_STRIPE_WEBHOOK_PATH` - Stripe webhook path (default `/store/stripe`)
 - `NOODLE_STRIPE_WEBHOOK_SECRET` - Stripe signing secret for webhook validation
 - `NOODLE_STRIPE_PRECHECK_PATH` and `NOODLE_STRIPE_PRECHECK_SECRET` - optional store precheck endpoint
+- `NOODLE_SUBSCRIPTION_SKU_MAP` - maps Discord store SKU IDs to subscription perks for entitlement lifecycle handling. Accepts JSON (`{"<sku_id>":"house_247","<sku_id>":"takeout_counter"}`) or comma-separated pairs (`<sku_id>:house_247,<sku_id>:takeout_counter`).
 
 ## PebbleHost .env Template
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -88,6 +88,23 @@ import {
 import { socialMainMenuRow, socialMainMenuRowNoProfile } from "./noodleSocial.js";
 import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS } from "../game/social.js";
 import {
+  SUBSCRIPTION_PERKS,
+  ensureSubscriptionState,
+  getOrderAcceptCap,
+  hasActivePerk,
+  hasUnlimitedMarketStock
+} from "../game/subscriptions.js";
+import {
+  TAKEOUT_SHIFT_DURATION_HOURS,
+  ensureTakeoutState,
+  getTakeoutMenuLimits,
+  setTakeoutMenu,
+  isTakeoutShiftActive,
+  claimTakeoutEarnings,
+  startTakeoutShiftWithCoverage,
+  processTakeoutCatchup
+} from "../game/takeout.js";
+import {
   applyResilienceMechanics,
   getAvailableRecipes,
   clearTemporaryRecipes,
@@ -712,6 +729,10 @@ function buildMarketRefreshFooterText(existingFooterText, marketRestockMs, nowMs
 
 function isDevAdmin(userId) {
   return String(userId ?? "") === DEV_ADMIN_USER_ID;
+}
+
+function hasHouse247Perk(player) {
+  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, nowTs());
 }
 
 function buildHelpPage({ page, userId, user }) {
@@ -2576,6 +2597,7 @@ function ensurePlayer(serverId, userId) {
   if (!p.seasons) {
     p.seasons = { last_seen: null, last_rewarded_from: null, last_rewarded_at: null };
   }
+  ensureTakeoutState(p);
   return p;
 }
 
@@ -3151,6 +3173,7 @@ return null;
 function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSellButton = true }) {
   if (!s.market_prices) s.market_prices = {};
   if (!p.market_stock) p.market_stock = {};
+  const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
 
   const allowed = getUnlockedIngredientIds(p, content);
 
@@ -3162,8 +3185,8 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
       if (!it) return null;
 
       const price = s.market_prices?.[id] ?? it.base_price ?? 0;
-      const stock = p.market_stock?.[id] ?? 0;
-      if (stock <= 0) return null;
+      const stock = unlimitedMarketStock ? "unlimited" : (p.market_stock?.[id] ?? 0);
+      if (!unlimitedMarketStock && Number(stock) <= 0) return null;
 
       const ownedQty = p.inv_ingredients?.[id] ?? 0;
       const labelRaw = `${it.name} — ${price}c (stock ${stock}, you have ${ownedQty})`;
@@ -3278,6 +3301,7 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
   const descriptionLines = [
     "Select up to **5** items",
     "When you’re done selecting, if on Desktop, press **Esc** to continue",
+    unlimitedMarketStock ? `${getIcon("sparkle")} 24/7 House active: market stock is **unlimited**.` : null,
     shoppingList ? "" : null,
     shoppingList,
     "",
@@ -4391,7 +4415,7 @@ return componentCommit(interaction, payload);
 
 try {
 const owner = `discord:${interaction.id}`;
-const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "dashboard";
+const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "subscriptions" || sub === "dashboard";
 const inDevPath = group === "dev" || isDevSubcommand;
 
 const buildDevStatusEmbed = () => {
@@ -4675,6 +4699,92 @@ if (inDevPath && sub === "repair_profile") {
             `(legacyScore=${result.legacyScore}, globalScore=${result.globalScore}).`
         })
       ],
+      ephemeral: true
+    });
+  });
+}
+
+if (inDevPath && sub === "subscriptions") {
+  const targetUser = opt.getUser("user");
+  const targetUserId = targetUser?.id || opt.getString("user_id")?.trim() || userId;
+  const targetServerId = opt.getString("server_id")?.trim() || serverId;
+
+  if (!targetUserId) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Provide a user or user ID to inspect.", isError: true })],
+      ephemeral: true
+    });
+  }
+  if (!db) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Database unavailable in this environment.", isError: true })],
+      ephemeral: true
+    });
+  }
+
+  const lockKey = `lock:user:${targetServerId}:${targetUserId}`;
+  return await withLock(db, lockKey, owner, 8000, async () => {
+    const targetPlayer = getPlayer(db, targetServerId, targetUserId);
+    if (!targetPlayer) {
+      return commit({
+        content: " ",
+        embeds: [
+          buildDevMessageEmbed({
+            message: `${getIcon("error")} No profile found for <@${targetUserId}> on server ${targetServerId}.`,
+            isError: true
+          })
+        ],
+        ephemeral: true
+      });
+    }
+
+    const subscriptions = ensureSubscriptionState(targetPlayer);
+    const perks = subscriptions.perks ?? {};
+    const now = nowTs();
+
+    const formatTime = (ts) => {
+      const n = Number(ts);
+      if (!Number.isFinite(n) || n <= 0) return "-";
+      return `<t:${Math.floor(n / 1000)}:f> (<t:${Math.floor(n / 1000)}:R>)`;
+    };
+
+    const perkLines = Object.values(SUBSCRIPTION_PERKS).map((perkId) => {
+      const state = perks[perkId] ?? {};
+      const activeNow = hasActivePerk(targetPlayer, perkId, now);
+      const name = perkId === SUBSCRIPTION_PERKS.HOUSE_247 ? "24/7 House" : "Take Out Counter";
+      const status = activeNow ? "ACTIVE" : "inactive";
+      return [
+        `**${name}** (${perkId})`,
+        `• status: ${status}`,
+        `• entitlement_id: ${state.entitlement_id ?? "-"}`,
+        `• period_start_at: ${formatTime(state.period_start_at)}`,
+        `• period_end_at: ${formatTime(state.period_end_at)}`,
+        `• last_coin_grant_period: ${state.last_coin_grant_period ?? "-"}`,
+        `• last_coin_grant_at: ${formatTime(state.last_coin_grant_at)}`,
+        `• last_event_type: ${state.last_event_type ?? "-"}`,
+        `• last_event_at: ${formatTime(state.last_event_at)}`
+      ].join("\n");
+    });
+
+    const description = [
+      `User: <@${targetUserId}> (${targetUserId})`,
+      `Server: ${targetServerId}`,
+      `Coins: ${Number(targetPlayer.coins || 0).toLocaleString()}`,
+      "",
+      ...perkLines
+    ].join("\n\n");
+
+    const embed = buildMenuEmbed({
+      title: `${getIcon("stats")} Subscription State`,
+      description,
+      user: interaction.member ?? interaction.user
+    });
+
+    return commit({
+      content: " ",
+      embeds: [embed],
       ephemeral: true
     });
   });
@@ -5697,6 +5807,293 @@ if (sub === "kitchen" || sub === "kitchen_start" || sub === "kitchen_collect") {
 }
 
 /* ---------------- RECIPES ---------------- */
+if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub === "takeout_claim") {
+  if (!db) {
+    const unavailableEmbed = buildMenuEmbed({
+      title: `${getIcon("orders")} Take Out Counter`,
+      description: `${getIcon("error")} Database unavailable in this environment.`,
+      user: interaction.member ?? interaction.user,
+      color: theme.colors.warning
+    });
+    return commit({ content: " ", embeds: [unavailableEmbed], ephemeral: true });
+  }
+
+  const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, async () => {
+    const p = ensurePlayer(serverId, userId);
+    const s = ensureServer(serverId);
+    unlockNoticePlayer = p;
+    const now = nowTs();
+    const takeoutEnabled = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now);
+
+    const finalize = (payload) => {
+      if (db) {
+        upsertPlayer(db, serverId, userId, p, null, p.schema_version);
+      }
+      return payload;
+    };
+
+    if (!takeoutEnabled) {
+      const lockedEmbed = buildMenuEmbed({
+        title: `${getIcon("orders")} Take Out Counter`,
+        description: `${getIcon("lock")} Take Out Counter requires an active subscription entitlement.`,
+        user: interaction.member ?? interaction.user,
+        color: theme.colors.warning
+      });
+      return finalize({
+        content: " ",
+        embeds: [lockedEmbed],
+        ephemeral: true
+      });
+    }
+
+    const takeout = ensureTakeoutState(p);
+    const takeoutCatchup = processTakeoutCatchup(p, {
+      now,
+      recipes: content.recipes ?? {},
+      marketPrices: s.market_prices ?? {},
+      items: content.items ?? {}
+    });
+    if ((takeoutCatchup?.processedHours ?? 0) > 0) {
+      emitTelemetry("takeout_shift_catchup", {
+        userId,
+        serverId,
+        processedHours: takeoutCatchup.processedHours,
+        earnedCoins: takeoutCatchup.earned,
+        totalProcessedHours: takeoutCatchup.totalProcessedHours,
+        completed: Boolean(takeoutCatchup.completed)
+      });
+    }
+
+    const availableRecipeIds = getValidAvailableRecipeIds(p);
+    const availableRecipeSet = new Set(availableRecipeIds);
+    const existingMenu = (takeout.menu_recipe_ids || []).filter((recipeId) => availableRecipeSet.has(recipeId));
+    if (existingMenu.length !== (takeout.menu_recipe_ids || []).length) {
+      takeout.menu_recipe_ids = existingMenu;
+    }
+
+    const menuLimits = getTakeoutMenuLimits(availableRecipeIds.length);
+
+    const renderStatus = (banner = null, { ephemeral = false } = {}) => {
+      const active = isTakeoutShiftActive(p, nowTs());
+      const shiftEndsAt = Number(takeout.shift?.ends_at || 0);
+      const shiftStartedAt = Number(takeout.shift?.started_at || 0);
+      const processedHours = Math.max(0, Math.floor(Number(takeout.shift?.last_processed_hour_index || 0) || 0));
+      const remainingHours = Math.max(0, TAKEOUT_SHIFT_DURATION_HOURS - processedHours);
+      const snapshot = Array.isArray(takeout.shift?.idle_order_board_snapshot)
+        ? takeout.shift.idle_order_board_snapshot
+        : [];
+      const shiftOperatingCost = Math.max(0, Math.floor(Number(takeout.shift?.operating_cost || 0) || 0));
+      const coveredIngredientsCount = Object.values(takeout.shift?.covered_ingredients ?? {})
+        .reduce((sum, qty) => sum + Math.max(0, Math.floor(Number(qty || 0) || 0)), 0);
+      const shiftSnapshotOrderCount = snapshot
+        .reduce((sum, row) => sum + Math.max(0, Math.floor(Number(row?.total_orders || row?.visible_order_count || 0) || 0)), 0);
+
+      const menuLine = takeout.menu_recipe_ids.length > 0
+        ? takeout.menu_recipe_ids.map((rid) => `• ${displayRecipeName(rid)}`).join("\n")
+        : "_No menu configured yet._";
+
+      const countByRecipe = new Map();
+      for (const row of snapshot) {
+        const rid = String(row?.recipe_id || "").trim();
+        if (!rid) continue;
+        const count = Math.max(0, Math.floor(Number(row?.visible_order_count) || 0));
+        countByRecipe.set(rid, count);
+      }
+
+      const visibleCounts = takeout.menu_recipe_ids.length > 0
+        ? takeout.menu_recipe_ids
+          .map((rid) => `• ${displayRecipeName(rid)}: **${countByRecipe.get(rid) ?? 0}**`)
+          .join("\n")
+        : "_No counter orders to show yet._";
+
+      const statusBits = [];
+      if (active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0) {
+        statusBits.push(`${getIcon("time")} **Shift Active** until <t:${Math.floor(shiftEndsAt / 1000)}:R> (<t:${Math.floor(shiftEndsAt / 1000)}:f>)`);
+        statusBits.push(`${getIcon("refresh")} Next eligible shift: <t:${Math.floor(shiftEndsAt / 1000)}:R>`);
+      } else {
+        statusBits.push(`${getIcon("status_pending")} **Shift Inactive**`);
+        statusBits.push(`${getIcon("refresh")} Next eligible shift: **Now**`);
+      }
+      if (Number.isFinite(shiftStartedAt) && shiftStartedAt > 0) {
+        statusBits.push(`${getIcon("calendar")} Last start: <t:${Math.floor(shiftStartedAt / 1000)}:f>`);
+      }
+      statusBits.push(`${getIcon("coins")} Unclaimed idle coins: **${takeout.earned_unclaimed_coins || 0}c**`);
+      if (shiftOperatingCost > 0) {
+        statusBits.push(`${getIcon("coins")} Fixed shift operating cost paid: **${shiftOperatingCost}c**`);
+      }
+      if (coveredIngredientsCount > 0) {
+        statusBits.push(`${getIcon("basket")} Covered ingredients reserved for idle shift: **${coveredIngredientsCount}** units`);
+      }
+      if (shiftSnapshotOrderCount > 0) {
+        statusBits.push(`${getIcon("orders")} Shift snapshot orders: **${shiftSnapshotOrderCount}** total`);
+      }
+      statusBits.push(`${getIcon("time")} Processed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
+      statusBits.push(`${getIcon("time")} Remaining hours: **${remainingHours}**`);
+      statusBits.push(`${getIcon("help")} Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})`);
+
+      const description = [
+        banner,
+        takeoutCatchup?.processedHours > 0
+          ? `${getIcon("time")} Catch-up processed **${takeoutCatchup.processedHours}h** and accrued **${takeoutCatchup.earned}c** while you were away.`
+          : null,
+        statusBits.join("\n"),
+        "\n**Counter Menu**",
+        menuLine,
+        "\n**Visible Order Counts**",
+        visibleCounts
+      ].filter(Boolean).join("\n");
+
+      const embed = buildMenuEmbed({
+        title: `${getIcon("orders")} Take Out Counter`,
+        description,
+        user: interaction.member ?? interaction.user,
+        color: theme.colors.success
+      });
+
+      return { content: " ", embeds: [embed], ephemeral };
+    };
+
+    if (sub === "takeout_menu") {
+      const rawRecipes = String(opt.getString("recipes") || "").trim();
+      if (!rawRecipes) {
+        return finalize(renderStatus(`${getIcon("help")} Provide recipe ids via the recipes option (comma-separated).`, { ephemeral: true }));
+      }
+
+      const requestedIds = rawRecipes
+        .split(",")
+        .map((id) => resolveCanonicalRecipeId(id))
+        .filter(Boolean);
+
+      const menuResult = setTakeoutMenu(p, {
+        menuRecipeIds: requestedIds,
+        learnedRecipeIds: availableRecipeIds,
+        now
+      });
+
+      if (!menuResult.ok) {
+        if (menuResult.reason === "no_learned_recipes") {
+          return finalize(renderStatus(`${getIcon("warning")} You need at least one learned recipe before setting a takeout menu.`, { ephemeral: true }));
+        }
+        if (menuResult.reason === "menu_too_small") {
+          const needed = menuResult.limits?.minRequired ?? 0;
+          return finalize(renderStatus(`${getIcon("warning")} Menu too small. Select at least **${needed}** recipe${needed === 1 ? "" : "s"}.`, { ephemeral: true }));
+        }
+        return finalize(renderStatus(`${getIcon("warning")} Could not update menu. Check recipe ids and try again.`, { ephemeral: true }));
+      }
+
+      if (!isTakeoutShiftActive(p, nowTs())) {
+        takeout.shift.idle_order_board_snapshot = takeout.menu_recipe_ids.map((rid) => ({
+          recipe_id: rid,
+          visible_order_count: 0
+        }));
+      }
+
+      return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`));
+    }
+
+    if (sub === "takeout_open") {
+      if (takeout.menu_recipe_ids.length <= 0) {
+        return finalize(renderStatus(`${getIcon("warning")} Configure your counter menu first with /noodle takeout_menu.` , { ephemeral: true }));
+      }
+
+      const set = buildSettingsMap(settingsCatalog, s.settings);
+      s.season = computeActiveSeason(set);
+      ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, s.active_event_id ?? null);
+
+      const boardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
+      const unlimitedOrders = hasHouse247Perk(p);
+
+      const openResult = startTakeoutShiftWithCoverage(p, {
+        now,
+        boardOrderTotal,
+        unlimitedOrders,
+        recipes: content.recipes ?? {},
+        marketPrices: s.market_prices ?? {},
+        items: content.items ?? {}
+      });
+      if (!openResult.ok && openResult.reason === "shift_active") {
+        emitTelemetry("takeout_shift_start_blocked", {
+          userId,
+          serverId,
+          reason: "shift_active"
+        });
+        return finalize(renderStatus(`${getIcon("time")} Your current takeout shift is still active.`, { ephemeral: true }));
+      }
+      if (!openResult.ok && openResult.reason === "insufficient_coins") {
+        const needed = Math.max(0, Math.floor(Number(openResult.operatingCost || 0) || 0));
+        const has = Math.max(0, Math.floor(Number(p.coins || 0) || 0));
+        emitTelemetry("takeout_shift_start_blocked", {
+          userId,
+          serverId,
+          reason: "insufficient_coins",
+          neededCoins: needed,
+          hasCoins: has
+        });
+        return finalize(renderStatus(`${getIcon("warning")} You need **${needed}c** to open this 12h shift, but only have **${has}c**.`, { ephemeral: true }));
+      }
+      if (!openResult.ok) {
+        emitTelemetry("takeout_shift_start_blocked", {
+          userId,
+          serverId,
+          reason: String(openResult.reason || "unknown")
+        });
+        return finalize(renderStatus(`${getIcon("warning")} Could not open your takeout shift right now.`, { ephemeral: true }));
+      }
+
+      const coveredUnits = Object.values(openResult.requiredIngredients ?? {})
+        .reduce((sum, qty) => sum + Math.max(0, Math.floor(Number(qty || 0) || 0)), 0);
+      emitTelemetry("takeout_shift_started", {
+        userId,
+        serverId,
+        boardOrderTotal,
+        unlimitedOrders,
+        snapshotOrderTotal: openResult.snapshotOrderTotal,
+        operatingCost: openResult.operatingCost,
+        coveredUnits,
+        menuSize: takeout.menu_recipe_ids.length,
+        startsAt: openResult.startedAt,
+        endsAt: openResult.endsAt
+      });
+
+      return finalize(
+        renderStatus(
+          `${getIcon("status_complete")} Shift opened for **${TAKEOUT_SHIFT_DURATION_HOURS}h** with **${openResult.snapshotOrderTotal}** snapshot orders and a fixed operating cost of **${openResult.operatingCost}c**. ` +
+          `Idle ingredients are pre-covered and isolated from your pantry, and you can start another shift after this one ends.`
+        )
+      );
+    }
+
+    if (sub === "takeout_claim") {
+      const claimed = claimTakeoutEarnings(p, { now });
+      if (!claimed.ok) {
+        emitTelemetry("takeout_claim_attempt", {
+          userId,
+          serverId,
+          ok: false,
+          reason: String(claimed.reason || "unknown"),
+          unclaimedCoins: Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0))
+        });
+        return finalize(renderStatus(`${getIcon("help")} No idle earnings to claim yet.`, { ephemeral: true }));
+      }
+
+      emitTelemetry("takeout_claim_attempt", {
+        userId,
+        serverId,
+        ok: true,
+        amount: claimed.amount,
+        unclaimedCoinsAfter: Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0))
+      });
+
+      return finalize(renderStatus(`${getIcon("coins")} Claimed **${claimed.amount}c** from takeout idle earnings.`));
+    }
+
+    return finalize(renderStatus());
+  });
+
+  return commit(lockedPayload);
+}
+
+/* ---------------- RECIPES ---------------- */
 if (sub === "recipes") {
   const p = ensurePlayer(serverId, userId);
   const allRecipeIds = new Set(Object.keys(content.recipes ?? {}));
@@ -6138,6 +6535,13 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
     const effects = prepareCombinedEffects();
     const lastActiveAt = db ? (getLastActiveAt(db, serverId, userId) || now) : now;
     activeEventEffects = getActiveEventEffects(eventsContent, s);
+
+    processTakeoutCatchup(p, {
+      now,
+      recipes: content.recipes ?? {},
+      marketPrices: s.market_prices ?? {},
+      items: content.items ?? {}
+    });
 
     // Apply time catch-up (spoilage, inactivity messages, cooldown checks)
     timeCatchup = applyTimeCatchup(p, s, set, content, lastActiveAt, now, effects);
@@ -7818,7 +8222,8 @@ ${lines.join("\n")}`;
     const pityPrice = getPityDiscount(p, itemId);
     const basePrice = pityPrice ?? (s.market_prices?.[itemId] ?? item.base_price);
     const price = applyMarketDiscount(basePrice, combinedEffects);
-    const stock = p.market_stock?.[itemId] ?? 0;
+    const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
+    const stock = unlimitedMarketStock ? Number.MAX_SAFE_INTEGER : (p.market_stock?.[itemId] ?? 0);
     const type = normalizeIngredientType(itemId);
     const perTypeCap = getIngredientCapacitiesByType(p, combinedEffects);
     const remaining = (perTypeCap[type] ?? perTypeCap.topping ?? 0) - getIngredientCountForType(p, type);
@@ -7833,7 +8238,7 @@ ${lines.join("\n")}`;
     const qtyToBuy = Math.min(qty, remaining);
     const cost = price * qtyToBuy;
 
-    if (stock < qtyToBuy) {
+    if (!unlimitedMarketStock && stock < qtyToBuy) {
       const friendly = displayItemName(itemId);
       return commitState({ content: `Only ${stock} in stock today for **${friendly}**.`, ephemeral: true });
     }
@@ -7852,7 +8257,9 @@ ${lines.join("\n")}`;
 
     p.coins -= cost;
     p.inv_ingredients[itemId] = (p.inv_ingredients[itemId] ?? 0) + qtyToBuy;
-    p.market_stock[itemId] = stock - qtyToBuy;
+    if (!unlimitedMarketStock) {
+      p.market_stock[itemId] = stock - qtyToBuy;
+    }
 
     applyQuestProgress(p, questsContent, userId, { type: "buy", amount: qtyToBuy }, now);
 
@@ -7864,9 +8271,12 @@ ${lines.join("\n")}`;
     });
 
     const capacityNote = qtyToBuy < qty ? `\n${getIcon("pantry")} Pantry capacity limited your purchase to **${qtyToBuy}**.` : "";
+    const subscriptionNote = unlimitedMarketStock
+      ? `\n${getIcon("sparkle")} 24/7 House active: unlimited stock.`
+      : "";
     const buyEmbed = buildMenuEmbed({
       title: `${getIcon("cart")} Purchase Complete`,
-      description: `${getIcon("cart")} Bought **${qtyToBuy}× ${item.name}** for **${cost}c**.${capacityNote}${tutorialSuffix(p)}`,
+      description: `${getIcon("cart")} Bought **${qtyToBuy}× ${item.name}** for **${cost}c**.${capacityNote}${subscriptionNote}${tutorialSuffix(p)}`,
       user: interaction.member ?? interaction.user
     });
     return commitState({
@@ -8239,7 +8649,8 @@ ${lines.join("\n")}`;
     const remaining = availableCount;
     const marketRestockDay = p.market_stock_day ?? s.market_day ?? dayKeyUTC(now2);
     const marketRestockMs = parseYYYYMMDD(marketRestockDay) + (24 * 60 * 60 * 1000);
-    const hasMarketStock = Object.values(p.market_stock ?? {}).some((qty) => Number(qty) > 0);
+    const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
+    const hasMarketStock = unlimitedMarketStock || Object.values(p.market_stock ?? {}).some((qty) => Number(qty) > 0);
     const ordersDayKey = p.orders_day ?? dayKeyUTC(now2);
     const nextOrdersResetMs = parseYYYYMMDD(ordersDayKey) + (24 * 60 * 60 * 1000);
     const nextOrdersResetTs = Math.floor(nextOrdersResetMs / 1000);
@@ -8274,6 +8685,9 @@ ${lines.join("\n")}`;
 
     const tutSuffix = tutorialSuffix(p);
     if (tutSuffix) parts.push("", tutSuffix);
+    if (hasHouse247Perk(p)) {
+      parts.push("", `${getIcon("sparkle")} 24/7 House active: unlimited order capacity and market stock.`);
+    }
 
     const showCancel = acceptedEntries.length > 0;
     const highlightAccept = acceptedEntries.length === 0 && remaining > 0;
@@ -8322,7 +8736,7 @@ ${lines.join("\n")}`;
 
     if (!tokens.length) return commitState({ content: "Pick at least one order to accept.", ephemeral: true });
 
-    const cap = 5;
+    const cap = getOrderAcceptCap(p, nowTs());
     // Ensure orders is a valid object (handle case where it might be an array or null)
     if (!p.orders || typeof p.orders !== 'object' || Array.isArray(p.orders)) {
       p.orders = { accepted: {}, seasonal_served_today: 0, epic_served_today: 0 };
@@ -8419,6 +8833,7 @@ ${lines.join("\n")}`;
 
       const inventoryAvailable = { ...(p.inv_ingredients ?? {}) };
       const stockRemaining = { ...(p.market_stock ?? {}) };
+      const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
       const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
       const perTypeCap = getIngredientCapacitiesByType(p, combinedEffects);
       const countsByType = getIngredientCountsByType(p);
@@ -8498,7 +8913,7 @@ ${lines.join("\n")}`;
             }
 
             const stock = stockRemaining[itemId] ?? 0;
-            if (stock < missing) {
+            if (!unlimitedMarketStock && stock < missing) {
               blockedByStock = true;
               orderOk = false;
               break;
@@ -8531,7 +8946,9 @@ ${lines.join("\n")}`;
 
         for (const needItem of neededItems) {
           remainingByType[needItem.type] = Math.max(0, (remainingByType[needItem.type] ?? 0) - needItem.qty);
-          stockRemaining[needItem.itemId] = Math.max(0, (stockRemaining[needItem.itemId] ?? 0) - needItem.qty);
+          if (!unlimitedMarketStock) {
+            stockRemaining[needItem.itemId] = Math.max(0, (stockRemaining[needItem.itemId] ?? 0) - needItem.qty);
+          }
           purchasedByItem[needItem.itemId] = (purchasedByItem[needItem.itemId] ?? 0) + needItem.qty;
         }
 
@@ -8549,7 +8966,9 @@ ${lines.join("\n")}`;
         if (!p.market_stock) p.market_stock = {};
         for (const [id, qty] of Object.entries(purchasedByItem)) {
           p.inv_ingredients[id] = (p.inv_ingredients[id] ?? 0) + qty;
-          p.market_stock[id] = (p.market_stock[id] ?? 0) - qty;
+          if (!unlimitedMarketStock) {
+            p.market_stock[id] = (p.market_stock[id] ?? 0) - qty;
+          }
         }
         p.coins = coinsRemaining;
         results.push(`${getIcon("chef")} Prep Chef auto-bought: ${purchasedItems} (Total **${totalAutoCost}c**).`);
@@ -10698,6 +11117,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
         let s = ensureServer(serverId);
         let p2 = ensurePlayer(serverId, userId);
         if (!p2.market_stock) p2.market_stock = {};
+        const unlimitedMarketStock = hasUnlimitedMarketStock(p2, nowTs());
 
         const combinedEffects = calculateCombinedEffects(p2, upgradesContent, staffContent, calculateStaffEffects);
         const perTypeCap = getIngredientCapacitiesByType(p2, combinedEffects);
@@ -10741,7 +11161,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
             continue;
           }
 
-          if (stock < qtyToBuy) {
+          if (!unlimitedMarketStock && stock < qtyToBuy) {
             const friendly = displayItemName(id3);
             return {
               content: `Only ${stock} in stock today for **${friendly}**.`,
@@ -10789,7 +11209,9 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
         p2.coins -= totalCost;
 
         for (const x of buyLines) {
-          p2.market_stock[x.id] = (p2.market_stock[x.id] ?? 0) - x.qty;
+          if (!unlimitedMarketStock) {
+            p2.market_stock[x.id] = (p2.market_stock[x.id] ?? 0) - x.qty;
+          }
         }
 
         const totalBought = buyLines.reduce((sum, entry) => sum + entry.qty, 0);
@@ -10809,7 +11231,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
 
         const buyEmbed = buildMenuEmbed({
           title: `${getIcon("cart")} Purchase Complete`,
-          description: `Bought:\n${pretty}\n\nTotal: **${totalCost}c**.${capacityReduced ? `\n${getIcon("pantry")} Pantry capacity limited this purchase.` : ""}${tutorialSuffix(p2)}`,
+          description: `Bought:\n${pretty}\n\nTotal: **${totalCost}c**.${capacityReduced ? `\n${getIcon("pantry")} Pantry capacity limited this purchase.` : ""}${unlimitedMarketStock ? `\n${getIcon("sparkle")} 24/7 House active: stock limit bypassed.` : ""}${tutorialSuffix(p2)}`,
           user: interaction.member ?? interaction.user
         });
         buyEmbed.setFooter({
@@ -11141,6 +11563,20 @@ const noodleCommandData = new SlashCommandBuilder()
   .addSubcommand((sc) => sc.setName("quests_daily").setDescription("Claim your daily reward."))
   .addSubcommand((sc) => sc.setName("quests_claim").setDescription("Claim completed quest rewards."))
   .addSubcommand((sc) => sc.setName("quests_vote").setDescription("View and claim bot-list vote rewards."))
+  .addSubcommand((sc) => sc.setName("takeout").setDescription("View your Take Out Counter status."))
+  .addSubcommand((sc) =>
+    sc
+      .setName("takeout_menu")
+      .setDescription("Set your Take Out Counter menu (comma-separated recipe ids).")
+      .addStringOption((o) =>
+        o
+          .setName("recipes")
+          .setDescription("Comma-separated recipe ids (max 10).")
+          .setRequired(true)
+      )
+  )
+  .addSubcommand((sc) => sc.setName("takeout_open").setDescription("Open a 12-hour takeout shift."))
+  .addSubcommand((sc) => sc.setName("takeout_claim").setDescription("Claim idle takeout earnings."))
   .addSubcommand((sc) =>
     sc
       .setName("buy")

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -47,6 +47,24 @@ const noodleDevData = new SlashCommandBuilder()
           .setDescription("Force repair even if global profile score is not lower")
           .setRequired(false)
       )
+  )
+  .addSubcommand((sc) =>
+    sc
+      .setName("subscriptions")
+      .setDescription("Dev only.")
+      .addUserOption((o) => o.setName("user").setDescription("User to inspect").setRequired(false))
+      .addStringOption((o) =>
+        o
+          .setName("user_id")
+          .setDescription("User ID (use if the user left the server)")
+          .setRequired(false)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("server_id")
+          .setDescription("Override server ID (defaults to current guild)")
+          .setRequired(false)
+      )
   );
 
 export const noodleDevCommand = {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -468,8 +468,9 @@ function prunePlayerBeforePersist(player) {
       }
     }
 
-    // Safety cap: keep the most recent accepted orders (should normally stay under 5).
-    const ACCEPTED_CAP = 10;
+    // Safety cap: keep the most recent accepted orders.
+    // 24/7 House expands active order capacity, so this must be comfortably higher than base mode.
+    const ACCEPTED_CAP = 500;
     const acceptedEntries = Object.entries(orders.accepted);
     if (acceptedEntries.length > ACCEPTED_CAP) {
       const sorted = acceptedEntries.sort((a, b) => {

--- a/src/game/player.js
+++ b/src/game/player.js
@@ -1,5 +1,7 @@
 import { STARTER_PROFILE, DATA_SCHEMA_VERSION, TUTORIAL_QUESTS } from "../constants.js";
 import { nowTs } from "../util/time.js";
+import { createDefaultSubscriptionState } from "./subscriptions.js";
+import { createDefaultTakeoutState } from "./takeout.js";
 
 export function newPlayerProfile(userId) {
   return {
@@ -82,6 +84,10 @@ export function newPlayerProfile(userId) {
       active_blessing: null,
       last_blessing_at: null
     },
+
+    subscriptions: createDefaultSubscriptionState(),
+
+    takeout: createDefaultTakeoutState(),
 
     notifications: {
       pending_pantry_messages: [],

--- a/src/game/subscriptions.js
+++ b/src/game/subscriptions.js
@@ -1,0 +1,257 @@
+export const SUBSCRIPTION_PERKS = Object.freeze({
+  HOUSE_247: "house_247",
+  TAKEOUT_COUNTER: "takeout_counter"
+});
+
+export const SUBSCRIPTION_MONTHLY_COIN_GRANT = 25_000;
+export const ORDER_ACCEPT_CAP_BASE = 5;
+export const ORDER_ACCEPT_CAP_HOUSE_247 = 500;
+
+const KNOWN_PERKS = new Set(Object.values(SUBSCRIPTION_PERKS));
+
+function defaultPerkState() {
+  return {
+    active: false,
+    entitlement_id: null,
+    period_start_at: null,
+    period_end_at: null,
+    last_coin_grant_period: null,
+    last_coin_grant_at: null,
+    last_event_type: null,
+    last_event_at: null,
+    updated_at: null
+  };
+}
+
+export function createDefaultSubscriptionState() {
+  return {
+    perks: {
+      [SUBSCRIPTION_PERKS.HOUSE_247]: defaultPerkState(),
+      [SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]: defaultPerkState()
+    }
+  };
+}
+
+function parseSkuMap(rawValue) {
+  const raw = String(rawValue || "").trim();
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([sku, perk]) => [String(sku), String(perk).trim().toLowerCase()])
+        .filter(([, perk]) => KNOWN_PERKS.has(perk))
+    );
+  } catch {
+    const pairs = raw.split(",").map((entry) => entry.trim()).filter(Boolean);
+    const mapped = {};
+    for (const pair of pairs) {
+      const [sku, perk] = pair.split(":").map((part) => String(part || "").trim());
+      if (!sku || !perk) continue;
+      const perkId = perk.toLowerCase();
+      if (!KNOWN_PERKS.has(perkId)) continue;
+      mapped[sku] = perkId;
+    }
+    return mapped;
+  }
+}
+
+const ENV_SKU_MAP = parseSkuMap(process.env.NOODLE_SUBSCRIPTION_SKU_MAP);
+
+export function resolveSubscriptionPerkId(skuId) {
+  if (!skuId) return null;
+  return ENV_SKU_MAP[String(skuId)] ?? null;
+}
+
+function normalizeTimestamp(value) {
+  if (value == null || value === "") return null;
+
+  const asNumber = Number(value);
+  if (Number.isFinite(asNumber)) {
+    // Treat small numeric values as epoch seconds.
+    if (asNumber > 0 && asNumber < 1_000_000_000_000) {
+      return Math.floor(asNumber * 1000);
+    }
+    return Math.floor(asNumber);
+  }
+
+  const asDate = Date.parse(String(value));
+  if (!Number.isFinite(asDate)) return null;
+  return Math.floor(asDate);
+}
+
+function normalizePeriodMarker(value) {
+  const ts = normalizeTimestamp(value);
+  return Number.isFinite(ts) ? String(ts) : null;
+}
+
+export function resolveSubscriptionBillingPeriodKey({ periodStartAt = null, periodEndAt = null, now = Date.now() } = {}) {
+  const startMarker = normalizePeriodMarker(periodStartAt);
+  if (startMarker) return `start:${startMarker}`;
+
+  const endMarker = normalizePeriodMarker(periodEndAt);
+  if (endMarker) return `end:${endMarker}`;
+
+  const date = new Date(Number.isFinite(Number(now)) ? Number(now) : Date.now());
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `month:${y}-${m}`;
+}
+
+export function ensureSubscriptionState(player) {
+  if (!player || typeof player !== "object") return createDefaultSubscriptionState();
+
+  if (!player.subscriptions || typeof player.subscriptions !== "object" || Array.isArray(player.subscriptions)) {
+    player.subscriptions = createDefaultSubscriptionState();
+    return player.subscriptions;
+  }
+
+  if (!player.subscriptions.perks || typeof player.subscriptions.perks !== "object" || Array.isArray(player.subscriptions.perks)) {
+    player.subscriptions.perks = {};
+  }
+
+  for (const perkId of KNOWN_PERKS) {
+    const existing = player.subscriptions.perks[perkId];
+    if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+      player.subscriptions.perks[perkId] = defaultPerkState();
+      continue;
+    }
+
+    player.subscriptions.perks[perkId] = {
+      ...defaultPerkState(),
+      ...existing
+    };
+  }
+
+  return player.subscriptions;
+}
+
+export function hasActivePerk(player, perkId, now = Date.now()) {
+  const perkKey = String(perkId || "").trim().toLowerCase();
+  if (!KNOWN_PERKS.has(perkKey)) return false;
+
+  const subscriptions = ensureSubscriptionState(player);
+  const perkState = subscriptions.perks[perkKey];
+  if (!perkState?.active) return false;
+
+  const periodEndAt = normalizeTimestamp(perkState.period_end_at);
+  if (!Number.isFinite(periodEndAt)) return true;
+  return now < periodEndAt;
+}
+
+export function hasUnlimitedMarketStock(player, now = Date.now()) {
+  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now);
+}
+
+export function getOrderAcceptCap(player, now = Date.now()) {
+  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now)
+    ? ORDER_ACCEPT_CAP_HOUSE_247
+    : ORDER_ACCEPT_CAP_BASE;
+}
+
+export function applySubscriptionEntitlementEvent(player, {
+  perkId,
+  eventType,
+  entitlementId = null,
+  periodStartAt = null,
+  periodEndAt = null,
+  now = Date.now()
+} = {}) {
+  const perkKey = String(perkId || "").trim().toLowerCase();
+  if (!KNOWN_PERKS.has(perkKey)) {
+    return { ok: false, reason: "unknown_perk", changed: false };
+  }
+
+  const type = String(eventType || "").trim().toUpperCase();
+  if (!type) {
+    return { ok: false, reason: "missing_event_type", changed: false };
+  }
+
+  const subscriptions = ensureSubscriptionState(player);
+  const perkState = subscriptions.perks[perkKey];
+  const before = JSON.stringify(perkState);
+
+  const normalizedStartAt = normalizeTimestamp(periodStartAt);
+  const normalizedEndAt = normalizeTimestamp(periodEndAt);
+
+  if (type === "ENTITLEMENT_CREATE" || type === "ENTITLEMENT_UPDATE") {
+    perkState.active = true;
+    if (entitlementId) perkState.entitlement_id = String(entitlementId);
+    if (Number.isFinite(normalizedStartAt)) perkState.period_start_at = normalizedStartAt;
+    if (Number.isFinite(normalizedEndAt)) perkState.period_end_at = normalizedEndAt;
+  } else if (type === "ENTITLEMENT_DELETE") {
+    perkState.active = false;
+    if (Number.isFinite(normalizedEndAt)) {
+      perkState.period_end_at = normalizedEndAt;
+    } else {
+      perkState.period_end_at = now;
+    }
+  } else {
+    return { ok: false, reason: "unsupported_event_type", changed: false };
+  }
+
+  perkState.last_event_type = type;
+  perkState.last_event_at = now;
+  perkState.updated_at = now;
+
+  const changed = before !== JSON.stringify(perkState);
+
+  return {
+    ok: true,
+    changed,
+    perkId: perkKey,
+    eventType: type,
+    active: hasActivePerk(player, perkKey, now),
+    state: { ...perkState }
+  };
+}
+
+export function applyMonthlySubscriptionCoinGrant(player, {
+  perkId,
+  periodStartAt = null,
+  periodEndAt = null,
+  coins = SUBSCRIPTION_MONTHLY_COIN_GRANT,
+  now = Date.now()
+} = {}) {
+  const perkKey = String(perkId || "").trim().toLowerCase();
+  if (!KNOWN_PERKS.has(perkKey)) {
+    return { ok: false, reason: "unknown_perk", granted: false, amount: 0 };
+  }
+
+  const grantAmount = Math.max(0, Math.floor(Number(coins) || 0));
+  if (grantAmount <= 0) {
+    return { ok: false, reason: "invalid_grant_amount", granted: false, amount: 0 };
+  }
+
+  const subscriptions = ensureSubscriptionState(player);
+  const perkState = subscriptions.perks[perkKey];
+  const billingPeriodKey = resolveSubscriptionBillingPeriodKey({ periodStartAt, periodEndAt, now });
+
+  if (String(perkState.last_coin_grant_period || "") === billingPeriodKey) {
+    return {
+      ok: true,
+      granted: false,
+      amount: 0,
+      perkId: perkKey,
+      billingPeriodKey
+    };
+  }
+
+  player.coins = (Number(player.coins) || 0) + grantAmount;
+  if (!player.lifetime || typeof player.lifetime !== "object") player.lifetime = {};
+  player.lifetime.coins_earned = (Number(player.lifetime.coins_earned) || 0) + grantAmount;
+
+  perkState.last_coin_grant_period = billingPeriodKey;
+  perkState.last_coin_grant_at = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  perkState.updated_at = perkState.last_coin_grant_at;
+
+  return {
+    ok: true,
+    granted: true,
+    amount: grantAmount,
+    perkId: perkKey,
+    billingPeriodKey
+  };
+}

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -1,0 +1,548 @@
+import { nowTs } from "../util/time.js";
+
+export const TAKEOUT_SHIFT_DURATION_HOURS = 12;
+export const TAKEOUT_SHIFT_DURATION_MS = TAKEOUT_SHIFT_DURATION_HOURS * 60 * 60 * 1000;
+export const TAKEOUT_MENU_MIN_RECIPES = 5;
+export const TAKEOUT_MENU_MAX_RECIPES = 10;
+export const TAKEOUT_SNAPSHOT_MIN_ORDERS = 100;
+export const TAKEOUT_SNAPSHOT_MAX_ORDERS = 500;
+export const TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS = 1000;
+export const TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS = 2000;
+const TAKEOUT_HOUR_MS = 60 * 60 * 1000;
+
+const TIER_PAYOUT_MULTIPLIERS = Object.freeze({
+  common: 1.3,
+  uncommon: 1.5,
+  rare: 1.75,
+  epic: 2.1,
+  legendary: 2.5,
+  seasonal: 1.6
+});
+
+function defaultShiftState() {
+  return {
+    status: "inactive",
+    started_at: null,
+    ends_at: null,
+    last_processed_hour_index: 0,
+    last_tick_at: null,
+    operating_cost_paid_marker: null,
+    operating_cost: 0,
+    required_ingredients: {},
+    covered_ingredients: {},
+    idle_order_board_snapshot: []
+  };
+}
+
+export function createDefaultTakeoutState() {
+  return {
+    menu_recipe_ids: [],
+    shift: defaultShiftState(),
+    earned_unclaimed_coins: 0,
+    updated_at: null
+  };
+}
+
+export function ensureTakeoutState(player) {
+  if (!player || typeof player !== "object") return createDefaultTakeoutState();
+
+  if (!player.takeout || typeof player.takeout !== "object" || Array.isArray(player.takeout)) {
+    player.takeout = createDefaultTakeoutState();
+    return player.takeout;
+  }
+
+  const takeout = player.takeout;
+  if (!Array.isArray(takeout.menu_recipe_ids)) takeout.menu_recipe_ids = [];
+  if (!Number.isFinite(Number(takeout.earned_unclaimed_coins))) takeout.earned_unclaimed_coins = 0;
+  takeout.earned_unclaimed_coins = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins) || 0));
+
+  if (!takeout.shift || typeof takeout.shift !== "object" || Array.isArray(takeout.shift)) {
+    takeout.shift = defaultShiftState();
+  } else {
+    takeout.shift = {
+      ...defaultShiftState(),
+      ...takeout.shift
+    };
+  }
+
+  if (!Array.isArray(takeout.shift.idle_order_board_snapshot)) {
+    takeout.shift.idle_order_board_snapshot = [];
+  }
+
+  return takeout;
+}
+
+export function getTakeoutMenuLimits(learnedRecipeCount) {
+  const learned = Math.max(0, Math.floor(Number(learnedRecipeCount) || 0));
+  const maxAllowed = Math.min(TAKEOUT_MENU_MAX_RECIPES, learned);
+  const minRequired = learned > 0 ? Math.min(TAKEOUT_MENU_MIN_RECIPES, maxAllowed) : 0;
+  return { learned, minRequired, maxAllowed };
+}
+
+export function normalizeTakeoutMenuSelection({ selectedRecipeIds = [], learnedRecipeIds = [] } = {}) {
+  const learnedSet = new Set((learnedRecipeIds || []).map((id) => String(id || "").trim()).filter(Boolean));
+  const deduped = [];
+  const seen = new Set();
+
+  for (const rawId of selectedRecipeIds || []) {
+    const recipeId = String(rawId || "").trim();
+    if (!recipeId || seen.has(recipeId) || !learnedSet.has(recipeId)) continue;
+    seen.add(recipeId);
+    deduped.push(recipeId);
+    if (deduped.length >= TAKEOUT_MENU_MAX_RECIPES) break;
+  }
+
+  return deduped;
+}
+
+function buildShiftSnapshot(menuRecipeIds = []) {
+  return menuRecipeIds.map((recipeId) => ({
+    recipe_id: recipeId,
+    visible_order_count: 0,
+    total_orders: 0,
+    hourly_order_counts: Array.from({ length: TAKEOUT_SHIFT_DURATION_HOURS }, () => 0)
+  }));
+}
+
+function toIntSeed(value) {
+  const n = Math.floor(Number(value) || 0);
+  if (!Number.isFinite(n)) return 0;
+  return n;
+}
+
+function deriveShiftSeed(parts = []) {
+  // FNV-1a style integer mixing gives stable pseudo-randomness per shift seed.
+  let hash = 2166136261;
+  for (const part of parts) {
+    const n = toIntSeed(part);
+    hash ^= n;
+    hash = Math.imul(hash, 16777619);
+    hash >>>= 0;
+  }
+  return hash >>> 0;
+}
+
+export function buildTakeoutShiftSnapshot(menuRecipeIds = [], {
+  hours = TAKEOUT_SHIFT_DURATION_HOURS,
+  totalOrders = TAKEOUT_SNAPSHOT_MIN_ORDERS
+} = {}) {
+  const out = buildShiftSnapshot(menuRecipeIds);
+  if (!out.length) return out;
+
+  const totalHours = Math.max(1, Math.floor(Number(hours) || TAKEOUT_SHIFT_DURATION_HOURS));
+  const menuSize = out.length;
+  const parsedTotalOrders = Number(totalOrders);
+  const orderTotal = Number.isFinite(parsedTotalOrders) && parsedTotalOrders > 0
+    ? Math.floor(parsedTotalOrders)
+    : TAKEOUT_SNAPSHOT_MIN_ORDERS;
+  if (orderTotal <= 0) return out;
+
+  const hourlyCounts = Array.from({ length: totalHours }, () => Math.floor(orderTotal / totalHours));
+  let remainder = orderTotal % totalHours;
+  for (let hour = 0; hour < totalHours && remainder > 0; hour += 1) {
+    hourlyCounts[hour] += 1;
+    remainder -= 1;
+  }
+
+  let rotation = 0;
+  for (let hour = 0; hour < totalHours; hour += 1) {
+    const ordersThisHour = hourlyCounts[hour] ?? 0;
+    for (let j = 0; j < ordersThisHour; j += 1) {
+      const idx = (rotation + j) % menuSize;
+      const row = out[idx];
+      row.hourly_order_counts[hour] = (row.hourly_order_counts[hour] ?? 0) + 1;
+      row.total_orders += 1;
+      row.visible_order_count = row.total_orders;
+    }
+    rotation = (rotation + ordersThisHour) % menuSize;
+  }
+
+  return out;
+}
+
+function resolveSnapshotOrderTotal({
+  boardOrderTotal = null,
+  unlimitedOrders = false,
+  shiftSeed = 0,
+  menuRecipeCount = 0
+} = {}) {
+  if (unlimitedOrders) {
+    const minOrders = TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS;
+    const maxOrders = TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS;
+    const span = Math.max(1, maxOrders - minOrders + 1);
+    const seed = deriveShiftSeed([shiftSeed, boardOrderTotal, menuRecipeCount]);
+    return minOrders + (seed % span);
+  }
+
+  const boardTotal = Math.floor(Number(boardOrderTotal) || 0);
+  if (!Number.isFinite(boardTotal) || boardTotal <= 0) return TAKEOUT_SNAPSHOT_MIN_ORDERS;
+  return Math.max(TAKEOUT_SNAPSHOT_MIN_ORDERS, Math.min(TAKEOUT_SNAPSHOT_MAX_ORDERS, boardTotal));
+}
+
+export function computeTakeoutRequiredIngredients(snapshot = [], recipes = {}) {
+  const totals = {};
+
+  for (const row of snapshot || []) {
+    const recipeId = String(row?.recipe_id || "").trim();
+    if (!recipeId) continue;
+    const recipe = recipes?.[recipeId];
+    const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+    const orderCount = Math.max(
+      0,
+      Math.floor(Number(row?.total_orders ?? row?.visible_order_count ?? 0) || 0)
+    );
+    if (orderCount <= 0) continue;
+
+    for (const ing of ingredients) {
+      const itemId = String(ing?.item_id || "").trim();
+      const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+      if (!itemId || qty <= 0) continue;
+      totals[itemId] = (totals[itemId] ?? 0) + (qty * orderCount);
+    }
+  }
+
+  return totals;
+}
+
+export function computeTakeoutOperatingCost(requiredIngredients = {}, { marketPrices = {}, items = {} } = {}) {
+  let total = 0;
+  for (const [itemId, qtyRaw] of Object.entries(requiredIngredients || {})) {
+    const qty = Math.max(0, Math.floor(Number(qtyRaw || 0) || 0));
+    if (qty <= 0) continue;
+    const marketPrice = Number(marketPrices?.[itemId]);
+    const basePrice = Number(items?.[itemId]?.base_price);
+    const unitPrice = Number.isFinite(marketPrice) && marketPrice > 0
+      ? marketPrice
+      : (Number.isFinite(basePrice) && basePrice > 0 ? basePrice : 0);
+    total += unitPrice * qty;
+  }
+  return Math.max(0, Math.floor(total));
+}
+
+function resolveIngredientUnitPrice(itemId, { marketPrices = {}, items = {} } = {}) {
+  const marketPrice = Number(marketPrices?.[itemId]);
+  const basePrice = Number(items?.[itemId]?.base_price);
+  if (Number.isFinite(marketPrice) && marketPrice > 0) return marketPrice;
+  if (Number.isFinite(basePrice) && basePrice > 0) return basePrice;
+  return 0;
+}
+
+function resolveTakeoutOrderCoinValue(recipeId, {
+  recipes = {},
+  marketPrices = {},
+  items = {}
+} = {}) {
+  const recipe = recipes?.[recipeId];
+  const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+  let ingredientCost = 0;
+  for (const ing of ingredients) {
+    const itemId = String(ing?.item_id || "").trim();
+    const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+    if (!itemId || qty <= 0) continue;
+    ingredientCost += resolveIngredientUnitPrice(itemId, { marketPrices, items }) * qty;
+  }
+
+  const tierKey = String(recipe?.tier || "common").trim().toLowerCase();
+  const mult = Number(TIER_PAYOUT_MULTIPLIERS[tierKey] ?? TIER_PAYOUT_MULTIPLIERS.common);
+  const payout = Math.round(ingredientCost * mult);
+  return Math.max(1, Number.isFinite(payout) ? payout : 1);
+}
+
+function consumeCoveredIngredients(coveredIngredients, recipeIngredients, orderCount) {
+  const qtyToServe = Math.max(0, Math.floor(Number(orderCount || 0) || 0));
+  if (qtyToServe <= 0) return 0;
+
+  const required = [];
+  for (const ing of recipeIngredients || []) {
+    const itemId = String(ing?.item_id || "").trim();
+    const qtyPerOrder = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+    if (!itemId || qtyPerOrder <= 0) continue;
+    required.push({ itemId, qtyPerOrder });
+  }
+  if (!required.length) return qtyToServe;
+
+  let maxServable = qtyToServe;
+  for (const req of required) {
+    const available = Math.max(0, Math.floor(Number(coveredIngredients?.[req.itemId] || 0) || 0));
+    const possible = Math.floor(available / req.qtyPerOrder);
+    if (possible < maxServable) maxServable = possible;
+  }
+
+  if (maxServable <= 0) return 0;
+  for (const req of required) {
+    const needed = req.qtyPerOrder * maxServable;
+    coveredIngredients[req.itemId] = Math.max(
+      0,
+      Math.floor(Number(coveredIngredients?.[req.itemId] || 0) || 0) - needed
+    );
+  }
+
+  return maxServable;
+}
+
+export function processTakeoutCatchup(player, {
+  now = nowTs(),
+  recipes = {},
+  marketPrices = {},
+  items = {}
+} = {}) {
+  const takeout = ensureTakeoutState(player);
+  const shift = takeout.shift;
+  if (shift.status !== "active") {
+    return { ok: true, processedHours: 0, earned: 0, completed: false, totalProcessedHours: 0 };
+  }
+
+  const startedAt = Number(shift.started_at || 0);
+  const endsAt = Number(shift.ends_at || 0);
+  if (!Number.isFinite(startedAt) || startedAt < 0 || !Number.isFinite(endsAt) || endsAt <= startedAt) {
+    shift.status = "inactive";
+    shift.last_tick_at = now;
+    takeout.updated_at = now;
+    return { ok: true, processedHours: 0, earned: 0, completed: true, totalProcessedHours: 0 };
+  }
+
+  const effectiveNow = Math.min(now, endsAt);
+  const elapsedWholeHours = Math.max(0, Math.floor((effectiveNow - startedAt) / TAKEOUT_HOUR_MS));
+  const maxProcessableHours = Math.min(TAKEOUT_SHIFT_DURATION_HOURS, elapsedWholeHours);
+  const prevProcessedHours = Math.max(0, Math.floor(Number(shift.last_processed_hour_index || 0) || 0));
+  if (prevProcessedHours >= maxProcessableHours) {
+    const completed = maxProcessableHours >= TAKEOUT_SHIFT_DURATION_HOURS || now >= endsAt;
+    if (completed) shift.status = "inactive";
+    shift.last_tick_at = now;
+    takeout.updated_at = now;
+    return { ok: true, processedHours: 0, earned: 0, completed, totalProcessedHours: maxProcessableHours };
+  }
+
+  const coveredIngredients = shift.covered_ingredients && typeof shift.covered_ingredients === "object"
+    ? shift.covered_ingredients
+    : {};
+  shift.covered_ingredients = coveredIngredients;
+
+  const snapshot = Array.isArray(shift.idle_order_board_snapshot)
+    ? shift.idle_order_board_snapshot
+    : [];
+  let earned = 0;
+
+  for (let hour = prevProcessedHours; hour < maxProcessableHours; hour += 1) {
+    for (const row of snapshot) {
+      const recipeId = String(row?.recipe_id || "").trim();
+      if (!recipeId) continue;
+
+      const hourly = Array.isArray(row?.hourly_order_counts) ? row.hourly_order_counts : [];
+      const orderCount = Math.max(0, Math.floor(Number(hourly[hour] || 0) || 0));
+      if (orderCount <= 0) continue;
+
+      const recipe = recipes?.[recipeId];
+      const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+      const served = consumeCoveredIngredients(coveredIngredients, ingredients, orderCount);
+      if (served <= 0) continue;
+
+      const perOrderCoins = resolveTakeoutOrderCoinValue(recipeId, { recipes, marketPrices, items });
+      earned += perOrderCoins * served;
+    }
+  }
+
+  const earnedSafe = Math.max(0, Math.floor(Number(earned || 0) || 0));
+  takeout.earned_unclaimed_coins = Math.max(
+    0,
+    Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0) + earnedSafe
+  );
+  shift.last_processed_hour_index = maxProcessableHours;
+  shift.last_tick_at = now;
+
+  const completed = maxProcessableHours >= TAKEOUT_SHIFT_DURATION_HOURS || now >= endsAt;
+  if (completed) shift.status = "inactive";
+
+  takeout.updated_at = now;
+
+  return {
+    ok: true,
+    processedHours: Math.max(0, maxProcessableHours - prevProcessedHours),
+    earned: earnedSafe,
+    completed,
+    totalProcessedHours: maxProcessableHours
+  };
+}
+
+export function isTakeoutShiftActive(player, now = nowTs()) {
+  const takeout = ensureTakeoutState(player);
+  if (takeout.shift.status !== "active") return false;
+
+  const endsAt = Number(takeout.shift.ends_at || 0);
+  if (!Number.isFinite(endsAt) || endsAt <= 0) return false;
+  return now < endsAt;
+}
+
+export function finishTakeoutShiftIfEnded(player, now = nowTs()) {
+  const takeout = ensureTakeoutState(player);
+  const shift = takeout.shift;
+  if (shift.status !== "active") return false;
+
+  const endsAt = Number(shift.ends_at || 0);
+  if (!Number.isFinite(endsAt) || endsAt <= 0 || now < endsAt) return false;
+
+  shift.status = "inactive";
+  shift.last_tick_at = now;
+  takeout.updated_at = now;
+  return true;
+}
+
+export function openTakeoutShift(player, {
+  now = nowTs(),
+  snapshot = null,
+  snapshotOrderTotal = null,
+  requiredIngredients = null,
+  coveredIngredients = null,
+  operatingCost = null,
+  operatingCostMarker = null
+} = {}) {
+  const takeout = ensureTakeoutState(player);
+
+  // End stale active shifts first so players can immediately start a new 12h run.
+  finishTakeoutShiftIfEnded(player, now);
+
+  if (isTakeoutShiftActive(player, now)) {
+    return { ok: false, reason: "shift_active" };
+  }
+
+  const startedAt = now;
+  const endsAt = startedAt + TAKEOUT_SHIFT_DURATION_MS;
+  const normalizedSnapshot = Array.isArray(snapshot)
+    ? snapshot
+    : buildTakeoutShiftSnapshot(takeout.menu_recipe_ids, { totalOrders: snapshotOrderTotal });
+  const normalizedRequiredIngredients = requiredIngredients && typeof requiredIngredients === "object"
+    ? { ...requiredIngredients }
+    : {};
+  const normalizedCoveredIngredients = coveredIngredients && typeof coveredIngredients === "object"
+    ? { ...coveredIngredients }
+    : { ...normalizedRequiredIngredients };
+
+  takeout.shift = {
+    status: "active",
+    started_at: startedAt,
+    ends_at: endsAt,
+    last_processed_hour_index: 0,
+    last_tick_at: startedAt,
+    operating_cost_paid_marker: operatingCostMarker ?? null,
+    operating_cost: Math.max(0, Math.floor(Number(operatingCost || 0) || 0)),
+    required_ingredients: normalizedRequiredIngredients,
+    covered_ingredients: normalizedCoveredIngredients,
+    idle_order_board_snapshot: normalizedSnapshot
+  };
+  takeout.updated_at = now;
+
+  return {
+    ok: true,
+    startedAt,
+    endsAt
+  };
+}
+
+export function startTakeoutShiftWithCoverage(player, {
+  now = nowTs(),
+  boardOrderTotal = null,
+  unlimitedOrders = false,
+  recipes = {},
+  marketPrices = {},
+  items = {}
+} = {}) {
+  const takeout = ensureTakeoutState(player);
+  const menuRecipeIds = Array.isArray(takeout.menu_recipe_ids) ? [...takeout.menu_recipe_ids] : [];
+
+  if (menuRecipeIds.length <= 0) {
+    return { ok: false, reason: "menu_not_set" };
+  }
+
+  const snapshotOrderTotal = resolveSnapshotOrderTotal({
+    boardOrderTotal,
+    unlimitedOrders,
+    shiftSeed: now,
+    menuRecipeCount: menuRecipeIds.length
+  });
+  const snapshot = buildTakeoutShiftSnapshot(menuRecipeIds, { totalOrders: snapshotOrderTotal });
+  const requiredIngredients = computeTakeoutRequiredIngredients(snapshot, recipes);
+  const operatingCost = computeTakeoutOperatingCost(requiredIngredients, { marketPrices, items });
+  const playerCoins = Math.max(0, Math.floor(Number(player?.coins || 0) || 0));
+
+  if (playerCoins < operatingCost) {
+    return {
+      ok: false,
+      reason: "insufficient_coins",
+      operatingCost,
+      requiredIngredients,
+      snapshot
+    };
+  }
+
+  player.coins = playerCoins - operatingCost;
+
+  const openResult = openTakeoutShift(player, {
+    now,
+    snapshot,
+    snapshotOrderTotal,
+    requiredIngredients,
+    coveredIngredients: requiredIngredients,
+    operatingCost,
+    operatingCostMarker: `takeout_shift:${now}`
+  });
+  if (!openResult.ok) {
+    player.coins = playerCoins;
+    return {
+      ...openResult,
+      snapshotOrderTotal,
+      operatingCost,
+      requiredIngredients,
+      snapshot
+    };
+  }
+
+  return {
+    ok: true,
+    startedAt: openResult.startedAt,
+    endsAt: openResult.endsAt,
+    snapshotOrderTotal,
+    operatingCost,
+    requiredIngredients,
+    snapshot
+  };
+}
+
+export function setTakeoutMenu(player, { menuRecipeIds = [], learnedRecipeIds = [], now = nowTs() } = {}) {
+  const takeout = ensureTakeoutState(player);
+  const normalizedMenu = normalizeTakeoutMenuSelection({ selectedRecipeIds: menuRecipeIds, learnedRecipeIds });
+
+  const limits = getTakeoutMenuLimits(learnedRecipeIds.length);
+  if (limits.learned <= 0) {
+    return { ok: false, reason: "no_learned_recipes", limits, menuRecipeIds: [] };
+  }
+
+  if (normalizedMenu.length < limits.minRequired) {
+    return { ok: false, reason: "menu_too_small", limits, menuRecipeIds: normalizedMenu };
+  }
+
+  if (normalizedMenu.length > limits.maxAllowed) {
+    return { ok: false, reason: "menu_too_large", limits, menuRecipeIds: normalizedMenu };
+  }
+
+  takeout.menu_recipe_ids = normalizedMenu;
+  takeout.updated_at = now;
+
+  return { ok: true, limits, menuRecipeIds: [...normalizedMenu] };
+}
+
+export function claimTakeoutEarnings(player, { now = nowTs() } = {}) {
+  const takeout = ensureTakeoutState(player);
+  const amount = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins) || 0));
+  if (amount <= 0) {
+    return { ok: false, reason: "nothing_to_claim", amount: 0 };
+  }
+
+  player.coins = (Number(player.coins) || 0) + amount;
+  if (!player.lifetime || typeof player.lifetime !== "object") player.lifetime = {};
+  player.lifetime.coins_earned = (Number(player.lifetime.coins_earned) || 0) + amount;
+
+  takeout.earned_unclaimed_coins = 0;
+  takeout.updated_at = now;
+
+  return { ok: true, amount };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,13 @@ import { theme } from "./ui/theme.js";
   const { getKitchenUnlockState, KITCHEN_BROTH_RECIPES } = await import("./game/kitchen.js");
   const { getCustomEmojiEntries } = await import("./ui/icons.js");
   const { grantStoreBundle, resolveStoreBundleSpecId } = await import("./game/storeBundles.js");
+  const {
+    applySubscriptionEntitlementEvent,
+    applyMonthlySubscriptionCoinGrant,
+    hasActivePerk,
+    resolveSubscriptionBillingPeriodKey,
+    resolveSubscriptionPerkId
+  } = await import("./game/subscriptions.js");
   const { ensureSpecializationState, getSpecializationById } = await import("./game/specialization.js");
   const { getAvailableRecipes } = await import("./game/resilience.js");
   const {
@@ -1229,7 +1236,23 @@ import { theme } from "./ui/theme.js";
       skuId: data?.sku_id ?? data?.skuId ?? payload?.sku_id ?? payload?.skuId ?? null,
       userId: data?.user_id ?? data?.userId ?? payload?.user_id ?? payload?.userId ?? null,
       guildId: data?.guild_id ?? data?.guildId ?? payload?.guild_id ?? payload?.guildId ?? null,
-      entitlementId: data?.id ?? data?.entitlement_id ?? payload?.entitlement_id ?? payload?.id ?? null
+      entitlementId: data?.id ?? data?.entitlement_id ?? payload?.entitlement_id ?? payload?.id ?? null,
+      periodStartAt:
+        data?.starts_at
+        ?? data?.start_at
+        ?? data?.period_start
+        ?? data?.current_period_start
+        ?? payload?.starts_at
+        ?? payload?.period_start
+        ?? null,
+      periodEndAt:
+        data?.ends_at
+        ?? data?.end_at
+        ?? data?.period_end
+        ?? data?.current_period_end
+        ?? payload?.ends_at
+        ?? payload?.period_end
+        ?? null
     };
   }
 
@@ -2892,17 +2915,125 @@ import { theme } from "./ui/theme.js";
         return;
       }
 
-      const { eventType, skuId, userId, guildId, entitlementId } = extractEntitlementPayload(payload);
-      if (eventType !== "ENTITLEMENT_CREATE") {
-        res.writeHead(200, { "content-type": "text/plain" });
-        res.end("ignored");
+      const {
+        eventType,
+        skuId,
+        userId,
+        guildId,
+        entitlementId,
+        periodStartAt,
+        periodEndAt
+      } = extractEntitlementPayload(payload);
+      const specId = resolveStoreBundleSpecId(skuId);
+      const perkId = resolveSubscriptionPerkId(skuId);
+
+      if (!userId || (!specId && !perkId)) {
+        res.writeHead(202, { "content-type": "text/plain" });
+        res.end("missing sku or user");
         return;
       }
 
-      const specId = resolveStoreBundleSpecId(skuId);
-      if (!specId || !userId) {
-        res.writeHead(202, { "content-type": "text/plain" });
-        res.end("missing sku or user");
+      if (perkId) {
+        const billingPeriodKey = resolveSubscriptionBillingPeriodKey({
+          periodStartAt,
+          periodEndAt,
+          now: Date.now()
+        });
+        const subscriptionIdempotencyKey = entitlementId
+          ? `discord_subscription:${eventType}:${entitlementId}`
+          : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
+
+        const cached = getIdempotentResult(db, subscriptionIdempotencyKey);
+        if (cached) {
+          res.writeHead(200, { "content-type": "text/plain" });
+          res.end("ok");
+          return;
+        }
+
+        const subscriptionServerId = guildId || getLatestServerIdForUser(db, userId);
+        if (!subscriptionServerId) {
+          webhookWarn("Discord: Missing server for subscription user", userId);
+          res.writeHead(202, { "content-type": "text/plain" });
+          res.end("missing server");
+          return;
+        }
+
+        let subscriptionPlayer = getPlayer(db, subscriptionServerId, userId);
+        if (!subscriptionPlayer) subscriptionPlayer = newPlayerProfile(userId);
+
+        const lifecycleResult = applySubscriptionEntitlementEvent(subscriptionPlayer, {
+          perkId,
+          eventType,
+          entitlementId,
+          periodStartAt,
+          periodEndAt,
+          now: Date.now()
+        });
+
+        let monthlyGrantResult = { ok: true, granted: false, amount: 0, billingPeriodKey: null };
+        if (lifecycleResult.ok && (eventType === "ENTITLEMENT_CREATE" || eventType === "ENTITLEMENT_UPDATE")) {
+          monthlyGrantResult = applyMonthlySubscriptionCoinGrant(subscriptionPlayer, {
+            perkId,
+            periodStartAt,
+            periodEndAt,
+            now: Date.now()
+          });
+        }
+
+        if (lifecycleResult.ok || monthlyGrantResult.granted) {
+          upsertPlayer(db, subscriptionServerId, userId, subscriptionPlayer, null, subscriptionPlayer.schema_version);
+        }
+
+        webhookInfo(
+          "Discord: Subscription entitlement result",
+          JSON.stringify({
+            ok: lifecycleResult.ok,
+            reason: lifecycleResult.reason ?? null,
+            eventType,
+            perkId,
+            userId,
+            serverId: subscriptionServerId,
+            active: hasActivePerk(subscriptionPlayer, perkId),
+            monthlyCoinsGranted: monthlyGrantResult.granted ? monthlyGrantResult.amount : 0,
+            billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
+          })
+        );
+
+        emitTelemetry("subscription_state_change", {
+          userId,
+          serverId: subscriptionServerId,
+          perkId,
+          eventType,
+          active: hasActivePerk(subscriptionPlayer, perkId),
+          lifecycleOk: Boolean(lifecycleResult.ok),
+          lifecycleReason: lifecycleResult.reason ?? null,
+          monthlyCoinsGranted: monthlyGrantResult.granted ? monthlyGrantResult.amount : 0,
+          billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
+        });
+
+        putIdempotentResult(db, {
+          key: subscriptionIdempotencyKey,
+          userId,
+          action: "discord_subscription_entitlement",
+          ttlSeconds: 60 * 60 * 24 * 30,
+          result: {
+            ok: Boolean(lifecycleResult.ok),
+            perkId,
+            eventType,
+            active: hasActivePerk(subscriptionPlayer, perkId),
+            monthlyCoinsGranted: monthlyGrantResult.granted ? monthlyGrantResult.amount : 0,
+            billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
+          }
+        });
+
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end(lifecycleResult.ok ? "ok" : "ignored");
+        return;
+      }
+
+      if (eventType !== "ENTITLEMENT_CREATE") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("ignored");
         return;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2939,9 +2939,17 @@ import { theme } from "./ui/theme.js";
           periodEndAt,
           now: Date.now()
         });
-        const subscriptionIdempotencyKey = entitlementId
-          ? `discord_subscription:${eventType}:${entitlementId}`
-          : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
+        const subscriptionIdempotencyKey = (() => {
+          // Discord can reuse entitlement IDs across renewals; include billing period on updates.
+          if (eventType === "ENTITLEMENT_UPDATE") {
+            return entitlementId
+              ? `discord_subscription:${eventType}:${entitlementId}:${billingPeriodKey}`
+              : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
+          }
+          return entitlementId
+            ? `discord_subscription:${eventType}:${entitlementId}`
+            : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
+        })();
 
         const cached = getIdempotentResult(db, subscriptionIdempotencyKey);
         if (cached) {

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -1,0 +1,184 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ORDER_ACCEPT_CAP_BASE,
+  ORDER_ACCEPT_CAP_HOUSE_247,
+  SUBSCRIPTION_PERKS,
+  SUBSCRIPTION_MONTHLY_COIN_GRANT,
+  applySubscriptionEntitlementEvent,
+  applyMonthlySubscriptionCoinGrant,
+  createDefaultSubscriptionState,
+  ensureSubscriptionState,
+  getOrderAcceptCap,
+  hasUnlimitedMarketStock,
+  hasActivePerk
+} from "../src/game/subscriptions.js";
+
+test("Subscriptions: default state contains both perks", () => {
+  const state = createDefaultSubscriptionState();
+  assert.equal(state.perks[SUBSCRIPTION_PERKS.HOUSE_247].active, false);
+  assert.equal(state.perks[SUBSCRIPTION_PERKS.TAKEOUT_COUNTER].active, false);
+});
+
+test("Subscriptions: ensureSubscriptionState repairs malformed player state", () => {
+  const player = { subscriptions: { perks: { house_247: { active: true } } } };
+  ensureSubscriptionState(player);
+
+  assert.equal(typeof player.subscriptions.perks[SUBSCRIPTION_PERKS.HOUSE_247], "object");
+  assert.equal(typeof player.subscriptions.perks[SUBSCRIPTION_PERKS.TAKEOUT_COUNTER], "object");
+});
+
+test("Subscriptions: entitlement create activates perk and respects period end", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+  const later = now + (30 * 24 * 60 * 60 * 1000);
+
+  const result = applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_1",
+    periodStartAt: now,
+    periodEndAt: later,
+    now
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.active, true);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now + 1000), true);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, later + 1), false);
+});
+
+test("Subscriptions: entitlement update refreshes period timestamps", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_2",
+    periodStartAt: now,
+    periodEndAt: now + 1000,
+    now
+  });
+
+  const updated = applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_UPDATE",
+    entitlementId: "ent_2",
+    periodStartAt: now + 1000,
+    periodEndAt: now + 2000,
+    now: now + 1000
+  });
+
+  assert.equal(updated.ok, true);
+  assert.equal(updated.state.period_end_at, now + 2000);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now + 1500), true);
+});
+
+test("Subscriptions: entitlement delete deactivates perk", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_3",
+    periodEndAt: now + 10_000,
+    now
+  });
+
+  const deleted = applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_DELETE",
+    entitlementId: "ent_3",
+    now: now + 2_000
+  });
+
+  assert.equal(deleted.ok, true);
+  assert.equal(deleted.active, false);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now + 2_001), false);
+});
+
+test("Subscriptions: monthly coin grant is idempotent per billing period", () => {
+  const player = { coins: 100, lifetime: { coins_earned: 50 } };
+  const periodStart = 1_700_000_000_000;
+  const periodEnd = periodStart + (30 * 24 * 60 * 60 * 1000);
+
+  const first = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    periodStartAt: periodStart,
+    periodEndAt: periodEnd,
+    now: periodStart + 1000
+  });
+  assert.equal(first.ok, true);
+  assert.equal(first.granted, true);
+  assert.equal(first.amount, SUBSCRIPTION_MONTHLY_COIN_GRANT);
+  assert.equal(player.coins, 100 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
+  assert.equal(player.lifetime.coins_earned, 50 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
+
+  const second = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    periodStartAt: periodStart,
+    periodEndAt: periodEnd,
+    now: periodStart + 2000
+  });
+  assert.equal(second.ok, true);
+  assert.equal(second.granted, false);
+  assert.equal(second.amount, 0);
+  assert.equal(player.coins, 100 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
+});
+
+test("Subscriptions: both perks grant monthly coins independently", () => {
+  const player = { coins: 0, lifetime: { coins_earned: 0 } };
+  const periodStart = 1_700_000_000_000;
+
+  const houseGrant = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    periodStartAt: periodStart,
+    now: periodStart + 1000
+  });
+  const takeoutGrant = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    periodStartAt: periodStart,
+    now: periodStart + 1000
+  });
+
+  assert.equal(houseGrant.granted, true);
+  assert.equal(takeoutGrant.granted, true);
+  assert.equal(player.coins, SUBSCRIPTION_MONTHLY_COIN_GRANT * 2);
+  assert.equal(player.lifetime.coins_earned, SUBSCRIPTION_MONTHLY_COIN_GRANT * 2);
+});
+
+test("Subscriptions: 24/7 House increases active order cap", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  assert.equal(getOrderAcceptCap(player, now), ORDER_ACCEPT_CAP_BASE);
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    periodEndAt: now + 1000,
+    now
+  });
+
+  assert.equal(getOrderAcceptCap(player, now + 1), ORDER_ACCEPT_CAP_HOUSE_247);
+});
+
+test("Subscriptions: 24/7 House grants unlimited market stock behavior", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  assert.equal(hasUnlimitedMarketStock(player, now), false);
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    periodEndAt: now + 1000,
+    now
+  });
+
+  assert.equal(hasUnlimitedMarketStock(player, now + 1), true);
+  assert.equal(hasUnlimitedMarketStock(player, now + 1001), false);
+});

--- a/test/takeout.test.js
+++ b/test/takeout.test.js
@@ -1,0 +1,431 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  TAKEOUT_SHIFT_DURATION_MS,
+  TAKEOUT_SNAPSHOT_MAX_ORDERS,
+  TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS,
+  TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS,
+  createDefaultTakeoutState,
+  ensureTakeoutState,
+  getTakeoutMenuLimits,
+  setTakeoutMenu,
+  openTakeoutShift,
+  isTakeoutShiftActive,
+  finishTakeoutShiftIfEnded,
+  claimTakeoutEarnings,
+  buildTakeoutShiftSnapshot,
+  computeTakeoutRequiredIngredients,
+  computeTakeoutOperatingCost,
+  startTakeoutShiftWithCoverage,
+  processTakeoutCatchup
+} from "../src/game/takeout.js";
+
+test("Takeout: default state shape", () => {
+  const state = createDefaultTakeoutState();
+  assert.deepEqual(state.menu_recipe_ids, []);
+  assert.equal(state.shift.status, "inactive");
+  assert.equal(state.earned_unclaimed_coins, 0);
+});
+
+test("Takeout: menu limits allow fewer than 5 when learned recipes are below 5", () => {
+  const limits = getTakeoutMenuLimits(3);
+  assert.equal(limits.minRequired, 3);
+  assert.equal(limits.maxAllowed, 3);
+});
+
+test("Takeout: set menu enforces min/max and learned recipe membership", () => {
+  const player = {};
+  ensureTakeoutState(player);
+
+  const tooSmall = setTakeoutMenu(player, {
+    menuRecipeIds: ["r1"],
+    learnedRecipeIds: ["r1", "r2", "r3", "r4", "r5", "r6"]
+  });
+  assert.equal(tooSmall.ok, false);
+  assert.equal(tooSmall.reason, "menu_too_small");
+
+  const ok = setTakeoutMenu(player, {
+    menuRecipeIds: ["r1", "r2", "r3", "r4", "r5", "invalid"],
+    learnedRecipeIds: ["r1", "r2", "r3", "r4", "r5", "r6"]
+  });
+  assert.equal(ok.ok, true);
+  assert.deepEqual(player.takeout.menu_recipe_ids, ["r1", "r2", "r3", "r4", "r5"]);
+});
+
+test("Takeout: finished shift can immediately be reopened for another 12h", () => {
+  const player = {
+    takeout: {
+      menu_recipe_ids: ["r1", "r2", "r3", "r4", "r5"],
+      shift: {
+        status: "active",
+        started_at: 100,
+        ends_at: 200,
+        last_processed_hour_index: 12,
+        last_tick_at: 200,
+        operating_cost_paid_marker: null,
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: 200
+    }
+  };
+
+  const endedNow = 300;
+  const ended = finishTakeoutShiftIfEnded(player, endedNow);
+  assert.equal(ended, true);
+  assert.equal(player.takeout.shift.status, "inactive");
+
+  const reopened = openTakeoutShift(player, { now: endedNow });
+  assert.equal(reopened.ok, true);
+  assert.equal(player.takeout.shift.status, "active");
+  assert.equal(player.takeout.shift.started_at, endedNow);
+  assert.equal(player.takeout.shift.ends_at, endedNow + TAKEOUT_SHIFT_DURATION_MS);
+  assert.equal(isTakeoutShiftActive(player, endedNow + 1), true);
+});
+
+test("Takeout: claim earnings moves coins and is idempotent when empty", () => {
+  const player = {
+    coins: 10,
+    lifetime: { coins_earned: 5 },
+    takeout: {
+      menu_recipe_ids: [],
+      shift: {
+        status: "inactive",
+        started_at: null,
+        ends_at: null,
+        last_processed_hour_index: 0,
+        last_tick_at: null,
+        operating_cost_paid_marker: null,
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 250,
+      updated_at: null
+    }
+  };
+
+  const first = claimTakeoutEarnings(player);
+  assert.equal(first.ok, true);
+  assert.equal(first.amount, 250);
+  assert.equal(player.coins, 260);
+  assert.equal(player.lifetime.coins_earned, 255);
+  assert.equal(player.takeout.earned_unclaimed_coins, 0);
+
+  const second = claimTakeoutEarnings(player);
+  assert.equal(second.ok, false);
+  assert.equal(second.reason, "nothing_to_claim");
+});
+
+test("Takeout: fixed operating cost computed from 12h snapshot ingredient totals", () => {
+  const snapshot = [
+    { recipe_id: "r1", total_orders: 2, visible_order_count: 2, hourly_order_counts: [1, 1] },
+    { recipe_id: "r2", total_orders: 1, visible_order_count: 1, hourly_order_counts: [1] }
+  ];
+  const recipes = {
+    r1: { ingredients: [{ item_id: "i1", qty: 2 }, { item_id: "i2", qty: 1 }] },
+    r2: { ingredients: [{ item_id: "i1", qty: 1 }] }
+  };
+  const required = computeTakeoutRequiredIngredients(snapshot, recipes);
+  assert.deepEqual(required, { i1: 5, i2: 2 });
+
+  const cost = computeTakeoutOperatingCost(required, {
+    marketPrices: { i1: 3, i2: 4 },
+    items: {}
+  });
+  assert.equal(cost, 23);
+});
+
+test("Takeout: shift cannot start when player cannot afford fixed operating cost", () => {
+  const player = {
+    coins: 5,
+    takeout: {
+      menu_recipe_ids: ["r1"],
+      shift: {
+        status: "inactive",
+        started_at: null,
+        ends_at: null,
+        last_processed_hour_index: 0,
+        last_tick_at: null,
+        operating_cost_paid_marker: null,
+        operating_cost: 0,
+        required_ingredients: {},
+        covered_ingredients: {},
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: null
+    }
+  };
+
+  const result = startTakeoutShiftWithCoverage(player, {
+    now: 1000,
+    recipes: {
+      r1: { ingredients: [{ item_id: "i1", qty: 2 }] }
+    },
+    marketPrices: { i1: 2 },
+    items: {}
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "insufficient_coins");
+  assert.equal(player.takeout.shift.status, "inactive");
+  assert.equal(player.coins, 5);
+});
+
+test("Takeout: covered idle ingredient pool is isolated from pantry usage", () => {
+  const player = {
+    coins: 50_000,
+    inv_ingredients: { i1: 1, i2: 0 },
+    takeout: {
+      menu_recipe_ids: ["r1"],
+      shift: {
+        status: "inactive",
+        started_at: null,
+        ends_at: null,
+        last_processed_hour_index: 0,
+        last_tick_at: null,
+        operating_cost_paid_marker: null,
+        operating_cost: 0,
+        required_ingredients: {},
+        covered_ingredients: {},
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: null
+    }
+  };
+
+  const result = startTakeoutShiftWithCoverage(player, {
+    now: 2000,
+    recipes: {
+      r1: { ingredients: [{ item_id: "i1", qty: 2 }, { item_id: "i2", qty: 1 }] }
+    },
+    marketPrices: { i1: 3, i2: 4 },
+    items: {}
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(player.takeout.shift.status, "active");
+  assert.equal(player.takeout.shift.operating_cost, result.operatingCost);
+  assert.equal(player.takeout.shift.operating_cost_paid_marker, "takeout_shift:2000");
+  assert.ok(Object.keys(player.takeout.shift.covered_ingredients).length > 0);
+  assert.deepEqual(player.inv_ingredients, { i1: 1, i2: 0 });
+
+  const firstCovered = player.takeout.shift.covered_ingredients;
+  player.inv_ingredients.i1 = 0;
+  assert.deepEqual(player.takeout.shift.covered_ingredients, firstCovered);
+});
+
+test("Takeout: generated shift snapshot spans 12 hours with recipe demand", () => {
+  const snapshot = buildTakeoutShiftSnapshot(["r1", "r2", "r3"], { totalOrders: 120 });
+  assert.equal(snapshot.length, 3);
+  const total = snapshot.reduce((sum, row) => sum + row.total_orders, 0);
+  assert.equal(total, 120);
+  for (const row of snapshot) {
+    assert.equal(row.hourly_order_counts.length, 12);
+    assert.ok(row.total_orders > 0);
+    assert.equal(row.visible_order_count, row.total_orders);
+  }
+});
+
+test("Takeout: snapshot distribution is deterministic and sums to board total", () => {
+  const snapshot = buildTakeoutShiftSnapshot(["r1", "r2", "r3", "r4"], { totalOrders: 137 });
+  const total = snapshot.reduce((sum, row) => sum + row.total_orders, 0);
+  assert.equal(total, 137);
+
+  const hourlyTotals = Array.from({ length: 12 }, (_, hour) =>
+    snapshot.reduce((sum, row) => sum + (row.hourly_order_counts[hour] ?? 0), 0)
+  );
+  assert.equal(hourlyTotals.reduce((sum, count) => sum + count, 0), 137);
+  assert.ok(Math.max(...hourlyTotals) - Math.min(...hourlyTotals) <= 1);
+});
+
+test("Takeout: non-24/7 users snapshot board-total-at-open", () => {
+  const player = { coins: 50_000, takeout: createDefaultTakeoutState() };
+  player.takeout.menu_recipe_ids = ["r1", "r2"];
+
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    boardOrderTotal: 140,
+    unlimitedOrders: false,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+    },
+    marketPrices: { i1: 1 },
+    items: { i1: { base_price: 1 } }
+  });
+
+  assert.equal(open.ok, true);
+  assert.equal(open.snapshotOrderTotal, 140);
+  const total = player.takeout.shift.idle_order_board_snapshot
+    .reduce((sum, row) => sum + (row.total_orders || 0), 0);
+  assert.equal(total, 140);
+});
+
+test("Takeout: 24/7 users use unlimited snapshot total", () => {
+  const player = { coins: 100_000, takeout: createDefaultTakeoutState() };
+  player.takeout.menu_recipe_ids = ["r1", "r2"];
+
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    boardOrderTotal: 140,
+    unlimitedOrders: true,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+    },
+    marketPrices: { i1: 1 },
+    items: { i1: { base_price: 1 } }
+  });
+
+  assert.equal(open.ok, true);
+  assert.ok(open.snapshotOrderTotal > TAKEOUT_SNAPSHOT_MAX_ORDERS);
+  assert.ok(open.snapshotOrderTotal >= TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS);
+  assert.ok(open.snapshotOrderTotal <= TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS);
+  const total = player.takeout.shift.idle_order_board_snapshot
+    .reduce((sum, row) => sum + (row.total_orders || 0), 0);
+  assert.equal(total, open.snapshotOrderTotal);
+});
+
+test("Takeout: unlimited snapshot is deterministic per shift seed and can vary across shifts", () => {
+  const openAt = (now) => {
+    const player = { coins: 100_000, takeout: createDefaultTakeoutState() };
+    player.takeout.menu_recipe_ids = ["r1", "r2", "r3"];
+    const open = startTakeoutShiftWithCoverage(player, {
+      now,
+      boardOrderTotal: 200,
+      unlimitedOrders: true,
+      recipes: {
+        r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+        r2: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+        r3: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+      },
+      marketPrices: { i1: 1 },
+      items: { i1: { base_price: 1 } }
+    });
+    assert.equal(open.ok, true);
+    return open.snapshotOrderTotal;
+  };
+
+  const sameA = openAt(123_000);
+  const sameB = openAt(123_000);
+  const different = openAt(124_000);
+
+  assert.equal(sameA, sameB);
+  assert.ok(sameA >= TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS);
+  assert.ok(sameA <= TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS);
+  assert.ok(different >= TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS);
+  assert.ok(different <= TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS);
+  assert.notEqual(different, sameA);
+});
+
+test("Takeout: catch-up processes whole hours only and caps at 12", () => {
+  const player = {
+    coins: 1_000,
+    takeout: createDefaultTakeoutState()
+  };
+  player.takeout.menu_recipe_ids = ["r1"];
+
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(open.ok, true);
+
+  const halfHour = processTakeoutCatchup(player, {
+    now: 30 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(halfHour.processedHours, 0);
+
+  const after13h = processTakeoutCatchup(player, {
+    now: 13 * 60 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(after13h.totalProcessedHours, 12);
+  assert.equal(player.takeout.shift.last_processed_hour_index, 12);
+  assert.equal(player.takeout.shift.status, "inactive");
+});
+
+test("Takeout: catch-up is deterministic for same snapshot and elapsed time", () => {
+  const buildPlayer = () => {
+    const p = { coins: 1_000, takeout: createDefaultTakeoutState() };
+    p.takeout.menu_recipe_ids = ["r1", "r2"];
+    const open = startTakeoutShiftWithCoverage(p, {
+      now: 0,
+      recipes: {
+        r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+        r2: { tier: "rare", ingredients: [{ item_id: "i2", qty: 1 }] }
+      },
+      marketPrices: { i1: 5, i2: 9 },
+      items: { i1: { base_price: 5 }, i2: { base_price: 9 } }
+    });
+    assert.equal(open.ok, true);
+    return p;
+  };
+
+  const p1 = buildPlayer();
+  const p2 = buildPlayer();
+
+  const r1 = processTakeoutCatchup(p1, {
+    now: 5 * 60 * 60 * 1000,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "rare", ingredients: [{ item_id: "i2", qty: 1 }] }
+    },
+    marketPrices: { i1: 5, i2: 9 },
+    items: { i1: { base_price: 5 }, i2: { base_price: 9 } }
+  });
+  const r2 = processTakeoutCatchup(p2, {
+    now: 5 * 60 * 60 * 1000,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "rare", ingredients: [{ item_id: "i2", qty: 1 }] }
+    },
+    marketPrices: { i1: 5, i2: 9 },
+    items: { i1: { base_price: 5 }, i2: { base_price: 9 } }
+  });
+
+  assert.equal(r1.earned, r2.earned);
+  assert.equal(p1.takeout.earned_unclaimed_coins, p2.takeout.earned_unclaimed_coins);
+  assert.equal(p1.takeout.shift.last_processed_hour_index, p2.takeout.shift.last_processed_hour_index);
+});
+
+test("Takeout: catch-up does not double-process repeated calls", () => {
+  const player = { coins: 1_000, takeout: createDefaultTakeoutState() };
+  player.takeout.menu_recipe_ids = ["r1"];
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(open.ok, true);
+
+  const first = processTakeoutCatchup(player, {
+    now: 3 * 60 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  const before = player.takeout.earned_unclaimed_coins;
+
+  const second = processTakeoutCatchup(player, {
+    now: 3 * 60 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  const after = player.takeout.earned_unclaimed_coins;
+
+  assert.ok(first.processedHours > 0);
+  assert.equal(second.processedHours, 0);
+  assert.equal(after, before);
+});


### PR DESCRIPTION
## Summary
- Add subscription state/lifecycle support for 24/7 House and Takeout Counter, including monthly grant/idempotency handling.
- Add takeout subsystem with menu setup, 12h idle shift snapshots, fixed upfront operating cost, deterministic hourly catch-up, and claim flow.
- Integrate command surfaces and telemetry hooks for takeout lifecycle and subscription state changes.
- Include focused regression tests for subscriptions and takeout behavior/determinism.

## Target Branch (Required)
- [x] Target is develop (feature/integration testing)
- [ ] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (`cleanstart` / `syncmain`).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [x] I rebased this branch on latest origin/develop.
- [x] This PR is intended for integration/QA testing, not direct production release.
- [x] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [ ] I rebased this branch on latest origin/main.
- [ ] This change is release-ready and already validated at appropriate level.
- [ ] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [x] Lint/type checks pass (if applicable).

Commands run:
```bash
npm run lint -- src/game/takeout.js src/commands/noodle.js test/takeout.test.js
npm test -- test/takeout.test.js test/subscriptions.test.js
# push hooks also ran full guard/test suite successfully (250 passing)
```

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

## Reviewer Notes
- Areas to focus on:
  - Unlimited-order snapshot sizing behavior (1000-2000 deterministic per shift seed).
  - Catch-up idempotency/determinism for repeated processing windows.
  - Command UX text and telemetry fields around takeout_open/takeout_claim.
- Known limitations:
  - Economy tuning may need follow-up after QA telemetry (range is intentionally high-variance).
- Follow-up work (if any):
  - Tune unlimited snapshot min/max based on QA economy results.

---

### Review Gate
Do not request review until all required checkboxes are complete.
If any box is intentionally unchecked, explain why in this PR description.

