### PR TITLE
Hotfix: party invite scope + dev repair_party integrity fixer

### DIFF
--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -87,7 +87,7 @@ import {
   normalizeNewsClassification,
 } from "../util/news.js";
 import { socialMainMenuRow, socialMainMenuRowNoProfile } from "./noodleSocial.js";
-import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS } from "../game/social.js";
+import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS, repairPartyRecord } from "../game/social.js";
 import {
   applyResilienceMechanics,
   getAvailableRecipes,
@@ -4441,7 +4441,7 @@ return componentCommit(interaction, payload);
 
 try {
 const owner = `discord:${interaction.id}`;
-const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "dashboard";
+const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "repair_party" || sub === "dashboard";
 const inDevPath = group === "dev" || isDevSubcommand;
 
 const buildDevStatusEmbed = () => {
@@ -4727,6 +4727,66 @@ if (inDevPath && sub === "repair_profile") {
       ],
       ephemeral: true
     });
+  });
+}
+
+if (inDevPath && sub === "repair_party") {
+  const partyIdInput = opt.getString("party_id")?.trim();
+  const targetServerId = opt.getString("server_id")?.trim() || serverId;
+
+  if (!partyIdInput) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Provide a party ID or prefix to repair.", isError: true })],
+      ephemeral: true
+    });
+  }
+  if (!db) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Database unavailable in this environment.", isError: true })],
+      ephemeral: true
+    });
+  }
+
+  const lockKey = `lock:party:${targetServerId}:${partyIdInput}`;
+  return await withLock(db, lockKey, owner, 8000, async () => {
+    try {
+      const result = repairPartyRecord(db, partyIdInput, targetServerId);
+      const summary = [
+        `Party: ${result.partyId} (server ${result.serverId})`,
+        `Status: ${result.statusBefore} -> ${result.statusAfter}`,
+        `Leader: <@${result.leaderBefore}> -> <@${result.leaderAfter}>`,
+        `Active members: ${result.activeMemberCount}`
+      ];
+
+      if (result.repaired) {
+        summary.push(`Applied fixes: ${result.changes.join(", ")}`);
+        return commit({
+          content: " ",
+          embeds: [buildDevMessageEmbed({ message: `${getIcon("status_complete")} ${summary.join("\n")}` })],
+          ephemeral: true
+        });
+      }
+
+      summary.push("No repair needed.");
+      return commit({
+        content: " ",
+        embeds: [buildDevMessageEmbed({ message: `${getIcon("status_complete")} ${summary.join("\n")}` })],
+        ephemeral: true
+      });
+    } catch (err) {
+      return commit({
+        content: " ",
+        embeds: [
+          buildDevMessageEmbed({
+            message: `${getIcon("error")} Party repair failed: ${err?.message || "unknown error"}`,
+            isError: true
+          })
+        ],
+        ephemeral: true
+      });
+    }
   });
 }
 

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -47,6 +47,23 @@ const noodleDevData = new SlashCommandBuilder()
           .setDescription("Force repair even if global profile score is not lower")
           .setRequired(false)
       )
