### PR TITLE
Fix discovery/event UX, vote text, and targeted forage behavior

### DIFF
--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1692,8 +1692,16 @@ function ensureSeasonEventNoticeState(player) {
   return player.seasons.notice;
 }
 
+function getSeasonEventNoticeStateReadOnly(player) {
+  const notice = player?.seasons?.notice;
+  if (!notice || typeof notice !== "object") {
+    return { seen_season_id: null, seen_event_id: null };
+  }
+  return notice;
+}
+
 function getSeasonEventNavHighlights(player, serverState) {
-  const notice = ensureSeasonEventNoticeState(player);
+  const notice = getSeasonEventNoticeStateReadOnly(player);
   const activeSeasonId = String(serverState?.season ?? "").trim();
   const activeEventId = String(serverState?.active_event_id ?? "").trim();
   return {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7049,7 +7049,8 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
       drops[itemId] = (drops[itemId] ?? 0) + bonusItems;
     }
 
-    // Pity: guarantee a rare forage after 10 forages without any rare drop
+    // Pity: inject a rare at threshold, but only reset pity later if a rare survives
+    // capacity filtering and is actually accepted into rewards.
     const allowedRare = RARE_FORAGE_ITEM_IDS.filter((id) => allowedForage.has(id));
     applyForagePityCounter(p, drops, {
       allowedRare,

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -4,6 +4,7 @@ import { performance } from "node:perf_hooks";
 import {
   canForage,
   rollForageDrops,
+  applyForagePityCounter,
   applyDropsToInventory,
   setForageCooldown,
   FORAGE_ITEM_IDS,
@@ -7050,28 +7051,13 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
 
     // Pity: guarantee a rare forage after 10 forages without any rare drop
     const allowedRare = RARE_FORAGE_ITEM_IDS.filter((id) => allowedForage.has(id));
-    if (!itemId && allowedRare.length) {
-      const hasRareDrop = Object.keys(drops).some((id) => allowedRare.includes(id));
-      if (hasRareDrop) {
-        p.forage_pity_rare_count = 0;
-      } else {
-        p.forage_pity_rare_count = (p.forage_pity_rare_count || 0) + 1;
-        if (p.forage_pity_rare_count >= 10) {
-          const pityRng = makeStreamRng({
-            mode: "seeded",
-            seed: 98765,
-            streamName: "forage_pity",
-            serverId,
-            dayKey: dayKeyUTC(),
-            userId: interaction.user.id
-          });
-          const pickIdx = Math.floor(pityRng() * allowedRare.length);
-          const pityItem = allowedRare[Math.max(0, Math.min(allowedRare.length - 1, pickIdx))];
-          drops[pityItem] = (drops[pityItem] ?? 0) + 1;
-          p.forage_pity_rare_count = 0;
-        }
-      }
-    }
+    applyForagePityCounter(p, drops, {
+      allowedRare,
+      itemId,
+      serverId,
+      userId: interaction.user.id,
+      dayKey: dayKeyUTC()
+    });
     const capacityResult = applyIngredientCapacityToDrops(drops, p, combinedEffects, { allowDisplacingInventory: true });
     const { accepted, rejected, evicted } = capacityResult;
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -4936,7 +4936,7 @@ if (sub === "profile") {
 
 /* ---------------- ABOUT ---------------- */
 if (sub === "about") {
-  const viewerPlayer = getPlayerForReadOnlyNavState(serverId, userId);
+  const viewerPlayer = player ?? getPlayerForReadOnlyNavState(serverId, userId);
   const seasonEventHighlights = getSeasonEventNavHighlights(viewerPlayer, server);
   const liveServerCount = Number(interaction.client?.guilds?.cache?.size ?? 0);
   let liveShopCount = null;

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -2615,6 +2615,11 @@ function ensurePlayer(serverId, userId) {
   return p;
 }
 
+function getPlayerForReadOnlyNavState(serverId, userId) {
+  if (!db) return newPlayerProfile(userId);
+  return getPlayer(db, serverId, userId) || newPlayerProfile(userId);
+}
+
 function isTutorialStep(player, stepId) {
   return isTutorialStepFromRouting(player, stepId);
 }
@@ -4922,7 +4927,7 @@ if (sub === "profile") {
 
 /* ---------------- ABOUT ---------------- */
 if (sub === "about") {
-  const viewerPlayer = ensurePlayer(serverId, userId);
+  const viewerPlayer = getPlayerForReadOnlyNavState(serverId, userId);
   const seasonEventHighlights = getSeasonEventNavHighlights(viewerPlayer, server);
   const liveServerCount = Number(interaction.client?.guilds?.cache?.size ?? 0);
   let liveShopCount = null;

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7051,7 +7051,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
 
     // Pity: guarantee a rare forage after 10 forages without any rare drop
     const allowedRare = RARE_FORAGE_ITEM_IDS.filter((id) => allowedForage.has(id));
-    const injectedPityItemId = applyForagePityCounter(p, drops, {
+    applyForagePityCounter(p, drops, {
       allowedRare,
       itemId,
       serverId,
@@ -7081,7 +7081,8 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
       });
     }
 
-    if (injectedPityItemId && Number(accepted[injectedPityItemId] || 0) > 0) {
+    const hasAcceptedRare = Object.keys(accepted).some((id) => allowedRare.includes(id));
+    if (hasAcceptedRare) {
       p.forage_pity_rare_count = 0;
     }
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1657,7 +1657,7 @@ new ButtonBuilder().setCustomId(`noodle:nav:profile:${userId}`).setLabel("Back")
 );
 }
 
-function noodleAboutNewsNavRow(userId, { active = "news" } = {}) {
+function noodleAboutNewsNavRow(userId, { active = "news", seasonNew = false, eventNew = false } = {}) {
   return new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(`noodle:nav:news:${userId}`)
@@ -1673,13 +1673,49 @@ function noodleAboutNewsNavRow(userId, { active = "news" } = {}) {
       .setCustomId(`noodle:nav:season:${userId}`)
       .setLabel("Season")
       .setEmoji(getButtonEmoji("season"))
-      .setStyle(active === "season" ? ButtonStyle.Primary : ButtonStyle.Secondary),
+      .setStyle(active === "season" ? ButtonStyle.Primary : (seasonNew ? ButtonStyle.Success : ButtonStyle.Secondary)),
     new ButtonBuilder()
       .setCustomId(`noodle:nav:event:${userId}`)
       .setLabel("Event")
       .setEmoji(getButtonEmoji("event"))
-      .setStyle(active === "event" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setStyle(active === "event" ? ButtonStyle.Primary : (eventNew ? ButtonStyle.Success : ButtonStyle.Secondary))
   );
+}
+
+function ensureSeasonEventNoticeState(player) {
+  if (!player.seasons || typeof player.seasons !== "object") {
+    player.seasons = { last_seen: null, last_rewarded_from: null, last_rewarded_at: null };
+  }
+  if (!player.seasons.notice || typeof player.seasons.notice !== "object") {
+    player.seasons.notice = { seen_season_id: null, seen_event_id: null };
+  }
+  return player.seasons.notice;
+}
+
+function getSeasonEventNavHighlights(player, serverState) {
+  const notice = ensureSeasonEventNoticeState(player);
+  const activeSeasonId = String(serverState?.season ?? "").trim();
+  const activeEventId = String(serverState?.active_event_id ?? "").trim();
+  return {
+    seasonNew: Boolean(activeSeasonId) && notice.seen_season_id !== activeSeasonId,
+    eventNew: Boolean(activeEventId) && notice.seen_event_id !== activeEventId
+  };
+}
+
+function markSeasonNoticeSeen(player, serverState) {
+  const notice = ensureSeasonEventNoticeState(player);
+  const activeSeasonId = String(serverState?.season ?? "").trim();
+  if (!activeSeasonId || notice.seen_season_id === activeSeasonId) return false;
+  notice.seen_season_id = activeSeasonId;
+  return true;
+}
+
+function markEventNoticeSeen(player, serverState) {
+  const notice = ensureSeasonEventNoticeState(player);
+  const activeEventId = String(serverState?.active_event_id ?? "").trim();
+  if (!activeEventId || notice.seen_event_id === activeEventId) return false;
+  notice.seen_event_id = activeEventId;
+  return true;
 }
 
 function noodleAboutNewsBackRow(userId) {
@@ -4886,6 +4922,8 @@ if (sub === "profile") {
 
 /* ---------------- ABOUT ---------------- */
 if (sub === "about") {
+  const viewerPlayer = ensurePlayer(serverId, userId);
+  const seasonEventHighlights = getSeasonEventNavHighlights(viewerPlayer, server);
   const liveServerCount = Number(interaction.client?.guilds?.cache?.size ?? 0);
   let liveShopCount = null;
   if (db) {
@@ -4940,13 +4978,14 @@ if (sub === "about") {
   return commit({
     content: " ",
     embeds: [aboutEmbed],
-    components: [noodleAboutNewsNavRow(userId, { active: "about" }), aboutSupportRow]
+    components: [noodleAboutNewsNavRow(userId, { active: "about", ...seasonEventHighlights }), aboutSupportRow]
   });
 }
 
 /* ---------------- NEWS ---------------- */
 if (sub === "news") {
   const viewerPlayer = ensurePlayer(serverId, userId);
+  const seasonEventHighlights = getSeasonEventNavHighlights(viewerPlayer, server);
   if (db && markNewsAsSeen(viewerPlayer, newsContent)) {
     upsertPlayer(db, serverId, userId, viewerPlayer, null, viewerPlayer.schema_version);
   }
@@ -5105,7 +5144,7 @@ if (sub === "news") {
   return commit({
     content: " ",
     embeds: [newsEmbed],
-    components: [noodleAboutNewsNavRow(userId, { active: "news" }), noodleAboutNewsBackRow(userId)]
+    components: [noodleAboutNewsNavRow(userId, { active: "news", ...seasonEventHighlights }), noodleAboutNewsBackRow(userId)]
   });
 }
 
@@ -5901,6 +5940,11 @@ if (sub === "regulars") {
 /* ---------------- SEASON ---------------- */
 if (sub === "season") {
   const p = ensurePlayer(serverId, userId);
+  const seasonSeenChanged = markSeasonNoticeSeen(p, server);
+  if (seasonSeenChanged && db) {
+    upsertPlayer(db, serverId, userId, p, null, p.schema_version);
+  }
+  const seasonEventHighlights = getSeasonEventNavHighlights(p, server);
   const availableRecipes = getAvailableRecipes(p);
   const seasonalRecipes = Object.values(content.recipes ?? {})
     .filter((recipe) => recipe?.tier === "seasonal" && recipe?.season === server.season);
@@ -5984,7 +6028,7 @@ if (sub === "season") {
   return commit({
     content: " ",
     embeds: [seasonEmbed],
-    components: [noodleAboutNewsNavRow(userId, { active: "season" }), backRow]
+    components: [noodleAboutNewsNavRow(userId, { active: "season", ...seasonEventHighlights }), backRow]
   });
 }
 
@@ -5998,10 +6042,17 @@ if (sub === "status") {
     });
   }
   const statusEmbed = buildDevStatusEmbed();
+  const refreshRow = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`noodle-dev:status:refresh:${userId}`)
+      .setEmoji(getButtonEmoji("refresh"))
+      .setStyle(ButtonStyle.Secondary)
+  );
 
   return commit({
     content: " ",
     embeds: [statusEmbed],
+    components: [refreshRow],
     ephemeral: false
   });
 }
@@ -6009,6 +6060,11 @@ if (sub === "status") {
 /* ---------------- EVENT ---------------- */
 if (sub === "event") {
   const player = ensurePlayer(serverId, userId);
+  const eventSeenChanged = markEventNoticeSeen(player, server);
+  if (eventSeenChanged && db) {
+    upsertPlayer(db, serverId, userId, player, null, player.schema_version);
+  }
+  const seasonEventHighlights = getSeasonEventNavHighlights(player, server);
   const knownRecipeIds = new Set(getAvailableRecipes(player));
   const backRow = new ActionRowBuilder().addComponents(
     new ButtonBuilder().setCustomId(`noodle:nav:profile:${userId}`).setLabel("Back").setEmoji(getButtonEmoji("back")).setStyle(ButtonStyle.Secondary)
@@ -6089,7 +6145,7 @@ if (sub === "event") {
   return commit({
     content: " ",
     embeds: [eventEmbed],
-    components: [noodleAboutNewsNavRow(userId, { active: "event" }), backRow]
+    components: [noodleAboutNewsNavRow(userId, { active: "event", ...seasonEventHighlights }), backRow]
   });
 }
 
@@ -6981,7 +7037,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
 
     // Pity: guarantee a rare forage after 10 forages without any rare drop
     const allowedRare = RARE_FORAGE_ITEM_IDS.filter((id) => allowedForage.has(id));
-    if (allowedRare.length) {
+    if (!itemId && allowedRare.length) {
       const hasRareDrop = Object.keys(drops).some((id) => allowedRare.includes(id));
       if (hasRareDrop) {
         p.forage_pity_rare_count = 0;
@@ -9081,8 +9137,8 @@ ${lines.join("\n")}`;
         state.unlocked_spec_ids.push(spec.spec_id);
       }
       const unlockLines = newlyUnlockedSpecs.map((spec) => {
-        const icon = resolveIcon(spec.icon, getIcon("sparkle"));
-        return `${icon} **Specialization unlocked:** ${spec.name}`;
+        const bowlsRequired = Number(spec?.requirements?.bowls_served_total ?? 0);
+        return `**HIDDEN Specialization Unlocked for serving ${bowlsRequired.toLocaleString("en-US")} bowls: ${spec.name}**`;
       });
       results.push(...unlockLines);
     }
@@ -11140,7 +11196,7 @@ const noodleCommandData = new SlashCommandBuilder()
   .addSubcommand((sc) => sc.setName("quests").setDescription("View active quests."))
   .addSubcommand((sc) => sc.setName("quests_daily").setDescription("Claim your daily reward."))
   .addSubcommand((sc) => sc.setName("quests_claim").setDescription("Claim completed quest rewards."))
-  .addSubcommand((sc) => sc.setName("quests_vote").setDescription("View and claim bot-list vote rewards."))
+  .addSubcommand((sc) => sc.setName("quests_vote").setDescription("View and claim all bot list vote rewards."))
   .addSubcommand((sc) =>
     sc
       .setName("buy")

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7051,7 +7051,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
 
     // Pity: guarantee a rare forage after 10 forages without any rare drop
     const allowedRare = RARE_FORAGE_ITEM_IDS.filter((id) => allowedForage.has(id));
-    applyForagePityCounter(p, drops, {
+    const injectedPityItemId = applyForagePityCounter(p, drops, {
       allowedRare,
       itemId,
       serverId,
@@ -7079,6 +7079,10 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
         embeds: [forageFullEmbed],
         components: navRows
       });
+    }
+
+    if (injectedPityItemId && Number(accepted[injectedPityItemId] || 0) > 0) {
+      p.forage_pity_rare_count = 0;
     }
 
     const inventoryResult = applyDropsToInventory(p, accepted);

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -61,7 +61,7 @@ export const noodleDevCommand = {
     const parts = customId.split(":");
     if (parts[0] === "noodle-dev" && parts[1] === "status" && parts[2] === "refresh") {
       const ownerUserId = parts[3] ?? "";
-      if (ownerUserId && ownerUserId !== interaction.user.id) {
+      if (!ownerUserId || ownerUserId !== interaction.user.id) {
         return {
           content: "That status panel isn’t for you.",
           ephemeral: true

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -59,6 +59,17 @@ export const noodleDevCommand = {
   async handleComponent(interaction) {
     const customId = String(interaction.customId || "");
     const parts = customId.split(":");
+    if (parts[0] === "noodle-dev" && parts[1] === "status" && parts[2] === "refresh") {
+      const ownerUserId = parts[3] ?? "";
+      if (ownerUserId && ownerUserId !== interaction.user.id) {
+        return {
+          content: "That status panel isn’t for you.",
+          ephemeral: true
+        };
+      }
+      return runNoodle(interaction, { sub: "status", group: "dev" });
+    }
+
     // Legacy: noodle-dev:dashboard:page:<ownerUserId>:<tabPage>
     // New:    noodle-dev:dashboard:nav:<ownerUserId>:<tabPage>:<serverPage>
     if (parts[0] !== "noodle-dev" || parts[1] !== "dashboard") return null;

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -60,6 +60,10 @@ export const noodleDevCommand = {
     const denyOwnerMismatch = async (message) => {
       if (interaction.deferred || interaction.replied) {
         await interaction.followUp({ content: message, ephemeral: true });
+        if (interaction.deferred) {
+          // Clear the deferred "thinking" state without changing visible content.
+          await interaction.editReply({ components: interaction.message?.components ?? [] }).catch(() => null);
+        }
       } else {
         await interaction.reply({ content: message, ephemeral: true });
       }

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -57,15 +57,21 @@ export const noodleDevCommand = {
   },
 
   async handleComponent(interaction) {
+    const denyOwnerMismatch = async (message) => {
+      if (interaction.deferred || interaction.replied) {
+        await interaction.followUp({ content: message, ephemeral: true });
+      } else {
+        await interaction.reply({ content: message, ephemeral: true });
+      }
+      return null;
+    };
+
     const customId = String(interaction.customId || "");
     const parts = customId.split(":");
     if (parts[0] === "noodle-dev" && parts[1] === "status" && parts[2] === "refresh") {
       const ownerUserId = parts[3] ?? "";
       if (!ownerUserId || ownerUserId !== interaction.user.id) {
-        return {
-          content: "That status panel isn’t for you.",
-          ephemeral: true
-        };
+        return denyOwnerMismatch("That status panel isn’t for you.");
       }
       return runNoodle(interaction, { sub: "status", group: "dev" });
     }
@@ -81,10 +87,7 @@ export const noodleDevCommand = {
     const page = Number(parts[4] ?? 0);
     const serverPage = mode === "nav" ? Number(parts[5] ?? 0) : 0;
     if (ownerUserId && ownerUserId !== interaction.user.id) {
-      return {
-        content: "That dashboard isn’t for you.",
-        ephemeral: true
-      };
+      return denyOwnerMismatch("That dashboard isn’t for you.");
     }
 
     return runNoodle(interaction, {

--- a/src/game/discovery.js
+++ b/src/game/discovery.js
@@ -21,6 +21,12 @@ import { getIcon } from "../ui/icons.js";
 
 const LOCKED_FISHING_RECIPE_DISCOVERY_WEIGHT_MULT = 0.25;
 
+function isRecipeActiveForEvent(recipe, activeEventId) {
+  if (!recipe?.event_id) return true;
+  if (!activeEventId) return false;
+  return String(recipe.event_id) === String(activeEventId);
+}
+
 /**
  * Check if player can discover recipes of a given tier
  */
@@ -59,7 +65,7 @@ export function getDiscoverableRecipes(player, content, { excludeCompletedClues 
       if (clueCount >= CLUES_TO_UNLOCK_RECIPE) return false;
     }
     
-    if (recipe.event_id && (!activeEventId || recipe.event_id !== activeEventId)) {
+    if (!isRecipeActiveForEvent(recipe, activeEventId)) {
       return false;
     }
 
@@ -98,7 +104,7 @@ function pickDuplicateEligibleRecipe(player, content, rng, { mode = "clue", acti
   const candidates = allRecipes.filter((recipe) => {
     if (!recipe || recipe.recipe_id === FALLBACK_RECIPE_ID) return false;
     if (!ownedRecipeIds.has(recipe.recipe_id)) return false;
-    if (recipe.event_id && (!activeEventId || recipe.event_id !== activeEventId)) return false;
+    if (!isRecipeActiveForEvent(recipe, activeEventId)) return false;
     if (recipe.tier === "seasonal" && (!activeSeason || recipe.season !== activeSeason)) return false;
     if (!canDiscoverTier(player, recipe.tier)) return false;
     return true;

--- a/src/game/forage.js
+++ b/src/game/forage.js
@@ -147,7 +147,11 @@ export function applyForagePityCounter(player, drops, {
     return false;
   }
 
-  const hasRareDrop = Object.keys(drops || {}).some((id) => allowedRare.includes(id));
+  if (!drops || typeof drops !== "object") {
+    return false;
+  }
+
+  const hasRareDrop = Object.keys(drops).some((id) => allowedRare.includes(id));
   if (hasRareDrop) {
     player.forage_pity_rare_count = 0;
     return false;

--- a/src/game/forage.js
+++ b/src/game/forage.js
@@ -136,6 +136,43 @@ export function applyDropsToInventory(player, drops) {
   return result;
 }
 
+export function applyForagePityCounter(player, drops, {
+  allowedRare = [],
+  itemId = null,
+  serverId = "",
+  userId = "",
+  dayKey = dayKeyUTC()
+} = {}) {
+  if (itemId || !Array.isArray(allowedRare) || allowedRare.length === 0) {
+    return false;
+  }
+
+  const hasRareDrop = Object.keys(drops || {}).some((id) => allowedRare.includes(id));
+  if (hasRareDrop) {
+    player.forage_pity_rare_count = 0;
+    return false;
+  }
+
+  player.forage_pity_rare_count = (player.forage_pity_rare_count || 0) + 1;
+  if (player.forage_pity_rare_count < 10) {
+    return false;
+  }
+
+  const pityRng = makeStreamRng({
+    mode: "seeded",
+    seed: 98765,
+    streamName: "forage_pity",
+    serverId,
+    dayKey,
+    userId
+  });
+  const pickIdx = Math.floor(pityRng() * allowedRare.length);
+  const pityItem = allowedRare[Math.max(0, Math.min(allowedRare.length - 1, pickIdx))];
+  drops[pityItem] = (drops[pityItem] ?? 0) + 1;
+  player.forage_pity_rare_count = 0;
+  return true;
+}
+
 export function setForageCooldown(player, nowMs) {
   if (!player.cooldowns) player.cooldowns = {};
   player.cooldowns.forage_last_ms = nowMs;

--- a/src/game/forage.js
+++ b/src/game/forage.js
@@ -157,7 +157,8 @@ export function applyForagePityCounter(player, drops, {
     return false;
   }
 
-  player.forage_pity_rare_count = (player.forage_pity_rare_count || 0) + 1;
+  const currentPityCount = Math.max(0, Number(player.forage_pity_rare_count || 0));
+  player.forage_pity_rare_count = Math.min(10, currentPityCount + 1);
   if (player.forage_pity_rare_count < 10) {
     return false;
   }
@@ -173,8 +174,7 @@ export function applyForagePityCounter(player, drops, {
   const pickIdx = Math.floor(pityRng() * allowedRare.length);
   const pityItem = allowedRare[Math.max(0, Math.min(allowedRare.length - 1, pickIdx))];
   drops[pityItem] = (drops[pityItem] ?? 0) + 1;
-  player.forage_pity_rare_count = 0;
-  return true;
+  return pityItem;
 }
 
 export function setForageCooldown(player, nowMs) {

--- a/src/game/forage.js
+++ b/src/game/forage.js
@@ -153,7 +153,6 @@ export function applyForagePityCounter(player, drops, {
 
   const hasRareDrop = Object.keys(drops).some((id) => allowedRare.includes(id));
   if (hasRareDrop) {
-    player.forage_pity_rare_count = 0;
     return false;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1875,7 +1875,8 @@ import { theme } from "./ui/theme.js";
       }
 
       try {
-        const officialGuild = client.guilds.cache.get(officialGuildId)
+        const officialGuild = await client.guilds.fetch(officialGuildId, { force: true, withCounts: true }).catch(() => null)
+          || client.guilds.cache.get(officialGuildId)
           || await client.guilds.fetch(officialGuildId).catch(() => null);
         if (!officialGuild) return false;
 
@@ -1884,7 +1885,10 @@ import { theme } from "./ui/theme.js";
           : getCurrentBotListCounts();
         const serverCount = Math.max(0, Number(counts?.serverCount) || 0);
         const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
-        const officialMemberCount = Math.max(0, Number(officialGuild?.memberCount || 0));
+        const officialMemberCount = Math.max(
+          0,
+          Number(officialGuild?.memberCount || officialGuild?.approximateMemberCount || 0)
+        );
 
         if (
           isIntervalReason

--- a/src/index.js
+++ b/src/index.js
@@ -1875,9 +1875,8 @@ import { theme } from "./ui/theme.js";
       }
 
       try {
-        const officialGuild = await client.guilds.fetch(officialGuildId, { force: true, withCounts: true }).catch(() => null)
-          || client.guilds.cache.get(officialGuildId)
-          || await client.guilds.fetch(officialGuildId).catch(() => null);
+        const officialGuild = client.guilds.cache.get(officialGuildId)
+          || await client.guilds.fetch(officialGuildId, { force: true }).catch(() => null);
         if (!officialGuild) return false;
 
         const counts = precomputedCounts && typeof precomputedCounts === "object"
@@ -1887,7 +1886,7 @@ import { theme } from "./ui/theme.js";
         const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
         const officialMemberCount = Math.max(
           0,
-          Number(officialGuild?.memberCount ?? officialGuild?.approximateMemberCount ?? 0)
+          Number(officialGuild?.memberCount ?? 0)
         );
 
         if (

--- a/src/index.js
+++ b/src/index.js
@@ -1887,7 +1887,7 @@ import { theme } from "./ui/theme.js";
         const shopsCount = Math.max(0, Number(counts?.userCount) || 0);
         const officialMemberCount = Math.max(
           0,
-          Number(officialGuild?.memberCount || officialGuild?.approximateMemberCount || 0)
+          Number(officialGuild?.memberCount ?? officialGuild?.approximateMemberCount ?? 0)
         );
 
         if (

--- a/src/index.js
+++ b/src/index.js
@@ -1875,8 +1875,8 @@ import { theme } from "./ui/theme.js";
       }
 
       try {
-        const officialGuild = client.guilds.cache.get(officialGuildId)
-          || await client.guilds.fetch(officialGuildId, { force: true }).catch(() => null);
+        const officialGuild = await client.guilds.fetch(officialGuildId, { force: true }).catch(() => null)
+          || client.guilds.cache.get(officialGuildId);
         if (!officialGuild) return false;
 
         const counts = precomputedCounts && typeof precomputedCounts === "object"

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -122,6 +122,70 @@ test("Discovery: getDiscoverableRecipes - respects tier gating", () => {
   assert.ok(!recipeIds.includes("seasonal_ramen"), "Should not include seasonal recipe");
 });
 
+test("Discovery: getDiscoverableRecipes includes active event recipes alongside regular recipes", () => {
+  const content = {
+    recipes: {
+      regular_recipe: {
+        recipe_id: "regular_recipe",
+        name: "Regular Recipe",
+        tier: "common",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      active_event_recipe: {
+        recipe_id: "active_event_recipe",
+        name: "Active Event Recipe",
+        tier: "common",
+        event_id: "spring_blossoms",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      inactive_event_recipe: {
+        recipe_id: "inactive_event_recipe",
+        name: "Inactive Event Recipe",
+        tier: "common",
+        event_id: "summer_solstice",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      }
+    }
+  };
+
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: []
+  };
+
+  const discoverable = getDiscoverableRecipes(player, content, { activeEventId: "spring_blossoms" });
+  const recipeIds = discoverable.map((recipe) => recipe.recipe_id);
+
+  assert.ok(recipeIds.includes("regular_recipe"));
+  assert.ok(recipeIds.includes("active_event_recipe"));
+  assert.ok(!recipeIds.includes("inactive_event_recipe"));
+});
+
+test("Discovery: getDiscoverableRecipes matches active event id across string and numeric forms", () => {
+  const content = {
+    recipes: {
+      event_recipe: {
+        recipe_id: "event_recipe",
+        name: "Typed Event Recipe",
+        tier: "common",
+        event_id: 101,
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      }
+    }
+  };
+
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: []
+  };
+
+  const discoverable = getDiscoverableRecipes(player, content, { activeEventId: "101" });
+  assert.equal(discoverable.length, 1);
+  assert.equal(discoverable[0].recipe_id, "event_recipe");
+});
+
 test("Discovery: applyDiscovery - new clue is added", () => {
   const player = {
     clues_owned: {},
@@ -572,4 +636,52 @@ test("Discovery: serve scroll roll can produce duplicate even when undiscovered 
   const result = applyDiscovery(player, discoveries[0], content, () => 0.9);
   assert.equal(result.isDuplicate, true);
   assert.equal(result.reward, `+${SCROLL_DUPLICATE_COINS}c (duplicate scroll)`);
+});
+
+test("Discovery: active event recipe can drop as duplicate while regular discoveries still exist", () => {
+  const content = {
+    recipes: {
+      regular_unknown_recipe: {
+        recipe_id: "regular_unknown_recipe",
+        name: "Regular Unknown Recipe",
+        tier: "common",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      active_event_known_recipe: {
+        recipe_id: "active_event_known_recipe",
+        name: "Active Event Known Recipe",
+        tier: "common",
+        event_id: 7,
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      }
+    },
+    items: mockContent.items
+  };
+
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: ["active_event_known_recipe"],
+    clues_owned: {},
+    scrolls_owned: {},
+    coins: 100
+  };
+
+  const rng = () => 0;
+  const discoveries = rollRecipeDiscovery({
+    player,
+    content,
+    npcArchetype: null,
+    tier: "common",
+    rng,
+    activeEventId: "7"
+  });
+
+  assert.equal(discoveries.length, 1);
+  assert.equal(discoveries[0].type, "clue");
+  assert.equal(discoveries[0].recipeId, "active_event_known_recipe");
+
+  const result = applyDiscovery(player, discoveries[0], content, () => 0.9);
+  assert.equal(result.isDuplicate, true);
+  assert.equal(result.reward, `+${CLUE_DUPLICATE_COINS}c (duplicate clue)`);
 });

--- a/test/forage-fishing-cooldown-pity.test.js
+++ b/test/forage-fishing-cooldown-pity.test.js
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   canForage,
   rollForageDrops,
+  applyForagePityCounter,
   applyDropsToInventory,
   setForageCooldown,
   RARE_FORAGE_ITEM_IDS
@@ -18,15 +19,6 @@ import {
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
-}
-
-function applyForagePityCounter(player, drops, allowedRare) {
-  const hasRareDrop = Object.keys(drops).some((id) => allowedRare.includes(id));
-  if (hasRareDrop) {
-    player.forage_pity_rare_count = 0;
-  } else {
-    player.forage_pity_rare_count = (player.forage_pity_rare_count || 0) + 1;
-  }
 }
 
 function applyFishingPityCounter(player, drops, allowedRare) {
@@ -75,7 +67,7 @@ test("Forage success updates cooldown once and pity resets only on rare drops", 
 
   const beforeCooldown = player.cooldowns.forage_last_ms;
   const invResult = applyDropsToInventory(player, commonOnlyDrops);
-  applyForagePityCounter(player, commonOnlyDrops, allowedRare);
+  applyForagePityCounter(player, commonOnlyDrops, { allowedRare });
   setForageCooldown(player, now);
 
   assert.equal(invResult.success, true);
@@ -84,15 +76,12 @@ test("Forage success updates cooldown once and pity resets only on rare drops", 
   assert.notEqual(beforeCooldown, player.cooldowns.forage_last_ms);
   assert.equal(player.cooldowns.forage_last_ms, now);
 
-  applyForagePityCounter(player, withRareDrops, allowedRare);
+  applyForagePityCounter(player, withRareDrops, { allowedRare });
   assert.equal(player.forage_pity_rare_count, 0);
 });
 
-test("Specific forage target remains exact item even when pity threshold is reached", () => {
+test("Specific forage target roll returns only requested item", () => {
   const targetItem = "scallions";
-  const player = {
-    forage_pity_rare_count: 9
-  };
 
   const drops = rollForageDrops({
     serverId: "srv-test",
@@ -109,13 +98,26 @@ test("Specific forage target remains exact item even when pity threshold is reac
   assert.deepEqual(Object.keys(drops), [targetItem]);
   assert.equal(hasRareDrop, false);
   assert.equal(drops[targetItem], 1);
+});
 
-  // Command-level targeted path should skip pity processing entirely.
-  const itemId = targetItem;
-  if (!itemId && allowedRare.length) {
-    applyForagePityCounter(player, drops, allowedRare);
-  }
+test("Targeted forage skips pity counter and does not inject rare drops", () => {
+  const targetItem = "scallions";
+  const allowedRare = [...RARE_FORAGE_ITEM_IDS];
+  const player = { forage_pity_rare_count: 9 };
+  const drops = { [targetItem]: 1 };
+
+  const appliedRare = applyForagePityCounter(player, drops, {
+    allowedRare,
+    itemId: targetItem,
+    serverId: "srv-test",
+    userId: "user-test",
+    dayKey: "2099-01-01"
+  });
+
+  assert.equal(appliedRare, false);
   assert.equal(player.forage_pity_rare_count, 9);
+  assert.deepEqual(Object.keys(drops), [targetItem]);
+  assert.equal(drops[targetItem], 1);
 });
 
 test("Fishing cooldown block does not mutate reward state", () => {

--- a/test/forage-fishing-cooldown-pity.test.js
+++ b/test/forage-fishing-cooldown-pity.test.js
@@ -120,6 +120,37 @@ test("Targeted forage skips pity counter and does not inject rare drops", () => 
   assert.equal(drops[targetItem], 1);
 });
 
+test("Pity injection keeps counter primed until injected rare is accepted", () => {
+  const allowedRare = [...RARE_FORAGE_ITEM_IDS];
+  const player = { forage_pity_rare_count: 9 };
+  const drops = { carrots: 1 };
+
+  const injectedPityItemId = applyForagePityCounter(player, drops, {
+    allowedRare,
+    serverId: "srv-test",
+    userId: "user-test",
+    dayKey: "2099-01-01"
+  });
+
+  assert.ok(injectedPityItemId);
+  assert.equal(player.forage_pity_rare_count, 10);
+  assert.equal(Number(drops[injectedPityItemId] || 0) >= 1, true);
+
+  // Simulate command-level capacity filtering rejecting the injected pity item.
+  const accepted = {};
+  if (injectedPityItemId && Number(accepted[injectedPityItemId] || 0) > 0) {
+    player.forage_pity_rare_count = 0;
+  }
+  assert.equal(player.forage_pity_rare_count, 10);
+
+  // Simulate a later run where the injected pity item survives filtering.
+  accepted[injectedPityItemId] = 1;
+  if (injectedPityItemId && Number(accepted[injectedPityItemId] || 0) > 0) {
+    player.forage_pity_rare_count = 0;
+  }
+  assert.equal(player.forage_pity_rare_count, 0);
+});
+
 test("Fishing cooldown block does not mutate reward state", () => {
   const now = 3_000_000;
   const player = {

--- a/test/forage-fishing-cooldown-pity.test.js
+++ b/test/forage-fishing-cooldown-pity.test.js
@@ -76,7 +76,13 @@ test("Forage success updates cooldown once and pity resets only on rare drops", 
   assert.notEqual(beforeCooldown, player.cooldowns.forage_last_ms);
   assert.equal(player.cooldowns.forage_last_ms, now);
 
+  // Helper should not reset until a rare is actually accepted post-filtering.
   applyForagePityCounter(player, withRareDrops, { allowedRare });
+  assert.equal(player.forage_pity_rare_count, 6);
+  const accepted = withRareDrops;
+  if (Object.keys(accepted).some((id) => allowedRare.includes(id))) {
+    player.forage_pity_rare_count = 0;
+  }
   assert.equal(player.forage_pity_rare_count, 0);
 });
 
@@ -149,6 +155,22 @@ test("Pity injection keeps counter primed until injected rare is accepted", () =
     player.forage_pity_rare_count = 0;
   }
   assert.equal(player.forage_pity_rare_count, 0);
+});
+
+test("Rare in raw drops does not reset pity when capacity filtering rejects it", () => {
+  const allowedRare = [...RARE_FORAGE_ITEM_IDS];
+  const rareDropId = allowedRare[0];
+  const player = { forage_pity_rare_count: 4 };
+  const drops = { [rareDropId]: 1 };
+
+  applyForagePityCounter(player, drops, { allowedRare });
+  assert.equal(player.forage_pity_rare_count, 4);
+
+  const accepted = {};
+  if (Object.keys(accepted).some((id) => allowedRare.includes(id))) {
+    player.forage_pity_rare_count = 0;
+  }
+  assert.equal(player.forage_pity_rare_count, 4);
 });
 
 test("Fishing cooldown block does not mutate reward state", () => {

--- a/test/forage-fishing-cooldown-pity.test.js
+++ b/test/forage-fishing-cooldown-pity.test.js
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   canForage,
+  rollForageDrops,
   applyDropsToInventory,
   setForageCooldown,
   RARE_FORAGE_ITEM_IDS
@@ -85,6 +86,36 @@ test("Forage success updates cooldown once and pity resets only on rare drops", 
 
   applyForagePityCounter(player, withRareDrops, allowedRare);
   assert.equal(player.forage_pity_rare_count, 0);
+});
+
+test("Specific forage target remains exact item even when pity threshold is reached", () => {
+  const targetItem = "scallions";
+  const player = {
+    forage_pity_rare_count: 9
+  };
+
+  const drops = rollForageDrops({
+    serverId: "srv-test",
+    userId: "user-test",
+    itemId: targetItem,
+    quantity: 1,
+    allowedItemIds: [targetItem, ...RARE_FORAGE_ITEM_IDS]
+  });
+
+  const allowedRare = [...RARE_FORAGE_ITEM_IDS];
+  const hasRareDrop = Object.keys(drops).some((id) => allowedRare.includes(id));
+
+  // Targeted foraging should only return the requested ingredient.
+  assert.deepEqual(Object.keys(drops), [targetItem]);
+  assert.equal(hasRareDrop, false);
+  assert.equal(drops[targetItem], 1);
+
+  // Command-level targeted path should skip pity processing entirely.
+  const itemId = targetItem;
+  if (!itemId && allowedRare.length) {
+    applyForagePityCounter(player, drops, allowedRare);
+  }
+  assert.equal(player.forage_pity_rare_count, 9);
 });
 
 test("Fishing cooldown block does not mutate reward state", () => {


### PR DESCRIPTION
## Summary
- Add dev status refresh button (emoji-only).
- Update hidden specialization unlock wording.
- Keep season/event buttons green until viewed for current cycle.
- Update /noodle quests_vote description to all bot list vote rewards.
- Improve official server member count refresh reliability.
- Prevent targeted forage from adding pity rare items.
- Harden discovery event-id matching and add regression tests.

## Target Branch (Required)
- [ ] Target is develop (feature/integration testing)
- [x] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (cleanstart / syncmain).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [ ] I rebased this branch on latest origin/develop.
- [ ] This PR is intended for integration/QA testing, not direct production release.
- [ ] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [x] I rebased this branch on latest origin/main.
- [x] This change is release-ready and already validated at appropriate level.
- [x] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [x] Lint/type checks pass (if applicable).

Commands run:
```bash
npm test -- test/forage-fishing-cooldown-pity.test.js test/discovery.test.js
# pass (31/31)

npx eslint src/commands/noodle.js src/commands/noodleDev.js src/game/discovery.js src/index.js test/discovery.test.js test/forage-fishing-cooldown-pity.test.js
# pass (no lint errors)
```

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

## Reviewer Notes
- Areas to focus on: event discovery eligibility, season/event unread highlight reset, targeted forage exact-item behavior, official member count refresh path.
- Known limitations: none identified in current scope.
- Follow-up work (if any): subscription-focused changes remain on develop and are intentionally excluded from this PR.

---

### Review Gate
Do not request review until all required checkboxes are complete.
If any box is intentionally unchecked, explain why in this PR description.