+  )
+  .addSubcommand((sc) =>
+    sc
+      .setName("repair_party")
+      .setDescription("Dev only.")
+      .addStringOption((o) =>
+        o
+          .setName("party_id")
+          .setDescription("Party ID or prefix (e.g. first 8 chars)")
+          .setRequired(true)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("server_id")
+          .setDescription("Override server ID (defaults to current guild)")
+          .setRequired(false)
+      )
   );
 
 export const noodleDevCommand = {

--- a/src/commands/noodleSocial.js
+++ b/src/commands/noodleSocial.js
@@ -1216,7 +1216,7 @@ async function handleParty(interaction) {
       }
 
       // Check if already in a party
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (currentParty) {
         return { ok: false, error: `${getIcon("error")} You're already in party **${currentParty.party_name}**. Leave it first to create a new one.` };
       }
@@ -1271,7 +1271,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "leave") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1302,7 +1302,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "info") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1335,7 +1335,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "rename") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1364,7 +1364,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "transfer_leader") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1430,7 +1430,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "kick") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1792,7 +1792,7 @@ async function handleStats(interaction) {
     const player = ensurePlayer(serverId, userId);
     touchLastKitchen(player, serverId, channelId, userId);
     const tipStats = getUserTipStats(db, serverId, userId);
-    const party = getUserActiveParty(db, userId);
+    const party = getUserActiveParty(db, userId, serverId);
     const blessing = getActiveBlessing(player);
 
     const embed = new EmbedBuilder()
@@ -2115,7 +2115,7 @@ async function handleComponent(interaction) {
             }
             noteRecentSocialUser(serverId, targetId);
 
-            const party = getUserActiveParty(db, userId);
+            const party = getUserActiveParty(db, userId, serverId);
             const isLeader = party?.leader_user_id === userId;
             const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
             const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2195,7 +2195,7 @@ async function handleComponent(interaction) {
             }
             noteRecentSocialUser(serverId, targetId);
 
-            const party = getUserActiveParty(db, userId);
+            const party = getUserActiveParty(db, userId, serverId);
             const isLeader = party?.leader_user_id === userId;
             const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
             const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2287,7 +2287,7 @@ async function handleComponent(interaction) {
             };
             const blessingName = blessingNames[blessingType] || blessingType;
 
-            const party = getUserActiveParty(db, userId);
+            const party = getUserActiveParty(db, userId, serverId);
             const isLeader = party?.leader_user_id === userId;
             const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
             const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2379,7 +2379,7 @@ async function handleComponent(interaction) {
       }
       const lockedResult = await withLock(db, `lock:user:${userId}`, ownerLock, 8000, async () => {
         try {
-          const party = getUserActiveParty(db, userId);
+          const party = getUserActiveParty(db, userId, serverId);
           if (!party) {
             return { ok: false, payload: { content: `${getIcon("error")} You're not in a party.`, ephemeral: true } };
           }
@@ -2628,7 +2628,7 @@ async function handleComponent(interaction) {
               };
               const blessingName = blessingNames[blessingType] || blessingType;
 
-              const party = getUserActiveParty(db, userId);
+              const party = getUserActiveParty(db, userId, serverId);
               const isLeader = party?.leader_user_id === userId;
               const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
               const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2672,7 +2672,7 @@ async function handleComponent(interaction) {
         const ownerLock = `discord:${interaction.id}`;
         const lockedResult = await withLock(db, `lock:user:${userId}`, ownerLock, 8000, async () => {
           try {
-            const currentParty = getUserActiveParty(db, userId);
+            const currentParty = getUserActiveParty(db, userId, serverId);
             if (!currentParty) {
               return { ok: false, payload: { content: `${getIcon("error")} You're not in any party.`, ephemeral: true } };
             }
@@ -2724,7 +2724,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_recipe") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -2806,7 +2806,7 @@ async function handleComponent(interaction) {
 
       const lockedResult = await withLock(db, `lock:user:${userId}`, ownerLock, 8000, async () => {
         try {
-          const party = getUserActiveParty(db, userId);
+          const party = getUserActiveParty(db, userId, serverId);
           if (!party) {
             return { ok: false, payload: { content: `${getIcon("error")} You're not in a party.`, ephemeral: true } };
           }
@@ -2888,7 +2888,7 @@ async function handleComponent(interaction) {
         return componentCommit(interaction, { content: `${getIcon("error")} Invalid selection.`, ephemeral: true });
       }
 
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, { content: `${getIcon("error")} You're not in a party.`, ephemeral: true });
       }
@@ -2971,7 +2971,7 @@ async function handleComponent(interaction) {
       if (!db) {
         return componentCommit(interaction, { content: "Database unavailable in this environment.", ephemeral: true });
       }
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         const embed = new EmbedBuilder()
           .setTitle(`${getIcon("party")} Party`)
@@ -3032,7 +3032,7 @@ async function handleComponent(interaction) {
       const player = ensurePlayer(serverId, userId);
       const newsAvailable = hasUnreadNewsUpdate(player, newsContent);
       const tipStats = getUserTipStats(db, serverId, userId);
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       const blessing = getActiveBlessing(player);
 
       const embed = new EmbedBuilder()
@@ -3150,7 +3150,7 @@ async function handleComponent(interaction) {
     if (action === "profile") {
       const player = ensurePlayer(serverId, userId);
       const server = ensureServer(serverId);
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       const questsAvailable = hasDailyRewardAvailable(player, nowTs())
         || Object.values(player?.quests?.active ?? {}).some((quest) => quest?.completed_at && !quest?.claimed_at);
       const specializationsAvailable = hasNewShopLevelSpecialization(player, specializationsContent);
@@ -3245,7 +3245,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3328,7 +3328,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_refresh") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3407,7 +3407,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_create") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3475,7 +3475,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_info") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in any party.`,
@@ -3505,7 +3505,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_leave") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in any party.`,
@@ -3529,7 +3529,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_invite") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in any party.`,
@@ -3559,7 +3559,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_contribute") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3651,7 +3651,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_complete") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3733,7 +3733,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_cancel") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3797,7 +3797,7 @@ async function handleComponent(interaction) {
       }
 
       const targetMessageId = interaction.message?.id ?? null;
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3946,7 +3946,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_cancel_complete") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3977,7 +3977,7 @@ async function handleComponent(interaction) {
       if (!db) {
         return componentCommit(interaction, { content: "Database unavailable in this environment.", ephemeral: true });
       }
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -4049,7 +4049,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_abort_cancel") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -4087,7 +4087,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_create") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're already in party **${currentParty.party_name}**. Leave it first to create a new one.`,
@@ -4130,7 +4130,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_join") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're already in party **${currentParty.party_name}**. Leave it first to join another.`,

--- a/src/game/social.js
+++ b/src/game/social.js
@@ -305,6 +305,95 @@ export function getParty(db, partyId) {
 }
 
 /**
+ * Repair party integrity for a party id (or id prefix) in a server.
+ * Fixes:
+ * 1) Leader is not an active member.
+ * 2) Party status and active-member rows are inconsistent.
+ */
+export function repairPartyRecord(db, partyIdPrefix, serverId = null) {
+  const normalizedPrefix = String(partyIdPrefix ?? "").trim();
+  if (!normalizedPrefix) {
+    throw new Error("Party ID is required");
+  }
+
+  const lookupSql = serverId
+    ? "SELECT * FROM guild_parties WHERE party_id LIKE ? AND server_id = ? ORDER BY created_at DESC"
+    : "SELECT * FROM guild_parties WHERE party_id LIKE ? ORDER BY created_at DESC";
+  const matches = serverId
+    ? db.prepare(lookupSql).all(`${normalizedPrefix}%`, serverId)
+    : db.prepare(lookupSql).all(`${normalizedPrefix}%`);
+
+  if (!matches.length) {
+    throw new Error("Party not found");
+  }
+  if (matches.length > 1) {
+    throw new Error("Party ID prefix is ambiguous");
+  }
+
+  const now = nowTs();
+  const initial = matches[0];
+
+  const repairResult = db.transaction(() => {
+    let party = db.prepare("SELECT * FROM guild_parties WHERE party_id = ?").get(initial.party_id);
+    const members = db.prepare(
+      "SELECT user_id, joined_at FROM party_members WHERE party_id = ? AND left_at IS NULL ORDER BY joined_at, user_id"
+    ).all(initial.party_id);
+
+    const updates = [];
+    const activeMemberIds = new Set(members.map((m) => m.user_id));
+
+    const statusBefore = party.status;
+    const leaderBefore = party.leader_user_id;
+
+    if (party.status === "active" && members.length === 0) {
+      db.prepare("UPDATE guild_parties SET status = 'disbanded', disbanded_at = COALESCE(disbanded_at, ?) WHERE party_id = ?")
+        .run(now, party.party_id);
+      updates.push("status:active_to_disbanded");
+      party = { ...party, status: "disbanded", disbanded_at: party.disbanded_at ?? now };
+    } else if (party.status !== "active" && members.length > 0) {
+      db.prepare("UPDATE guild_parties SET status = 'active', disbanded_at = NULL WHERE party_id = ?")
+        .run(party.party_id);
+      updates.push("status:non_active_to_active");
+      party = { ...party, status: "active", disbanded_at: null };
+    }
+
+    if (party.status === "active" && party.disbanded_at != null) {
+      db.prepare("UPDATE guild_parties SET disbanded_at = NULL WHERE party_id = ?")
+        .run(party.party_id);
+      updates.push("disbanded_at:cleared_for_active");
+      party = { ...party, disbanded_at: null };
+    } else if (party.status !== "active" && party.disbanded_at == null) {
+      db.prepare("UPDATE guild_parties SET disbanded_at = ? WHERE party_id = ?")
+        .run(now, party.party_id);
+      updates.push("disbanded_at:set_for_inactive");
+      party = { ...party, disbanded_at: now };
+    }
+
+    if (party.status === "active" && members.length > 0 && !activeMemberIds.has(party.leader_user_id)) {
+      const newLeaderId = members[0].user_id;
+      db.prepare("UPDATE guild_parties SET leader_user_id = ? WHERE party_id = ?")
+        .run(newLeaderId, party.party_id);
+      updates.push("leader:reassigned_to_active_member");
+      party = { ...party, leader_user_id: newLeaderId };
+    }
+
+    return {
+      partyId: party.party_id,
+      serverId: party.server_id,
+      repaired: updates.length > 0,
+      changes: updates,
+      statusBefore,
+      statusAfter: party.status,
+      leaderBefore,
+      leaderAfter: party.leader_user_id,
+      activeMemberCount: members.length
+    };
+  })();
+
+  return repairResult;
+}
+
+/**
  * Get user's active party
  */
 export function getUserActiveParty(db, userId, serverId = null) {

--- a/test/social.test.js
+++ b/test/social.test.js
@@ -27,6 +27,7 @@ import {
   inviteUserToParty,
   leaveParty,
   getParty,
+  repairPartyRecord,
   getUserActiveParty,
   transferTip,
   getUserTipStats,
@@ -235,6 +236,54 @@ test("Party: getUserActiveParty can be scoped by server", dbTestOpts, () => {
 
   const invited = inviteUserToParty(db, "server2", server2Party.partyId, "user2");
   assert.equal(invited.partyId, server2Party.partyId);
+
+  db.close();
+});
+
+test("Party: repair reassigns leader when leader is not active member", dbTestOpts, () => {
+  const db = setupTestDb();
+  const { partyId } = createParty(db, "server1", "leader1", "Test Party");
+  joinParty(db, "server1", partyId, "user2");
+
+  // Create an inconsistent party: active party but inactive leader membership row.
+  db.prepare("UPDATE party_members SET left_at = ? WHERE party_id = ? AND user_id = ?")
+    .run(nowTs(), partyId, "leader1");
+
+  const repaired = repairPartyRecord(db, partyId, "server1");
+  const party = getParty(db, partyId);
+
+  assert.equal(repaired.repaired, true);
+  assert.ok(repaired.changes.includes("leader:reassigned_to_active_member"));
+  assert.equal(party.leader_user_id, "user2");
+  assert.equal(party.status, "active");
+
+  db.close();
+});
+
+test("Party: repair aligns party status with member rows", dbTestOpts, () => {
+  const db = setupTestDb();
+
+  // Active party with no active members should become disbanded.
+  const p1 = createParty(db, "server1", "leaderA", "Active No Members");
+  db.prepare("UPDATE party_members SET left_at = ? WHERE party_id = ?")
+    .run(nowTs(), p1.partyId);
+  const repaired1 = repairPartyRecord(db, p1.partyId, "server1");
+  const party1 = getParty(db, p1.partyId);
+
+  assert.equal(repaired1.repaired, true);
+  assert.equal(party1.status, "disbanded");
+  assert.ok(party1.disbanded_at);
+
+  // Disbanded party with active members should become active.
+  const p2 = createParty(db, "server1", "leaderB", "Disbanded With Members");
+  db.prepare("UPDATE guild_parties SET status = 'disbanded', disbanded_at = ? WHERE party_id = ?")
+    .run(nowTs(), p2.partyId);
+  const repaired2 = repairPartyRecord(db, p2.partyId, "server1");
+  const party2 = getParty(db, p2.partyId);
+
+  assert.equal(repaired2.repaired, true);
+  assert.equal(party2.status, "active");
+  assert.equal(party2.disbanded_at, null);
 
   db.close();
 });


### PR DESCRIPTION
## Summary
- Fix party invite/leader checks by scoping active party lookups to current server in social command flows.
- Add `/noodle-dev repair_party` to auto-fix broken party records when:
  - leader_user_id is not an active member
  - party status and active member rows are inconsistent
- Add social tests for new party repair behavior.

## Target Branch (Required)
- [ ] Target is develop (feature/integration testing)
- [x] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (`cleanstart` / `syncmain`).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [ ] I rebased this branch on latest origin/develop.
- [ ] This PR is intended for integration/QA testing, not direct production release.
- [ ] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [x] I rebased this branch on latest origin/main.
- [x] This change is release-ready and already validated at appropriate level.
- [x] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [ ] Lint/type checks pass (if applicable).

Commands run:
```bash
git worktree add /workspaces/noodle-story-bot-hotfix -b hotfix/party-invite-repair origin/main
npm run -s check:syntax
node --test test/social.test.js
```

Lint note: `eslint` is not installed in this container/worktree (`sh: 1: eslint: not found`).

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

## Reviewer Notes
- Areas to focus on:
  - Server-scoped party lookup changes in `src/commands/noodleSocial.js`
  - Repair invariants in `repairPartyRecord` and command handler in `src/commands/noodle.js`
- Known limitations:
  - `repair_party` requires server-scoped lookup if short IDs are ambiguous across servers.
- Follow-up work (if any):
  - Optionally add telemetry for repair invocations.

---

### Review Gate
Do not request review until all required checkboxes are complete.
If any box is intentionally unchecked, explain why in this PR description.
