### PR TITLE
feat: subscription rewards, coin packs, and giveaway winner upgrades

### DIFF
--- a/.github/workflows/register-commands.yml
+++ b/.github/workflows/register-commands.yml
@@ -3,6 +3,14 @@ name: Register Slash Commands
 on:
   workflow_dispatch:
     inputs:
+      bot:
+        description: "Bot profile"
+        required: true
+        default: "main"
+        type: choice
+        options:
+          - main
+          - tester
       mode:
         description: "Registration mode"
         required: true
@@ -19,6 +27,7 @@ on:
 jobs:
   register:
     runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.bot == 'tester' && 'staging' || 'production' }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
@@ -34,10 +43,21 @@ jobs:
             echo "guild input is required when mode=guild"
             exit 1
           fi
+      - name: Validate bot credentials
+        env:
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}
+        run: |
+          if [ -z "$DISCORD_TOKEN" ] || [ -z "$DISCORD_CLIENT_ID" ]; then
+            echo "Missing DISCORD_TOKEN or DISCORD_CLIENT_ID for selected bot profile '${{ github.event.inputs.bot }}'."
+              echo "Expected environment secrets in: ${{ github.event.inputs.bot == 'tester' && 'staging' || 'production' }}"
+            echo "Create/update environment-scoped secrets named DISCORD_TOKEN and DISCORD_CLIENT_ID."
+            exit 1
+          fi
       - name: Register
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}
           DISCORD_GUILD_ID: ${{ github.event.inputs.mode == 'guild' && github.event.inputs.guild || '' }}
-          NODE_ENV: ${{ secrets.NODE_ENV || 'development' }}
+          NODE_ENV: ${{ secrets.NODE_ENV || (github.event.inputs.bot == 'main' && 'production' || 'development') }}
         run: node src/register-commands.js

--- a/content/icons.json
+++ b/content/icons.json
@@ -221,6 +221,8 @@
     },
     "shop_profile": {
       "profile": "<:profile:1470315766652866591>",
+      "perk_house_247": "<:247House:1511430307637629041>",
+      "perk_takeout_counter": "<:TakeoutCounter:1511430310317916202>",
       "decor": "<:decor:1470315760990814259>",
       "customize": "<:customize:1470315759124217907>",
       "tag": "<:tag:1470315777084358760>",

--- a/content/news.json
+++ b/content/news.json
@@ -29,7 +29,7 @@
     "version": "0.4.0",
     "date": "2026-06-02",
     "classification": "player_update",
-    "summary": "Released premium perks and coin packs, plus official server giveaways and discovery/takeout reliability fixes."
+    "summary": "Big upgrade for your noodle shop: new premium perks, instant coin packs, and smoother takeout + discovery gameplay so you can earn more with less friction."
   },
   "sections": [
     {
@@ -40,10 +40,10 @@
           "date": "2026-06-02",
           "classification": "player_update",
           "changes": [
-            "Launched premium perks: **24/7 House** (expanded order capacity + unlimited market stock behavior) and **Take Out Counter** (idle shift earnings).",
-            "Added coin-pack support across Discord SKU purchases and Stripe checkout metadata so rewards grant coins automatically.",
-            "Upgraded giveaway winner dev rewards to grant **Perks**, **Coin Packs**, or any direct **Coins** amount.",
-            "Improved reliability in takeout menu selection limits and coin-pack metadata resolution, with added regression coverage."
+            "New premium perks are now live: **24/7 House** helps you keep your shop rolling, and **Take Out Counter** lets you keep earning even while you're away.",
+            "3 new coin packs are available for players who want a fast boost and more freedom to upgrade their shop their way.",
+            "Official giveaways are live in the Official Server, with flexible prizes including server xp, perks, coin packs, and direct coin drops.",
+            "Takeout and discovery flows were polished to feel smoother and more consistent, so your progress feels better session after session."
           ]
         }
       ]
@@ -86,8 +86,11 @@
     {
       "title": "Upcoming Updates",
       "items": [
-        "**Support Server Giveaways** are coming with NEW *clueboxes* that contain recipe clues!",
-        "**Noodle A Day** is on the way: a cozy daily noodle image posted in your channel of choice."
+        "**Daily Menu Customization** is coming soon so you can set your shop's lineup your way.",
+        "A one-tap **Cook All** button is on the way to prep bowls for your accepted orders faster.",
+        "**Achievements** are coming: track milestones, show off your progress, and earn rewards as your shop grows.",
+        "**Noodle A Day** is on the way: a cozy daily noodle image posted in your channel of choice.",
+        "A polished UI refresh is coming soon with cleaner menus, clearer actions, and smoother navigation."
       ]
     }
   ]

--- a/content/news.json
+++ b/content/news.json
@@ -14,6 +14,7 @@
     "classification": {
       "allowed": ["player_update", "internal_update"],
       "player_update_criteria": [
+        "Gameplay, progression, economy, or reward behavior changed.",
         "Menus, UX flows, or social systems players directly use changed.",
         "New or updated content/events/decor/recipes visible in game."
       ],
@@ -28,7 +29,7 @@
     "version": "0.4.0",
     "date": "2026-06-02",
     "classification": "player_update",
-    "summary": "Released premium perks and coin packs with webhook-backed grants, plus giveaway winner rewards and discovery/takeout reliability fixes."
+    "summary": "Released premium perks and coin packs, plus official server giveaways and discovery/takeout reliability fixes."
   },
   "sections": [
     {
@@ -86,8 +87,7 @@
       "title": "Upcoming Updates",
       "items": [
         "**Support Server Giveaways** are coming with NEW *clueboxes* that contain recipe clues!",
-        "**The ab",
-        "**Noodle A Day** is on the way: a cozy daily noodle image posted in your admin's channel of choice."
+        "**Noodle A Day** is on the way: a cozy daily noodle image posted in your channel of choice."
       ]
     }
   ]

--- a/content/news.json
+++ b/content/news.json
@@ -14,7 +14,6 @@
     "classification": {
       "allowed": ["player_update", "internal_update"],
       "player_update_criteria": [
-        "Gameplay, progression, economy, or reward behavior changed.",
         "Menus, UX flows, or social systems players directly use changed.",
         "New or updated content/events/decor/recipes visible in game."
       ],
@@ -26,12 +25,28 @@
   },
   "pinned": {
     "label": "Latest Update",
-    "version": "0.3.0",
-    "date": "2026-05-17",
+    "version": "0.4.0",
+    "date": "2026-06-02",
     "classification": "player_update",
-    "summary": "Expanded Bot List Vote Rewards with a cleaner vote menu, direct vote-site buttons, and clearer claim flow so players can stack high rewards faster."
+    "summary": "Released premium perks and coin packs with webhook-backed grants, plus giveaway winner rewards and discovery/takeout reliability fixes."
   },
   "sections": [
+    {
+      "title": "June 2026",
+      "entries": [
+        {
+          "version": "0.4.0",
+          "date": "2026-06-02",
+          "classification": "player_update",
+          "changes": [
+            "Launched premium perks: **24/7 House** (expanded order capacity + unlimited market stock behavior) and **Take Out Counter** (idle shift earnings).",
+            "Added coin-pack support across Discord SKU purchases and Stripe checkout metadata so rewards grant coins automatically.",
+            "Upgraded giveaway winner dev rewards to grant **Perks**, **Coin Packs**, or any direct **Coins** amount.",
+            "Improved reliability in takeout menu selection limits and coin-pack metadata resolution, with added regression coverage."
+          ]
+        }
+      ]
+    },
     {
       "title": "May 2026",
       "entries": [
@@ -71,8 +86,8 @@
       "title": "Upcoming Updates",
       "items": [
         "**Support Server Giveaways** are coming with NEW *clueboxes* that contain recipe clues!",
-        "**Monthly Subscriptions** are planned: **24/7 House** & **Take Out Counter** perks, allowing players to unlock either an unlimited order board and/or allow their noodle shop to become idle as they serve from a new location. *Estimated to release by the end of the month.*",
-        "**Noodle A Day** is on the way: a cozy daily noodle image posted in your channel of choice."
+        "**The ab",
+        "**Noodle A Day** is on the way: a cozy daily noodle image posted in your admin's channel of choice."
       ]
     }
   ]

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -96,7 +96,7 @@ For variables that accept file paths, absolute paths are honored, and relative p
 - `NOODLE_STRIPE_WEBHOOK_PATH` - Stripe webhook path (default `/store/stripe`)
 - `NOODLE_STRIPE_WEBHOOK_SECRET` - Stripe signing secret for webhook validation
 - `NOODLE_STRIPE_PRECHECK_PATH` and `NOODLE_STRIPE_PRECHECK_SECRET` - optional store precheck endpoint
-- `NOODLE_SUBSCRIPTION_SKU_MAP` - maps Discord store SKU IDs to subscription perks for entitlement lifecycle handling. Accepts JSON (`{"<sku_id>":"house_247","<sku_id>":"takeout_counter"}`) or comma-separated pairs (`<sku_id>:house_247,<sku_id>:takeout_counter`).
+- `NOODLE_SUBSCRIPTION_SKU_MAP` - maps Discord store SKU IDs to subscription perks for entitlement lifecycle handling. Accepts JSON (`{"<house_247_sku_id>":"house_247","<takeout_counter_sku_id>":"takeout_counter"}`) or comma-separated pairs (`<sku_id>:house_247,<sku_id>:takeout_counter`).
 
 ## PebbleHost .env Template
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -96,6 +96,7 @@ For variables that accept file paths, absolute paths are honored, and relative p
 - `NOODLE_STRIPE_WEBHOOK_PATH` - Stripe webhook path (default `/store/stripe`)
 - `NOODLE_STRIPE_WEBHOOK_SECRET` - Stripe signing secret for webhook validation
 - `NOODLE_STRIPE_PRECHECK_PATH` and `NOODLE_STRIPE_PRECHECK_SECRET` - optional store precheck endpoint
+- `NOODLE_SUBSCRIPTION_SKU_MAP` - maps Discord store SKU IDs to subscription perks for entitlement lifecycle handling. Accepts JSON (`{"<sku_id>":"house_247","<sku_id>":"takeout_counter"}`) or comma-separated pairs (`<sku_id>:house_247,<sku_id>:takeout_counter`).
 
 ## PebbleHost .env Template
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -96,7 +96,9 @@ For variables that accept file paths, absolute paths are honored, and relative p
 - `NOODLE_STRIPE_WEBHOOK_PATH` - Stripe webhook path (default `/store/stripe`)
 - `NOODLE_STRIPE_WEBHOOK_SECRET` - Stripe signing secret for webhook validation
 - `NOODLE_STRIPE_PRECHECK_PATH` and `NOODLE_STRIPE_PRECHECK_SECRET` - optional store precheck endpoint
-- `NOODLE_SUBSCRIPTION_SKU_MAP` - maps Discord store SKU IDs to subscription perks for entitlement lifecycle handling. Accepts JSON (`{"<house_247_sku_id>":"house_247","<takeout_counter_sku_id>":"takeout_counter"}`) or comma-separated pairs (`<sku_id>:house_247,<sku_id>:takeout_counter`).
+- `NOODLE_SUBSCRIPTION_SKU_MAP` - maps Discord store SKU IDs to paid subscription perks for entitlement lifecycle handling. Only `takeout_counter` is accepted. Accepts JSON (`{"<takeout_counter_sku_id>":"takeout_counter"}`) or comma-separated pairs (`<sku_id>:takeout_counter`).
+- `NOODLE_COIN_PACK_SKU_MAP` - maps Discord store SKU IDs to coin packs. Supported pack IDs: `coin_pack_099` (10,000c), `coin_pack_199` (25,000c), `coin_pack_499` (100,000c). When unset, built-in defaults are used: `1511191985644507336 -> coin_pack_099`, `1511192707119321109 -> coin_pack_199`, `1511192852288376884 -> coin_pack_499`.
+- `NOODLE_COIN_PACK_PRODUCT_MAP` - maps Stripe metadata product IDs (or `spec_id`) to coin pack IDs using the same values as `NOODLE_COIN_PACK_SKU_MAP`.
 
 ## PebbleHost .env Template
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1840,6 +1840,36 @@ function noodleTakeoutActionRow(userId, { disableOpen = false, disableClaim = fa
   );
 }
 
+function buildTakeoutMenuSelectRow(userId, {
+  availableRecipeIds = [],
+  selectedRecipeIds = [],
+  minRequired = 1,
+  maxAllowed = 1
+} = {}) {
+  const options = [...availableRecipeIds]
+    .sort((a, b) => displayRecipeName(a).localeCompare(displayRecipeName(b), undefined, { sensitivity: "base" }))
+    .slice(0, 25)
+    .map((recipeId) => ({
+      label: displayRecipeName(recipeId).slice(0, 100),
+      value: recipeId,
+      default: selectedRecipeIds.includes(recipeId)
+    }));
+
+  if (!options.length) return null;
+
+  const safeMax = Math.max(1, Math.min(maxAllowed, options.length));
+  const safeMin = Math.max(1, Math.min(minRequired, safeMax));
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(`noodle:takeout:menu_select:${userId}`)
+    .setPlaceholder("Pick recipes for your takeout menu")
+    .setMinValues(safeMin)
+    .setMaxValues(safeMax)
+    .addOptions(options);
+
+  return new ActionRowBuilder().addComponents(menu);
+}
+
 /* ------------------------------------------------------------------ */
 /*  Small helpers                                                      */
 /* ------------------------------------------------------------------ */
@@ -6040,7 +6070,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
     const menuLimits = getTakeoutMenuLimits(availableRecipeIds.length);
 
-    const renderStatus = (banner = null, { ephemeral = false } = {}) => {
+    const renderStatus = (banner = null, { ephemeral = false, showMenuPicker = false } = {}) => {
       const active = isTakeoutShiftActive(p, nowTs());
       const shiftEndsAt = Number(takeout.shift?.ends_at || 0);
       const shiftStartedAt = Number(takeout.shift?.started_at || 0);
@@ -6119,11 +6149,20 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const canOpenShift = !active && takeout.menu_recipe_ids.length >= menuLimits.minRequired;
       const canClaim = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0)) > 0;
+      const menuPickerRow = showMenuPicker
+        ? buildTakeoutMenuSelectRow(userId, {
+            availableRecipeIds,
+            selectedRecipeIds: takeout.menu_recipe_ids,
+            minRequired: menuLimits.minRequired,
+            maxAllowed: menuLimits.maxAllowed
+          })
+        : null;
 
       return {
         content: " ",
         embeds: [embed],
         components: [
+          ...(menuPickerRow ? [menuPickerRow] : []),
           noodleTakeoutActionRow(userId, { disableOpen: !canOpenShift, disableClaim: !canClaim }),
           noodleMainMenuRowNoOrders(userId)
         ],
@@ -6134,7 +6173,10 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     if (sub === "takeout_menu") {
       const rawRecipes = String(opt.getString("recipes") || "").trim();
       if (!rawRecipes) {
-        return finalize(renderStatus(`${getIcon("help")} Provide recipe ids via the recipes option (comma-separated).`, { ephemeral: true }));
+        if (!availableRecipeIds.length) {
+          return finalize(renderStatus(`${getIcon("warning")} You need at least one learned recipe before setting a takeout menu.`, { ephemeral: true }));
+        }
+        return finalize(renderStatus(`${getIcon("recipes")} Pick recipes below to set your takeout menu.`, { showMenuPicker: true }));
       }
 
       const requestedIds = rawRecipes
@@ -6166,7 +6208,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         }));
       }
 
-      return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`));
+      return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`, { showMenuPicker: true }));
     }
 
     if (sub === "takeout_open") {
@@ -10707,6 +10749,26 @@ return componentCommit(interaction, { content: "Unknown picker action.", ephemer
 // Handle select menus for pickers:
 if (interaction.isSelectMenu?.()) {
 const cid = interaction.customId;
+
+if (cid.startsWith("noodle:takeout:menu_select:")) {
+  const owner = cid.split(":")[3];
+  if (owner && owner !== interaction.user.id) {
+    return componentCommit(interaction, { content: "That menu isn’t for you.", ephemeral: true });
+  }
+
+  const selectedRecipeIds = (interaction.values ?? []).filter(Boolean);
+  if (!selectedRecipeIds.length) {
+    return componentCommit(interaction, { content: `${getIcon("help")} Pick at least one recipe.`, ephemeral: true });
+  }
+
+  return runNoodle(interaction, {
+    sub: "takeout_menu",
+    overrides: {
+      strings: { recipes: selectedRecipeIds.join(",") },
+      messageId: interaction.message?.id ?? null
+    }
+  });
+}
 
 // accept picker
 if (cid.startsWith("noodle:pick:accept_select:")) {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1746,6 +1746,15 @@ new ButtonBuilder().setCustomId(`noodle:nav:profile:${userId}`).setLabel("Profil
 );
 }
 
+function noodleMainMenuRowNoOrdersWithBack(userId) {
+return new ActionRowBuilder().addComponents(
+new ButtonBuilder().setCustomId(`noodle:nav:buy:${userId}`).setLabel("Buy").setEmoji(getButtonEmoji("cart")).setStyle(ButtonStyle.Secondary),
+new ButtonBuilder().setCustomId(`noodle:nav:pantry:${userId}`).setLabel("Pantry").setEmoji(getButtonEmoji("pantry")).setStyle(ButtonStyle.Secondary),
+new ButtonBuilder().setCustomId(`noodle:nav:profile:${userId}`).setLabel("Profile").setEmoji(getButtonEmoji("profile")).setStyle(ButtonStyle.Secondary),
+new ButtonBuilder().setCustomId(`noodle:nav:orders:${userId}`).setLabel("Back").setEmoji(getButtonEmoji("back")).setStyle(ButtonStyle.Secondary)
+);
+}
+
 function noodleOrdersActionRow(userId, { highlightAccept = true, disableAccept = false, disableServe = false } = {}) {
   const acceptStyle = disableAccept ? ButtonStyle.Secondary : (highlightAccept ? ButtonStyle.Success : ButtonStyle.Secondary);
   return new ActionRowBuilder().addComponents(
@@ -1824,6 +1833,11 @@ function noodleTakeoutActionRow(userId, { activeShift = false, disableOpen = fal
         .setEmoji(getButtonEmoji("orders"))
         .setStyle(ButtonStyle.Primary),
       new ButtonBuilder()
+        .setCustomId(`noodle:nav:takeout_needs:${userId}`)
+        .setLabel("Ingredients")
+        .setEmoji(getButtonEmoji("basket"))
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
         .setCustomId(`noodle:pick:takeout_cook:${userId}`)
         .setLabel("Counter Cook")
         .setEmoji(getButtonEmoji("cook"))
@@ -1839,12 +1853,7 @@ function noodleTakeoutActionRow(userId, { activeShift = false, disableOpen = fal
         .setLabel("Claim")
         .setEmoji(getButtonEmoji("coins"))
         .setStyle(disableClaim ? ButtonStyle.Secondary : ButtonStyle.Primary)
-        .setDisabled(disableClaim),
-      new ButtonBuilder()
-        .setCustomId(`noodle:nav:orders:${userId}`)
-        .setLabel("Back")
-        .setEmoji(getButtonEmoji("back"))
-        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(disableClaim)
     );
   }
 
@@ -4211,7 +4220,7 @@ function buildTakeoutCookPickerPayload({ userId, p, takeout, ownerUser, page = 0
       disableClaim: Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) <= 0,
       disableServe: !canCounterServe
     }),
-    noodleMainMenuRowNoOrders(userId)
+    noodleMainMenuRowNoOrdersWithBack(userId)
   );
 
   return { content: " ", embeds: [cookEmbed], components };
@@ -4273,7 +4282,54 @@ function buildTakeoutServePickerPayload({ userId, p, takeout, ownerUser }) {
         disableClaim: Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) <= 0,
         disableServe: !canCounterServe
       }),
-      noodleMainMenuRowNoOrders(userId)
+      noodleMainMenuRowNoOrdersWithBack(userId)
+    ]
+  };
+}
+
+function buildTakeoutNeedsPayload({ userId, p, takeout, ownerUser }) {
+  const needRows = getTakeoutRecipeNeedRows(p, takeout)
+    .filter((entry) => entry.need > 0)
+    .sort((a, b) => {
+      if (b.short !== a.short) return b.short - a.short;
+      return displayRecipeName(a.recipeId).localeCompare(displayRecipeName(b.recipeId), "en", { sensitivity: "base" });
+    });
+
+  const remainingOrderLines = needRows.length
+    ? needRows
+      .slice(0, 10)
+      .map((entry) => `• ${displayRecipeName(entry.recipeId)} — need **${entry.need}**, ready **${entry.ready}** (cook **${entry.short}** more)`)
+      .join("\n")
+    : "_No remaining active counter orders._";
+
+  const neededIngredientsBlock = buildTakeoutNeededIngredientsBlock(p, takeout, { maxLines: 20 });
+  const description = [
+    "Needed ingredients for your remaining active counter orders (after counting ready bowls).",
+    "",
+    "**Remaining Counter Orders**",
+    remainingOrderLines,
+    "",
+    neededIngredientsBlock
+  ].join("\n");
+
+  const canCounterServe = needRows.some((entry) => entry.ready > 0);
+  const embed = buildMenuEmbed({
+    title: `${getIcon("basket")} Counter Ingredients`,
+    description,
+    user: ownerUser,
+    color: theme.colors.success
+  });
+
+  return {
+    content: " ",
+    embeds: [embed],
+    components: [
+      noodleTakeoutActionRow(userId, {
+        activeShift: true,
+        disableClaim: Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) <= 0,
+        disableServe: !canCounterServe
+      }),
+      noodleMainMenuRowNoOrdersWithBack(userId)
     ]
   };
 }
@@ -6305,7 +6361,7 @@ if (sub === "kitchen" || sub === "kitchen_start" || sub === "kitchen_collect") {
 }
 
 /* ---------------- RECIPES ---------------- */
-if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub === "takeout_claim" || sub === "takeout_cook" || sub === "takeout_serve") {
+if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub === "takeout_claim" || sub === "takeout_cook" || sub === "takeout_serve" || sub === "takeout_needs") {
   if (!db) {
     const unavailableEmbed = buildMenuEmbed({
       title: `${getIcon("orders")} Take Out Counter`,
@@ -6448,7 +6504,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     const renderStatus = (banner = null, { ephemeral = false, showMenuPicker = false, menuPage = requestedMenuPage } = {}) => {
       const active = isTakeoutShiftActive(p, nowTs());
       const shiftEndsAt = Number(takeout.shift?.ends_at || 0);
-      const shiftStartedAt = Number(takeout.shift?.started_at || 0);
       const processedHours = Math.max(0, Math.floor(Number(takeout.shift?.last_processed_hour_index || 0) || 0));
       const remainingHours = Math.max(0, TAKEOUT_SHIFT_DURATION_HOURS - processedHours);
       const snapshot = Array.isArray(takeout.shift?.idle_order_board_snapshot)
@@ -6486,21 +6541,14 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
           .map((rid) => `• ${displayRecipeName(rid)} — **${countByRecipe.get(rid) ?? 0}** orders`)
           .join("\n")
         : "_No menu configured yet._";
-      const neededIngredientsBlock = active
-        ? buildTakeoutNeededIngredientsBlock(p, takeout, { maxLines: 8 })
-        : null;
 
       const statusBits = [];
       if (active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0) {
-        statusBits.push(`${getIcon("time")} **Shift Active** until <t:${Math.floor(shiftEndsAt / 1000)}:R> (<t:${Math.floor(shiftEndsAt / 1000)}:f>)`);
-        statusBits.push(`${getIcon("orders")} Your Shop's Order Board is idle right now. Serve from the Takeout Counter while this shift runs.`);
+        statusBits.push(`${getIcon("time")} **Shift Active,** ends <t:${Math.floor(shiftEndsAt / 1000)}:R> (<t:${Math.floor(shiftEndsAt / 1000)}:f>)`);
       } else {
         statusBits.push(`${getIcon("status_pending")} **Shift Inactive**`);
-      }
-      statusBits.push(`${getIcon("coins")} Next shift ingredient cost: **${projectedOperatingCost}c**`);
-      statusBits.push(`${getIcon("orders")} Next shift expected orders served: **${projectedOrders}**`);
-      if (Number.isFinite(shiftStartedAt) && shiftStartedAt > 0) {
-        statusBits.push(`${getIcon("calendar")} Last start: <t:${Math.floor(shiftStartedAt / 1000)}:f>`);
+        statusBits.push(`${getIcon("coins")} Next shift ingredient cost: **${projectedOperatingCost}c**`);
+        statusBits.push(`${getIcon("orders")} Next shift expected orders served: **${projectedOrders}**`);
       }
       const unclaimedIdleCoins = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0));
       if (unclaimedIdleCoins > 0) {
@@ -6531,9 +6579,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         "\u200b",
         statusBits.join("\n"),
         "\n**Counter Menu**",
-        counterMenuLines,
-        "",
-        neededIngredientsBlock
+        counterMenuLines
       ].filter(Boolean).join("\n");
 
       const embed = buildMenuEmbed({
@@ -6571,7 +6617,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
             disableClaim: !canClaim,
             disableServe: !canCounterServe
           }),
-          noodleMainMenuRowNoOrders(userId)
+          active ? noodleMainMenuRowNoOrdersWithBack(userId) : noodleMainMenuRowNoOrders(userId)
         ],
         ephemeral
       };
@@ -6742,8 +6788,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       return finalize(
         renderStatus(
-          `${getIcon("status_complete")} Shift opened for **${TAKEOUT_SHIFT_DURATION_HOURS}h** with **${openResult.snapshotOrderTotal}** snapshot orders and a fixed operating cost of **${openResult.operatingCost}c**. ` +
-          `Idle ingredients are pre-covered and isolated from your pantry, and you can start another shift after this one ends.`
+          `${getIcon("status_complete")} Shift started for **${TAKEOUT_SHIFT_DURATION_HOURS}h** with **${openResult.snapshotOrderTotal}** orders and an ingredient cost of **${openResult.operatingCost}c**. ` +
+          `Ingredients needed for idle earnings are reserved while the shift is active.`, { ephemeral: true }
         )
       );
     }
@@ -6759,6 +6805,18 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         takeout,
         ownerUser: interaction.member ?? interaction.user,
         page: Number.isFinite(rawPage) ? rawPage : 0
+      }));
+    }
+
+    if (sub === "takeout_needs") {
+      if (!isTakeoutShiftActive(p, now)) {
+        return finalize(renderStatus(`${getIcon("help")} Start a shift to view **Counter Ingredients**.`, { ephemeral: true }));
+      }
+      return finalize(buildTakeoutNeedsPayload({
+        userId,
+        p,
+        takeout,
+        ownerUser: interaction.member ?? interaction.user
       }));
     }
 
@@ -9495,7 +9553,7 @@ ${lines.join("\n")}`;
       parts.push(
         "**Today’s Orders**",
         hasHouse247Perk(p)
-          ? `${getIcon("sparkle")} 24/7 House active: unlimited orders. Tap **Accept** below to start serving customers.`
+          ? `${getIcon("sparkle")} **24/7 House active: unlimited orders.** Tap **Accept** below to start serving customers.`
           : `There are **${remaining}** orders available. Tap **Accept** below to start serving customers.`
       );
     } else if (acceptedLines.length) {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -896,7 +896,8 @@ function buildHelpPage({ page, userId, user }) {
             "• `/noodle accept` — Accept an order.",
             "• `/noodle cook` — Cook a recipe.",
             "• `/noodle serve` — Serve accepted orders.",
-            "• `/noodle cancel` — Cancel an accepted order."
+            "• `/noodle cancel` — Cancel an accepted order.",
+            `• \`/noodle takeout\` — Run your takeout counter. ${getIcon("lock")} Unlocks with the **${getTakeoutCounterLabel()}** perk.`
           ].join("\n"),
           inline: true
         },

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6134,14 +6134,37 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
           .join("\n")
         : "_No counter orders to show yet._";
 
+      const previewNow = active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0
+        ? shiftEndsAt + 1000
+        : now;
+      const previewPlayer = JSON.parse(JSON.stringify(p));
+      const previewBoardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
+      const previewResult = startTakeoutShiftWithCoverage(previewPlayer, {
+        now: previewNow,
+        boardOrderTotal: previewBoardOrderTotal,
+        unlimitedOrders: hasHouse247Perk(p),
+        recipes: content.recipes ?? {},
+        marketPrices: s.market_prices ?? {},
+        items: content.items ?? {}
+      });
+
+      const projectedOperatingCost = Math.max(
+        0,
+        Math.floor(Number(previewResult?.operatingCost || 0) || 0)
+      );
+      const projectedOrders = Math.max(
+        0,
+        Math.floor(Number(previewResult?.snapshotOrderTotal || 0) || 0)
+      );
+
       const statusBits = [];
       if (active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0) {
         statusBits.push(`${getIcon("time")} **Shift Active** until <t:${Math.floor(shiftEndsAt / 1000)}:R> (<t:${Math.floor(shiftEndsAt / 1000)}:f>)`);
-        statusBits.push(`${getIcon("refresh")} Next eligible shift: <t:${Math.floor(shiftEndsAt / 1000)}:R>`);
       } else {
         statusBits.push(`${getIcon("status_pending")} **Shift Inactive**`);
-        statusBits.push(`${getIcon("refresh")} Next eligible shift: **Now**`);
       }
+      statusBits.push(`${getIcon("coins")} Next shift ingredient cost: **${projectedOperatingCost}c**`);
+      statusBits.push(`${getIcon("orders")} Next shift expected orders served: **${projectedOrders}**`);
       if (Number.isFinite(shiftStartedAt) && shiftStartedAt > 0) {
         statusBits.push(`${getIcon("calendar")} Last start: <t:${Math.floor(shiftStartedAt / 1000)}:f>`);
       }
@@ -6161,6 +6184,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const description = [
         banner,
+        "Run a 12-hour counter shift with your selected menu, pay ingredient costs up front, and claim idle coin earnings when ready.",
         takeoutCatchup?.processedHours > 0
           ? `${getIcon("time")} Catch-up processed **${takeoutCatchup.processedHours}h** and accrued **${takeoutCatchup.earned}c** while you were away.`
           : null,

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1840,34 +1840,63 @@ function noodleTakeoutActionRow(userId, { disableOpen = false, disableClaim = fa
   );
 }
 
-function buildTakeoutMenuSelectRow(userId, {
+function buildTakeoutMenuPickerRows(userId, {
   availableRecipeIds = [],
   selectedRecipeIds = [],
   minRequired = 1,
-  maxAllowed = 1
+  maxAllowed = 1,
+  page = 0
 } = {}) {
-  const options = [...availableRecipeIds]
+  const pageSize = 25;
+  const sortedRecipeIds = [...availableRecipeIds]
     .sort((a, b) => displayRecipeName(a).localeCompare(displayRecipeName(b), undefined, { sensitivity: "base" }))
-    .slice(0, 25)
+    .filter(Boolean);
+
+  if (!sortedRecipeIds.length) return null;
+
+  const totalPages = Math.max(1, Math.ceil(sortedRecipeIds.length / pageSize));
+  const rawPage = Number.isFinite(page) ? page : 0;
+  const safePage = Math.max(0, Math.min(rawPage, totalPages - 1));
+  const pageRecipeIds = sortedRecipeIds.slice(safePage * pageSize, (safePage + 1) * pageSize);
+
+  const options = pageRecipeIds
     .map((recipeId) => ({
       label: displayRecipeName(recipeId).slice(0, 100),
       value: recipeId,
       default: selectedRecipeIds.includes(recipeId)
     }));
 
-  if (!options.length) return null;
-
   const safeMax = Math.max(1, Math.min(maxAllowed, options.length));
   const safeMin = Math.max(1, Math.min(minRequired, safeMax));
 
   const menu = new StringSelectMenuBuilder()
-    .setCustomId(`noodle:takeout:menu_select:${userId}`)
+    .setCustomId(`noodle:takeout:menu_select:${userId}:${safePage}`)
     .setPlaceholder("Pick recipes for your takeout menu")
     .setMinValues(safeMin)
     .setMaxValues(safeMax)
     .addOptions(options);
 
-  return new ActionRowBuilder().addComponents(menu);
+  const rows = [new ActionRowBuilder().addComponents(menu)];
+  if (totalPages > 1) {
+    const prevPage = safePage <= 0 ? totalPages - 1 : safePage - 1;
+    const nextPage = safePage >= totalPages - 1 ? 0 : safePage + 1;
+    rows.push(
+      new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`noodle:nav:takeout_menu:${userId}:${prevPage}`)
+          .setLabel("Prev")
+          .setEmoji(getButtonEmoji("back"))
+          .setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder()
+          .setCustomId(`noodle:nav:takeout_menu:${userId}:${nextPage}`)
+          .setLabel("Next")
+          .setEmoji(getButtonEmoji("next"))
+          .setStyle(ButtonStyle.Secondary)
+      )
+    );
+  }
+
+  return { rows, safePage, totalPages };
 }
 
 /* ------------------------------------------------------------------ */
@@ -6069,8 +6098,10 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     }
 
     const menuLimits = getTakeoutMenuLimits(availableRecipeIds.length);
+    const requestedMenuPageRaw = Number(opt.getInteger("page") ?? 0);
+    const requestedMenuPage = Number.isFinite(requestedMenuPageRaw) ? Math.max(0, requestedMenuPageRaw) : 0;
 
-    const renderStatus = (banner = null, { ephemeral = false, showMenuPicker = false } = {}) => {
+    const renderStatus = (banner = null, { ephemeral = false, showMenuPicker = false, menuPage = requestedMenuPage } = {}) => {
       const active = isTakeoutShiftActive(p, nowTs());
       const shiftEndsAt = Number(takeout.shift?.ends_at || 0);
       const shiftStartedAt = Number(takeout.shift?.started_at || 0);
@@ -6149,12 +6180,13 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const canOpenShift = !active && takeout.menu_recipe_ids.length >= menuLimits.minRequired;
       const canClaim = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0)) > 0;
-      const menuPickerRow = showMenuPicker
-        ? buildTakeoutMenuSelectRow(userId, {
+      const menuPicker = showMenuPicker
+        ? buildTakeoutMenuPickerRows(userId, {
             availableRecipeIds,
             selectedRecipeIds: takeout.menu_recipe_ids,
             minRequired: menuLimits.minRequired,
-            maxAllowed: menuLimits.maxAllowed
+            maxAllowed: menuLimits.maxAllowed,
+            page: menuPage
           })
         : null;
 
@@ -6162,7 +6194,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         content: " ",
         embeds: [embed],
         components: [
-          ...(menuPickerRow ? [menuPickerRow] : []),
+          ...(menuPicker?.rows ?? []),
           noodleTakeoutActionRow(userId, { disableOpen: !canOpenShift, disableClaim: !canClaim }),
           noodleMainMenuRowNoOrders(userId)
         ],
@@ -6176,7 +6208,10 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         if (!availableRecipeIds.length) {
           return finalize(renderStatus(`${getIcon("warning")} You need at least one learned recipe before setting a takeout menu.`, { ephemeral: true }));
         }
-        return finalize(renderStatus(`${getIcon("recipes")} Pick recipes below to set your takeout menu.`, { showMenuPicker: true }));
+        return finalize(renderStatus(`${getIcon("recipes")} Pick recipes below to set your takeout menu.`, {
+          showMenuPicker: true,
+          menuPage: requestedMenuPage
+        }));
       }
 
       const requestedIds = rawRecipes
@@ -6208,7 +6243,10 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         }));
       }
 
-      return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`, { showMenuPicker: true }));
+      return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`, {
+        showMenuPicker: true,
+        menuPage: requestedMenuPage
+      }));
     }
 
     if (sub === "takeout_open") {
@@ -10751,7 +10789,10 @@ if (interaction.isSelectMenu?.()) {
 const cid = interaction.customId;
 
 if (cid.startsWith("noodle:takeout:menu_select:")) {
-  const owner = cid.split(":")[3];
+  const idParts = cid.split(":");
+  const owner = idParts[3];
+  const rawPage = Number(idParts[4] ?? 0);
+  const page = Number.isFinite(rawPage) ? Math.max(0, rawPage) : 0;
   if (owner && owner !== interaction.user.id) {
     return componentCommit(interaction, { content: "That menu isn’t for you.", ephemeral: true });
   }
@@ -10765,6 +10806,7 @@ if (cid.startsWith("noodle:takeout:menu_select:")) {
     sub: "takeout_menu",
     overrides: {
       strings: { recipes: selectedRecipeIds.join(",") },
+      integers: { page },
       messageId: interaction.message?.id ?? null
     }
   });
@@ -11823,12 +11865,12 @@ const noodleCommandData = new SlashCommandBuilder()
       .addSubcommand((sc) =>
         sc
           .setName("menu")
-          .setDescription("Set your Take Out Counter menu (comma-separated recipe ids).")
+          .setDescription("Set your Take Out Counter menu using a recipe picker.")
           .addStringOption((o) =>
             o
               .setName("recipes")
-              .setDescription("Comma-separated recipe ids (max 10).")
-              .setRequired(true)
+              .setDescription("Optional legacy input: comma-separated recipe ids (max 10).")
+              .setRequired(false)
           )
       )
       .addSubcommand((sc) => sc.setName("open").setDescription("Open a 12-hour takeout shift."))

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6757,6 +6757,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     const s = ensureServer(serverId);
     unlockNoticePlayer = p;
     const now = nowTs();
+    const takeout = ensureTakeoutState(p);
     const takeoutEnabled = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now);
 
     const finalize = (payload) => {
@@ -6766,21 +6767,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       return payload;
     };
 
-    if (!takeoutEnabled) {
-      const lockedEmbed = buildMenuEmbed({
-        title: getTakeoutCounterLabel(),
-        description: `${getIcon("lock")} ${getTakeoutCounterLabel()} requires an active subscription.`,
-        user: interaction.member ?? interaction.user,
-        color: theme.colors.warning
-      });
-      return finalize({
-        content: " ",
-        embeds: [lockedEmbed],
-        ephemeral: true
-      });
-    }
-
-    const takeout = ensureTakeoutState(p);
     const takeoutCatchup = processTakeoutCatchup(p, {
       now,
       recipes: content.recipes ?? {},
@@ -6795,6 +6781,25 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         earnedCoins: takeoutCatchup.earned,
         totalProcessedHours: takeoutCatchup.totalProcessedHours,
         completed: Boolean(takeoutCatchup.completed)
+      });
+    }
+
+    const hasUnclaimedTakeoutCoins = Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) > 0;
+    const hasActiveTakeoutShift = isTakeoutShiftActive(p, now);
+    const isTakeoutStatusOrClaimRoute = sub === "takeout" || sub === "takeout_claim";
+    const allowTakeoutGraceAccess = isTakeoutStatusOrClaimRoute && (hasActiveTakeoutShift || hasUnclaimedTakeoutCoins);
+
+    if (!takeoutEnabled && !allowTakeoutGraceAccess) {
+      const lockedEmbed = buildMenuEmbed({
+        title: getTakeoutCounterLabel(),
+        description: `${getIcon("lock")} ${getTakeoutCounterLabel()} requires an active subscription.`,
+        user: interaction.member ?? interaction.user,
+        color: theme.colors.warning
+      });
+      return finalize({
+        content: " ",
+        embeds: [lockedEmbed],
+        ephemeral: true
       });
     }
 
@@ -7013,9 +7018,9 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
           })
         : null;
 
-      const canOpenShift = !active && takeout.menu_recipe_ids.length >= menuLimits.minRequired;
+      const canOpenShift = takeoutEnabled && !active && takeout.menu_recipe_ids.length >= menuLimits.minRequired;
       const canClaim = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0)) > 0;
-      const canCounterServe = active && takeout.menu_recipe_ids.some((rid) => {
+      const canCounterServe = takeoutEnabled && active && takeout.menu_recipe_ids.some((rid) => {
         const remaining = Math.max(0, Math.floor(Number(countByRecipe.get(rid) || 0) || 0));
         if (remaining <= 0) return false;
         return getTotalBowlsForRecipe(p, rid) > 0;

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6883,6 +6883,13 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     };
 
     if (sub === "takeout_menu") {
+      if (isTakeoutShiftActive(p, now)) {
+        return finalize(renderStatus(
+          `${getIcon("time")} Your takeout shift is active. Update your counter menu after the current shift ends.`,
+          { ephemeral: true }
+        ));
+      }
+
       const rawRecipes = String(opt.getString("recipes") || "").trim();
       if (!rawRecipes) {
         if (!availableRecipeIds.length) {
@@ -6933,6 +6940,14 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     if (sub === "takeout_open") {
       if (takeout.menu_recipe_ids.length <= 0) {
         return finalize(renderStatus(`${getIcon("warning")} Configure your counter menu first with /noodle takeout_menu.` , { ephemeral: true }));
+      }
+
+      const acceptedOrderCount = Object.keys(p.orders?.accepted ?? {}).length;
+      if (acceptedOrderCount > 0) {
+        return finalize(renderStatus(
+          `${getIcon("warning")} You still have **${acceptedOrderCount}** accepted main-board order${acceptedOrderCount === 1 ? "" : "s"}. Serve or cancel them before opening a takeout shift.`,
+          { ephemeral: true }
+        ));
       }
 
       const set = buildSettingsMap(settingsCatalog, s.settings);

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -5,6 +5,7 @@ import {
   canForage,
   rollForageDrops,
   applyDropsToInventory,
+  applyForagePityCounter,
   setForageCooldown,
   FORAGE_ITEM_IDS,
   RARE_FORAGE_ITEM_IDS
@@ -8791,32 +8792,25 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
       drops[itemId] = (drops[itemId] ?? 0) + bonusItems;
     }
 
-    // Pity: guarantee a rare forage after 10 forages without any rare drop
+    // Pity: guarantee a rare forage after 10 forages without any rare drop.
+    // Keep pity progress until a rare actually survives capacity filtering.
     const allowedRare = RARE_FORAGE_ITEM_IDS.filter((id) => allowedForage.has(id));
-    if (allowedRare.length) {
-      const hasRareDrop = Object.keys(drops).some((id) => allowedRare.includes(id));
-      if (hasRareDrop) {
-        p.forage_pity_rare_count = 0;
-      } else {
-        p.forage_pity_rare_count = (p.forage_pity_rare_count || 0) + 1;
-        if (p.forage_pity_rare_count >= 10) {
-          const pityRng = makeStreamRng({
-            mode: "seeded",
-            seed: 98765,
-            streamName: "forage_pity",
-            serverId,
-            dayKey: dayKeyUTC(),
-            userId: interaction.user.id
-          });
-          const pickIdx = Math.floor(pityRng() * allowedRare.length);
-          const pityItem = allowedRare[Math.max(0, Math.min(allowedRare.length - 1, pickIdx))];
-          drops[pityItem] = (drops[pityItem] ?? 0) + 1;
-          p.forage_pity_rare_count = 0;
-        }
-      }
-    }
+    const injectedPityItemId = applyForagePityCounter(p, drops, {
+      allowedRare,
+      itemId,
+      serverId,
+      userId: interaction.user.id,
+      dayKey: dayKeyUTC()
+    });
     const capacityResult = applyIngredientCapacityToDrops(drops, p, combinedEffects, { allowDisplacingInventory: true });
     const { accepted, rejected, evicted } = capacityResult;
+
+    if (allowedRare.length) {
+      const acceptedHasRare = Object.keys(accepted).some((id) => allowedRare.includes(id));
+      if (acceptedHasRare || (injectedPityItemId && Number(accepted[injectedPityItemId] || 0) > 0)) {
+        p.forage_pity_rare_count = 0;
+      }
+    }
 
     if (evicted && Object.keys(evicted).length) {
       removeIngredientsFromInventory(p, evicted);

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6753,7 +6753,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const hasStartedFirstTakeoutShift = Number.isFinite(Number(takeout.first_shift_started_at || 0))
         && Number(takeout.first_shift_started_at || 0) > 0;
       const minMenuRequired = Math.max(0, Math.floor(Number(menuLimits.minRequired || 0) || 0));
-      const firstCounterSetupGuide = !hasStartedFirstTakeoutShift
+      const showFirstCounterSetupGuide = !active && !hasStartedFirstTakeoutShift;
+      const firstCounterSetupGuide = showFirstCounterSetupGuide
         ? [
             minMenuRequired > 0
               ? `• Set your counter **Menu** with at least **${minMenuRequired}** recipe${minMenuRequired === 1 ? "" : "s"}.`
@@ -6821,7 +6822,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
             disableClaim: !canClaim,
             disableServe: !canCounterServe
           }),
-          active ? noodleMainMenuRowNoOrdersWithBack(userId) : noodleMainMenuRowNoOrders(userId)
+          noodleMainMenuRowNoOrdersWithBack(userId)
         ],
         ephemeral
       };

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -3327,6 +3327,66 @@ if (idMatches.length === 1) return idMatches[0];
 return null;
 }
 
+function computeMarketShoppingShortages(player, serverState) {
+  const acceptedEntries = Object.entries(player.orders?.accepted ?? {});
+  const allNeeded = {};
+
+  const neededCountsByRecipe = {};
+  acceptedEntries.forEach(([, entry]) => {
+    const recipeId = entry?.order?.recipe_id;
+    if (!recipeId) return;
+    neededCountsByRecipe[recipeId] = (neededCountsByRecipe[recipeId] ?? 0) + 1;
+  });
+
+  for (const [recipeId, neededCount] of Object.entries(neededCountsByRecipe)) {
+    const recipe = content.recipes[recipeId];
+    if (!recipe?.ingredients) continue;
+
+    const ready = getTotalBowlsForRecipe(player, recipeId);
+    const remaining = Math.max(0, neededCount - ready);
+    if (remaining <= 0) continue;
+
+    getRelevantRecipeIngredients(player, recipe).forEach((ing) => {
+      allNeeded[ing.item_id] = (allNeeded[ing.item_id] ?? 0) + (ing.qty * remaining);
+    });
+  }
+
+  const takeoutState = ensureTakeoutState(player);
+  const takeoutActive = isTakeoutShiftActive(player, nowTs());
+  if (takeoutActive) {
+    const takeoutNeedRows = getTakeoutRecipeNeedRows(player, takeoutState).filter((entry) => entry.short > 0);
+    for (const entry of takeoutNeedRows) {
+      const recipe = content.recipes?.[entry.recipeId];
+      if (!recipe?.ingredients) continue;
+      getRelevantRecipeIngredients(player, recipe).forEach((ing) => {
+        if (isIngredientOptionalForPlayer(player, ing)) return;
+        const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+        if (qty <= 0) return;
+        allNeeded[ing.item_id] = (allNeeded[ing.item_id] ?? 0) + (qty * entry.short);
+      });
+    }
+  }
+
+  const shortages = Object.entries(allNeeded)
+    .map(([id, needed]) => {
+      const have = player.inv_ingredients?.[id] ?? 0;
+      const short = Math.max(0, needed - have);
+      return { id, needed, have, short };
+    })
+    .filter((s) => s.short > 0);
+
+  const shoppingShortages = shortages.filter(
+    (s) => MARKET_ITEM_IDS.includes(s.id) && !FORAGE_ITEM_IDS.includes(s.id)
+  );
+
+  return {
+    acceptedEntries,
+    shortages,
+    shoppingShortages,
+    takeoutActive
+  };
+}
+
 function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSellButton = true }) {
   if (!s.market_prices) s.market_prices = {};
   if (!p.market_stock) p.market_stock = {};
@@ -3403,57 +3463,7 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
       )
     : null;
 
-  const acceptedEntries = Object.entries(p.orders?.accepted ?? {});
-  const allNeeded = {};
-
-  // Account for cooked bowls so shopping list only shows truly missing ingredients
-  const neededCountsByRecipe = {};
-  acceptedEntries.forEach(([, entry]) => {
-    const recipeId = entry?.order?.recipe_id;
-    if (!recipeId) return;
-    neededCountsByRecipe[recipeId] = (neededCountsByRecipe[recipeId] ?? 0) + 1;
-  });
-
-  for (const [recipeId, neededCount] of Object.entries(neededCountsByRecipe)) {
-    const recipe = content.recipes[recipeId];
-    if (!recipe?.ingredients) continue;
-
-    const ready = getTotalBowlsForRecipe(p, recipeId);
-    const remaining = Math.max(0, neededCount - ready);
-    if (remaining <= 0) continue;
-
-    getRelevantRecipeIngredients(p, recipe).forEach((ing) => {
-      allNeeded[ing.item_id] = (allNeeded[ing.item_id] ?? 0) + (ing.qty * remaining);
-    });
-  }
-
-  const takeoutState = ensureTakeoutState(p);
-  const takeoutActive = isTakeoutShiftActive(p, nowTs());
-  if (takeoutActive) {
-    const takeoutNeedRows = getTakeoutRecipeNeedRows(p, takeoutState).filter((entry) => entry.short > 0);
-    for (const entry of takeoutNeedRows) {
-      const recipe = content.recipes?.[entry.recipeId];
-      if (!recipe?.ingredients) continue;
-      getRelevantRecipeIngredients(p, recipe).forEach((ing) => {
-        if (isIngredientOptionalForPlayer(p, ing)) return;
-        const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
-        if (qty <= 0) return;
-        allNeeded[ing.item_id] = (allNeeded[ing.item_id] ?? 0) + (qty * entry.short);
-      });
-    }
-  }
-
-  const shortages = Object.entries(allNeeded)
-    .map(([id, needed]) => {
-      const have = p.inv_ingredients?.[id] ?? 0;
-      const short = Math.max(0, needed - have);
-      return { id, needed, have, short };
-    })
-    .filter((s) => s.short > 0);
-
-  const shoppingShortages = shortages.filter(
-    (s) => MARKET_ITEM_IDS.includes(s.id) && !FORAGE_ITEM_IDS.includes(s.id)
-  );
+  const { acceptedEntries, shortages, shoppingShortages, takeoutActive } = computeMarketShoppingShortages(p, s);
 
   const showShoppingList = acceptedEntries.length > 0 || takeoutActive;
   const maxShoppingLines = 8;
@@ -4330,7 +4340,6 @@ function buildTakeoutNeedsPayload({ userId, p, takeout, ownerUser, page = 0 }) {
     : "_No remaining active counter orders._";
   const hiddenOrderCount = Math.max(0, needRows.length - 12);
   const hiddenOrderSuffix = hiddenOrderCount > 0 ? `\n…and **${hiddenOrderCount}** more order lines` : "";
-  const ingredientPageSuffix = shortageRows.length > 0 ? `\n\nPage **${safePage + 1}/${totalPages}**` : "";
 
   const description = [
     "Ingredients needed for your remaining active counter orders (after counting ready bowls).",
@@ -4339,7 +4348,7 @@ function buildTakeoutNeedsPayload({ userId, p, takeout, ownerUser, page = 0 }) {
     `${remainingOrderLines}${hiddenOrderSuffix}`,
     "",
     `${getIcon("basket")} **Needed Ingredients**`,
-    `${neededIngredientLines}${ingredientPageSuffix}`
+    neededIngredientLines
   ].join("\n");
 
   const canCounterServe = needRows.some((entry) => entry.ready > 0);
@@ -4349,6 +4358,11 @@ function buildTakeoutNeedsPayload({ userId, p, takeout, ownerUser, page = 0 }) {
     user: ownerUser,
     color: theme.colors.success
   });
+  if (shortageRows.length > 0) {
+    const existingFooter = embed?.data?.footer?.text ?? embed?.footer?.text ?? "";
+    const pageLabel = `Page ${safePage + 1}/${totalPages}`;
+    embed.setFooter({ text: existingFooter ? `${pageLabel} • ${existingFooter}` : pageLabel });
+  }
 
   return {
     content: " ",
@@ -4710,6 +4724,10 @@ new ButtonBuilder()
 
 if (!limitToBuy1) {
   btnRow.addComponents(
+    new ButtonBuilder()
+      .setCustomId(`noodle:multibuy:buyneed:${userId}:${msgId}`)
+      .setLabel("Buy Needed")
+      .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
       .setCustomId(`noodle:multibuy:buy5:${userId}:${msgId}`)
       .setLabel("Buy 5 each")
@@ -12123,11 +12141,11 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
       return renderMultiBuyPicker({ interaction, userId, s: serverState, p });
     }
 
-    // Buy N each -> perform purchase
-    if (mode === "buy1" || mode === "buy5" || mode === "buy10") {
+    // Buy N each / needed -> perform purchase
+    if (mode === "buy1" || mode === "buy5" || mode === "buy10" || mode === "buyneed") {
       const qtyEach = mode === "buy10" ? 10 : mode === "buy5" ? 5 : 1;
       const sourceMessageId = interaction.message?.id;
-      const action = `multibuy_buy${qtyEach}`;
+      const action = mode === "buyneed" ? "multibuy_buyneed" : `multibuy_buy${qtyEach}`;
       const idemKey = makeIdempotencyKey({ serverId, userId, action, interactionId: interaction.id });
       const cached = db ? getIdempotentResult(db, idemKey) : null;
       if (cached) return componentCommit(interaction, cached);
@@ -12152,7 +12170,16 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
         };
 
         const want = {};
-        for (const id3 of selectedIds) want[id3] = qtyEach;
+        if (mode === "buyneed") {
+          const { shoppingShortages } = computeMarketShoppingShortages(p2, s);
+          const shortById = new Map(shoppingShortages.map((row) => [row.id, row.short]));
+          for (const id3 of selectedIds) {
+            const neededShort = Math.max(0, Math.floor(Number(shortById.get(id3) || 0) || 0));
+            want[id3] = neededShort;
+          }
+        } else {
+          for (const id3 of selectedIds) want[id3] = qtyEach;
+        }
 
         let totalCost = 0;
         const buyLines = [];
@@ -12199,7 +12226,9 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
 
         if (!buyLines.length) {
           return {
-            content: `${getIcon("pantry")} Your pantry is full. Upgrade storage or use ingredients to make room.`,
+            content: mode === "buyneed"
+              ? `${getIcon("help")} No purchasable shopping shortages found for the selected items right now.`
+              : `${getIcon("pantry")} Your pantry is full. Upgrade storage or use ingredients to make room.`,
             ephemeral: true
           };
         }

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6116,10 +6116,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const shiftSnapshotOrderCount = snapshot
         .reduce((sum, row) => sum + Math.max(0, Math.floor(Number(row?.total_orders || row?.visible_order_count || 0) || 0)), 0);
 
-      const menuLine = takeout.menu_recipe_ids.length > 0
-        ? takeout.menu_recipe_ids.map((rid) => `• ${displayRecipeName(rid)}`).join("\n")
-        : "_No menu configured yet._";
-
       const countByRecipe = new Map();
       for (const row of snapshot) {
         const rid = String(row?.recipe_id || "").trim();
@@ -6128,11 +6124,11 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         countByRecipe.set(rid, count);
       }
 
-      const visibleCounts = takeout.menu_recipe_ids.length > 0
+      const counterMenuLines = takeout.menu_recipe_ids.length > 0
         ? takeout.menu_recipe_ids
-          .map((rid) => `• ${displayRecipeName(rid)}: **${countByRecipe.get(rid) ?? 0}**`)
+          .map((rid) => `• ${displayRecipeName(rid)} — **${countByRecipe.get(rid) ?? 0}** orders`)
           .join("\n")
-        : "_No counter orders to show yet._";
+        : "_No menu configured yet._";
 
       const previewNow = active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0
         ? shiftEndsAt + 1000
@@ -6160,6 +6156,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const statusBits = [];
       if (active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0) {
         statusBits.push(`${getIcon("time")} **Shift Active** until <t:${Math.floor(shiftEndsAt / 1000)}:R> (<t:${Math.floor(shiftEndsAt / 1000)}:f>)`);
+        statusBits.push(`${getIcon("orders")} Your main order board is resting right now. Cozy up here and serve through the counter while this shift runs.`);
       } else {
         statusBits.push(`${getIcon("status_pending")} **Shift Inactive**`);
       }
@@ -6168,7 +6165,10 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       if (Number.isFinite(shiftStartedAt) && shiftStartedAt > 0) {
         statusBits.push(`${getIcon("calendar")} Last start: <t:${Math.floor(shiftStartedAt / 1000)}:f>`);
       }
-      statusBits.push(`${getIcon("coins")} Unclaimed idle coins: **${takeout.earned_unclaimed_coins || 0}c**`);
+      const unclaimedIdleCoins = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0));
+      if (unclaimedIdleCoins > 0) {
+        statusBits.push(`${getIcon("coins")} Unclaimed idle coins: **${unclaimedIdleCoins}c**`);
+      }
       if (shiftOperatingCost > 0) {
         statusBits.push(`${getIcon("coins")} Fixed shift operating cost paid: **${shiftOperatingCost}c**`);
       }
@@ -6178,21 +6178,22 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       if (shiftSnapshotOrderCount > 0) {
         statusBits.push(`${getIcon("orders")} Shift snapshot orders: **${shiftSnapshotOrderCount}** total`);
       }
-      statusBits.push(`${getIcon("time")} Processed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
-      statusBits.push(`${getIcon("time")} Remaining hours: **${remainingHours}**`);
+      if (active) {
+        statusBits.push(`${getIcon("time")} Processed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
+        statusBits.push(`${getIcon("time")} Remaining hours: **${remainingHours}**`);
+      }
       statusBits.push(`${getIcon("help")} Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})`);
 
       const description = [
         banner,
-        "Run a 12-hour counter shift with your selected menu, pay ingredient costs up front, and claim idle coin earnings when ready.",
+        "Run a cozy 12-hour counter shift with your selected menu, pay ingredient costs up front, and claim idle coin earnings when ready.",
+        "",
         takeoutCatchup?.processedHours > 0
           ? `${getIcon("time")} Catch-up processed **${takeoutCatchup.processedHours}h** and accrued **${takeoutCatchup.earned}c** while you were away.`
           : null,
         statusBits.join("\n"),
         "\n**Counter Menu**",
-        menuLine,
-        "\n**Visible Order Counts**",
-        visibleCounts
+        counterMenuLines
       ].filter(Boolean).join("\n");
 
       const embed = buildMenuEmbed({

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -88,6 +88,7 @@ import {
 import { socialMainMenuRow, socialMainMenuRowNoProfile } from "./noodleSocial.js";
 import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS } from "../game/social.js";
 import {
+  applySubscriptionEntitlementEvent,
   SUBSCRIPTION_PERKS,
   ensureSubscriptionState,
   getOrderAcceptCap,
@@ -4415,7 +4416,7 @@ return componentCommit(interaction, payload);
 
 try {
 const owner = `discord:${interaction.id}`;
-const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "subscriptions" || sub === "dashboard";
+const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "subscriptions" || sub === "subscriptions_toggle" || sub === "dashboard";
 const inDevPath = group === "dev" || isDevSubcommand;
 
 const buildDevStatusEmbed = () => {
@@ -4785,6 +4786,104 @@ if (inDevPath && sub === "subscriptions") {
     return commit({
       content: " ",
       embeds: [embed],
+      ephemeral: true
+    });
+  });
+}
+
+if (inDevPath && sub === "subscriptions_toggle") {
+  const targetUser = opt.getUser("user");
+  const targetUserId = targetUser?.id || opt.getString("user_id")?.trim() || userId;
+  const targetServerId = opt.getString("server_id")?.trim() || serverId;
+  const perkSelection = String(opt.getString("perk") || "").trim().toLowerCase();
+  const active = opt.getBoolean("active");
+  const durationDaysRaw = Number(opt.getInteger("duration_days"));
+  const durationDays = Number.isFinite(durationDaysRaw) && durationDaysRaw > 0
+    ? Math.floor(durationDaysRaw)
+    : 30;
+  const reason = String(opt.getString("reason") || "").trim();
+
+  if (!targetUserId) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Provide a user or user ID to update.", isError: true })],
+      ephemeral: true
+    });
+  }
+  if (active == null) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Provide active=true or active=false.", isError: true })],
+      ephemeral: true
+    });
+  }
+  if (!db) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Database unavailable in this environment.", isError: true })],
+      ephemeral: true
+    });
+  }
+
+  let selectedPerkIds;
+  if (perkSelection === "both") {
+    selectedPerkIds = [SUBSCRIPTION_PERKS.HOUSE_247, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER];
+  } else if (perkSelection === SUBSCRIPTION_PERKS.HOUSE_247 || perkSelection === SUBSCRIPTION_PERKS.TAKEOUT_COUNTER) {
+    selectedPerkIds = [perkSelection];
+  } else {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Invalid perk selection. Use house_247, takeout_counter, or both.", isError: true })],
+      ephemeral: true
+    });
+  }
+
+  const lockKey = `lock:user:${targetServerId}:${targetUserId}`;
+  return await withLock(db, lockKey, owner, 8000, async () => {
+    const existingPlayer = getPlayer(db, targetServerId, targetUserId);
+    const targetPlayer = existingPlayer || newPlayerProfile(targetUserId);
+    const now = nowTs();
+    const periodEndAt = active ? (now + (durationDays * 24 * 60 * 60 * 1000)) : now;
+    const eventType = active ? "ENTITLEMENT_UPDATE" : "ENTITLEMENT_DELETE";
+
+    const beforeStates = {};
+    const afterStates = {};
+    for (const perkId of selectedPerkIds) {
+      beforeStates[perkId] = hasActivePerk(targetPlayer, perkId, now);
+      applySubscriptionEntitlementEvent(targetPlayer, {
+        perkId,
+        eventType,
+        entitlementId: `dev_manual:${perkId}:${targetUserId}`,
+        periodStartAt: active ? now : null,
+        periodEndAt,
+        now
+      });
+      afterStates[perkId] = hasActivePerk(targetPlayer, perkId, now);
+    }
+
+    upsertPlayer(db, targetServerId, targetUserId, targetPlayer, null, targetPlayer.schema_version);
+
+    const perkNames = {
+      [SUBSCRIPTION_PERKS.HOUSE_247]: "24/7 House",
+      [SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]: "Take Out Counter"
+    };
+    const stateLines = selectedPerkIds.map((perkId) => {
+      const before = beforeStates[perkId] ? "ACTIVE" : "inactive";
+      const after = afterStates[perkId] ? "ACTIVE" : "inactive";
+      return `• ${perkNames[perkId]} (${perkId}): ${before} -> ${after}`;
+    });
+
+    const messageLines = [
+      `${getIcon("status_complete")} Updated subscriptions for <@${targetUserId}> (${targetUserId}) on server ${targetServerId}.`,
+      `Mode: ${active ? `enable (${durationDays} day${durationDays === 1 ? "" : "s"})` : "disable"}`,
+      ...stateLines,
+      reason ? `Reason: ${reason}` : null,
+      !existingPlayer ? "Note: Created a new player profile for this target." : null
+    ].filter(Boolean);
+
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: messageLines.join("\n") })],
       ephemeral: true
     });
   });

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1813,6 +1813,33 @@ if (showTakeout) {
 return row;
 }
 
+function noodleTakeoutActionRow(userId, { disableOpen = false, disableClaim = false } = {}) {
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`noodle:nav:takeout:${userId}`)
+      .setLabel("Status")
+      .setEmoji(getButtonEmoji("orders"))
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`noodle:nav:takeout_menu:${userId}`)
+      .setLabel("Set Menu")
+      .setEmoji(getButtonEmoji("recipes"))
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(`noodle:nav:takeout_open:${userId}`)
+      .setLabel("Open")
+      .setEmoji(getButtonEmoji("status_complete"))
+      .setStyle(disableOpen ? ButtonStyle.Secondary : ButtonStyle.Success)
+      .setDisabled(disableOpen),
+    new ButtonBuilder()
+      .setCustomId(`noodle:nav:takeout_claim:${userId}`)
+      .setLabel("Claim")
+      .setEmoji(getButtonEmoji("coins"))
+      .setStyle(disableClaim ? ButtonStyle.Secondary : ButtonStyle.Primary)
+      .setDisabled(disableClaim)
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Small helpers                                                      */
 /* ------------------------------------------------------------------ */
@@ -6090,7 +6117,18 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         color: theme.colors.success
       });
 
-      return { content: " ", embeds: [embed], ephemeral };
+      const canOpenShift = !active && takeout.menu_recipe_ids.length >= menuLimits.minRequired;
+      const canClaim = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0)) > 0;
+
+      return {
+        content: " ",
+        embeds: [embed],
+        components: [
+          noodleTakeoutActionRow(userId, { disableOpen: !canOpenShift, disableClaim: !canClaim }),
+          noodleMainMenuRowNoOrders(userId)
+        ],
+        ephemeral
+      };
     };
 
     if (sub === "takeout_menu") {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -2099,7 +2099,10 @@ function mergeTakeoutMenuPageSelection({
   const pageSelected = dedupeOrdered(pageSelectedRecipeIds).filter((id) => pageRecipeIds.has(id));
   const keepFromOtherPages = current.filter((id) => !pageRecipeIds.has(id));
 
-  const merged = [...keepFromOtherPages, ...pageSelected].slice(0, Math.max(1, Math.floor(Number(maxAllowed) || TAKEOUT_MENU_MAX_RECIPES)));
+  const resolvedMax = Number.isFinite(Number(maxAllowed))
+    ? Math.max(0, Math.floor(Number(maxAllowed)))
+    : TAKEOUT_MENU_MAX_RECIPES;
+  const merged = [...keepFromOtherPages, ...pageSelected].slice(0, resolvedMax);
   return merged;
 }
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6662,6 +6662,19 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         marketPrices: s.market_prices ?? {},
         items: content.items ?? {}
       });
+      const previewSnapshot = Array.isArray(previewResult?.snapshot) ? previewResult.snapshot : [];
+      const previewSnapshotOrderTotal = Math.max(
+        0,
+        Math.floor(
+          Number(
+            previewResult?.snapshotOrderTotal
+            ?? previewSnapshot.reduce(
+              (sum, row) => sum + Math.max(0, Math.floor(Number(row?.total_orders ?? row?.visible_order_count ?? 0) || 0)),
+              0
+            )
+          ) || 0
+        )
+      );
 
       const quote = {
         created_at: nowMs,
@@ -6669,10 +6682,10 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         menu_key: currentMenuKey,
         board_order_total: boardOrderTotal,
         unlimited_orders: unlimitedOrders,
-        snapshot_order_total: Math.max(0, Math.floor(Number(previewResult?.snapshotOrderTotal || 0) || 0)),
+        snapshot_order_total: previewSnapshotOrderTotal,
         operating_cost: Math.max(0, Math.floor(Number(previewResult?.operatingCost || 0) || 0)),
         required_ingredients: previewResult?.requiredIngredients ?? {},
-        snapshot: Array.isArray(previewResult?.snapshot) ? previewResult.snapshot : []
+        snapshot: previewSnapshot
       };
 
       if (!quote.snapshot.length || quote.snapshot_order_total <= 0) {
@@ -12536,7 +12549,10 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
           const remaining = remainingByType[type] ?? 0;
           const capacity = checkIngredientCapacity(p2, id3, 0);
           const stackRemaining = Math.max(0, (capacity.maxCapacity ?? 0) - (capacity.currentQty ?? 0));
-          const qtyToBuy = Math.min(qty3, remaining, stackRemaining);
+          const requestedQty = Math.max(0, Math.floor(Number(qty3 || 0) || 0));
+          if (requestedQty <= 0) continue;
+
+          const qtyToBuy = Math.min(requestedQty, remaining, stackRemaining);
 
           if (qtyToBuy <= 0) {
             capacityReduced = true;
@@ -12551,7 +12567,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
             };
           }
 
-          if (qtyToBuy < qty3) capacityReduced = true;
+          if (qtyToBuy < requestedQty) capacityReduced = true;
 
           totalCost += price * qtyToBuy;
           buyLines.push({ id: id3, qty: qtyToBuy, name: it.name, price });

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1814,7 +1814,39 @@ if (showTakeout) {
 return row;
 }
 
-function noodleTakeoutActionRow(userId, { disableOpen = false, disableClaim = false } = {}) {
+function noodleTakeoutActionRow(userId, { activeShift = false, disableOpen = false, disableClaim = false, disableServe = false } = {}) {
+  if (activeShift) {
+    return new ActionRowBuilder().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`noodle:nav:takeout:${userId}`)
+        .setLabel("Counter")
+        .setEmoji(getButtonEmoji("orders"))
+        .setStyle(ButtonStyle.Primary),
+      new ButtonBuilder()
+        .setCustomId(`noodle:pick:takeout_cook:${userId}`)
+        .setLabel("Counter Cook")
+        .setEmoji(getButtonEmoji("cook"))
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(`noodle:pick:takeout_serve:${userId}`)
+        .setLabel("Counter Serve")
+        .setEmoji(getButtonEmoji("serve"))
+        .setStyle(disableServe ? ButtonStyle.Secondary : ButtonStyle.Success)
+        .setDisabled(disableServe),
+      new ButtonBuilder()
+        .setCustomId(`noodle:nav:takeout_claim:${userId}`)
+        .setLabel("Claim")
+        .setEmoji(getButtonEmoji("coins"))
+        .setStyle(disableClaim ? ButtonStyle.Secondary : ButtonStyle.Primary)
+        .setDisabled(disableClaim),
+      new ButtonBuilder()
+        .setCustomId(`noodle:nav:orders:${userId}`)
+        .setLabel("Back")
+        .setEmoji(getButtonEmoji("back"))
+        .setStyle(ButtonStyle.Secondary)
+    );
+  }
+
   return new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(`noodle:nav:takeout:${userId}`)
@@ -4007,6 +4039,244 @@ function buildCookPickerPayload({ userId, p, s, ownerUser, page = 0 }) {
   };
 }
 
+function getTakeoutRecipeNeedRows(player, takeoutState) {
+  const menuRecipeIds = (takeoutState?.menu_recipe_ids ?? []).filter(Boolean);
+  const menuSet = new Set(menuRecipeIds);
+  const snapshot = Array.isArray(takeoutState?.shift?.idle_order_board_snapshot)
+    ? takeoutState.shift.idle_order_board_snapshot
+    : [];
+
+  const neededByRecipe = {};
+  for (const row of snapshot) {
+    const recipeId = String(row?.recipe_id || "").trim();
+    if (!recipeId) continue;
+    if (menuSet.size > 0 && !menuSet.has(recipeId)) continue;
+    const need = Math.max(0, Math.floor(Number(row?.visible_order_count || 0) || 0));
+    neededByRecipe[recipeId] = (neededByRecipe[recipeId] ?? 0) + need;
+  }
+
+  return menuRecipeIds.map((recipeId) => {
+    const need = Math.max(0, neededByRecipe[recipeId] ?? 0);
+    const ready = getTotalBowlsForRecipe(player, recipeId);
+    const short = Math.max(0, need - ready);
+    return { recipeId, need, ready, short };
+  });
+}
+
+function buildTakeoutNeededIngredientsBlock(player, takeoutState, { maxLines = 10 } = {}) {
+  const recipeNeeds = getTakeoutRecipeNeedRows(player, takeoutState).filter((entry) => entry.short > 0);
+  if (!recipeNeeds.length) {
+    return `${getIcon("basket")} **Needed Ingredients (Counter Orders)**\n_All ingredients currently ready for remaining counter orders._`;
+  }
+
+  const neededByIngredient = {};
+  for (const entry of recipeNeeds) {
+    const recipe = content.recipes?.[entry.recipeId];
+    if (!recipe) continue;
+    getRelevantRecipeIngredients(player, recipe).forEach((ing) => {
+      if (isIngredientOptionalForPlayer(player, ing)) return;
+      const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+      if (qty <= 0) return;
+      neededByIngredient[ing.item_id] = (neededByIngredient[ing.item_id] ?? 0) + (qty * entry.short);
+    });
+  }
+
+  const shortageRows = Object.entries(neededByIngredient)
+    .map(([itemId, needed]) => {
+      const have = Math.max(0, Math.floor(Number(player.inv_ingredients?.[itemId] || 0) || 0));
+      const short = Math.max(0, needed - have);
+      return { itemId, needed, have, short };
+    })
+    .filter((row) => row.short > 0)
+    .sort((a, b) => displayItemName(a.itemId).localeCompare(displayItemName(b.itemId), "en", { sensitivity: "base" }));
+
+  if (!shortageRows.length) {
+    return `${getIcon("basket")} **Needed Ingredients (Counter Orders)**\n_All ingredients currently ready for remaining counter orders._`;
+  }
+
+  const lines = shortageRows.slice(0, maxLines).map((row) => (
+    `• ${displayItemName(row.itemId)} — need **${row.needed}**, have **${row.have}** (short **${row.short}**)`
+  ));
+  const more = shortageRows.length > maxLines ? `\n…and **${shortageRows.length - maxLines}** more` : "";
+
+  return `${getIcon("basket")} **Needed Ingredients (Counter Orders)**\n${lines.join("\n")}${more}`;
+}
+
+function buildTakeoutCookPickerPayload({ userId, p, takeout, ownerUser, page = 0 }) {
+  const menuRecipeIds = (takeout?.menu_recipe_ids ?? []).filter((rid) => content.recipes?.[rid]);
+  if (!menuRecipeIds.length) {
+    return { content: `${getIcon("warning")} Your takeout menu is empty. Set a menu first.`, ephemeral: true };
+  }
+
+  const sortKey = (rid) => {
+    const r = content.recipes?.[rid];
+    return (r?.name ?? displayItemName(rid, content) ?? "").toLowerCase();
+  };
+  const sorted = [...menuRecipeIds].sort((a, b) => sortKey(a).localeCompare(sortKey(b), "en", { sensitivity: "base" }));
+  const totalPages = Math.max(1, Math.ceil(sorted.length / 25));
+  const safePage = Math.min(Math.max(Number(page) || 0, 0), totalPages - 1);
+
+  const opts = sorted
+    .slice(safePage * 25, (safePage + 1) * 25)
+    .map((rid) => {
+      const r = content.recipes?.[rid];
+      const relevantIngredients = getRelevantRecipeIngredients(p, r);
+      const labelRaw = r ? `${r.name} (${r.tier})` : displayItemName(rid, content);
+      const label = labelRaw.length > 100 ? labelRaw.slice(0, 97) + "…" : labelRaw;
+
+      const ingTokens = relevantIngredients.map((ing) => {
+        const have = Math.max(0, p.inv_ingredients?.[ing.item_id] ?? 0);
+        const name = displayItemName(ing.item_id);
+        const base = `${name}:${have}`;
+        return isIngredientOptionalForPlayer(p, ing) ? `${base} (opt)` : base;
+      });
+
+      const maxCookable = relevantIngredients
+        .filter((ing) => !isIngredientOptionalForPlayer(p, ing) && (ing?.qty ?? 0) > 0)
+        .map((ing) => Math.floor((p.inv_ingredients?.[ing.item_id] ?? 0) / (ing.qty ?? 1)))
+        .reduce((min, cur) => Math.min(min, cur), Infinity);
+      const cookable = Number.isFinite(maxCookable) ? Math.max(0, maxCookable) : 0;
+
+      const descRaw = ingTokens.length
+        ? `${ingTokens.join(" · ")} | Max ${cookable}`
+        : `Max ${cookable}`;
+      const description = descRaw.length > 100 ? descRaw.slice(0, 97) + "…" : descRaw;
+
+      const option = { label, value: rid, description };
+      if (cookable > 0) {
+        const emoji = getButtonEmoji("status_complete");
+        if (emoji) option.emoji = emoji;
+      }
+      return option;
+    });
+
+  const needRows = getTakeoutRecipeNeedRows(p, takeout)
+    .filter((entry) => entry.need > 0)
+    .map((entry) => {
+      const line = `• ${displayRecipeName(entry.recipeId)} — need **${entry.need}**, ready **${entry.ready}** (cook **${entry.short}** more)`;
+      return { ...entry, line };
+    })
+    .sort((a, b) => {
+      if (b.short !== a.short) return b.short - a.short;
+      return displayRecipeName(a.recipeId).localeCompare(displayRecipeName(b.recipeId), "en", { sensitivity: "base" });
+    });
+
+  const cookNeedsText = needRows.length
+    ? `${getIcon("cook")} Counter orders to cook:\n${needRows.slice(0, 6).map((x) => x.line).join("\n")}${needRows.length > 6 ? "\n…" : ""}`
+    : "";
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(`noodle:pick:cook_select:${userId}:${safePage}:${Date.now().toString(36)}`)
+    .setPlaceholder("Select a recipe to cook")
+    .setMinValues(1)
+    .setMaxValues(1)
+    .addOptions(opts);
+
+  const cookEmbed = buildMenuEmbed({
+    title: `${getIcon("cook")} Counter Cook`,
+    description: totalPages > 1
+      ? `Select a recipe to cook:\n(page ${safePage + 1}/${totalPages})`
+      : "Select a recipe to cook:",
+    user: ownerUser
+  });
+
+  if (cookNeedsText) {
+    const baseDesc = cookEmbed?.data?.description ?? cookEmbed?.description ?? "";
+    const combined = baseDesc ? `${baseDesc}\n\n${cookNeedsText}` : cookNeedsText;
+    cookEmbed.setDescription(combined);
+  }
+
+  const canCounterServe = needRows.some((entry) => entry.need > 0 && entry.ready > 0);
+  const navRow = totalPages > 1
+    ? new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`noodle:pick:takeout_cook:${userId}:${safePage <= 0 ? totalPages - 1 : safePage - 1}`)
+          .setLabel("Prev")
+          .setEmoji(getButtonEmoji("back"))
+          .setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder()
+          .setCustomId(`noodle:pick:takeout_cook:${userId}:${safePage >= totalPages - 1 ? 0 : safePage + 1}`)
+          .setLabel("Next")
+          .setEmoji(getButtonEmoji("next"))
+          .setStyle(ButtonStyle.Secondary)
+      )
+    : null;
+
+  const components = [new ActionRowBuilder().addComponents(menu)];
+  if (navRow) components.push(navRow);
+  components.push(
+    noodleTakeoutActionRow(userId, {
+      activeShift: true,
+      disableClaim: Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) <= 0,
+      disableServe: !canCounterServe
+    }),
+    noodleMainMenuRowNoOrders(userId)
+  );
+
+  return { content: " ", embeds: [cookEmbed], components };
+}
+
+function buildTakeoutServePickerPayload({ userId, p, takeout, ownerUser }) {
+  const needRows = getTakeoutRecipeNeedRows(p, takeout).filter((entry) => entry.need > 0);
+  if (!needRows.length) {
+    return { content: `${getIcon("help")} No counter orders remain to serve right now.`, ephemeral: true };
+  }
+
+  const opts = needRows
+    .slice()
+    .sort((a, b) => displayRecipeName(a.recipeId).localeCompare(displayRecipeName(b.recipeId), "en", { sensitivity: "base" }))
+    .map((entry) => {
+      const labelRaw = `${displayRecipeName(entry.recipeId)} — ${entry.ready} ready`;
+      const label = labelRaw.length > 100 ? labelRaw.slice(0, 97) + "…" : labelRaw;
+      const descRaw = `Remaining ${entry.need}`;
+      const description = descRaw.length > 100 ? descRaw.slice(0, 97) + "…" : descRaw;
+      const option = { label, value: entry.recipeId, description };
+      if (entry.ready > 0) {
+        const emoji = getButtonEmoji("status_complete");
+        if (emoji) option.emoji = emoji;
+      }
+      return option;
+    })
+    .slice(0, 25);
+
+  const missingLines = needRows
+    .filter((entry) => entry.short > 0)
+    .map((entry) => `• ${displayRecipeName(entry.recipeId)} — need **${entry.need}**, ready **${entry.ready}** (cook **${entry.short}** more)`);
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(`noodle:pick:takeout_serve_select:${userId}`)
+    .setPlaceholder("Select a recipe to serve")
+    .setMinValues(1)
+    .setMaxValues(1)
+    .addOptions(opts);
+
+  const descBase = "Select counter orders to serve.\nWhen you're done selecting, if on Desktop, press **Esc** to continue.";
+  const descWithMissing = missingLines.length
+    ? `${descBase}\n\n${getIcon("basket")} Missing bowls\n${missingLines.join("\n")}`
+    : descBase;
+
+  const serveEmbed = buildMenuEmbed({
+    title: `${getIcon("bowl")} Counter Serve`,
+    description: descWithMissing,
+    user: ownerUser
+  });
+
+  const canCounterServe = needRows.some((entry) => entry.ready > 0);
+  return {
+    content: " ",
+    embeds: [serveEmbed],
+    components: [
+      new ActionRowBuilder().addComponents(menu),
+      noodleTakeoutActionRow(userId, {
+        activeShift: true,
+        disableClaim: Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) <= 0,
+        disableServe: !canCounterServe
+      }),
+      noodleMainMenuRowNoOrders(userId)
+    ]
+  };
+}
+
 function getAllowedForageIdsForPlayer(player) {
   const allowed = getUnlockedIngredientIds(player, content);
   return (FORAGE_ITEM_IDS ?? []).filter((id) => allowed.has(id));
@@ -6034,7 +6304,7 @@ if (sub === "kitchen" || sub === "kitchen_start" || sub === "kitchen_collect") {
 }
 
 /* ---------------- RECIPES ---------------- */
-if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub === "takeout_claim") {
+if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub === "takeout_claim" || sub === "takeout_cook" || sub === "takeout_serve") {
   if (!db) {
     const unavailableEmbed = buildMenuEmbed({
       title: `${getIcon("orders")} Take Out Counter`,
@@ -6159,6 +6429,9 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
           .map((rid) => `• ${displayRecipeName(rid)} — **${countByRecipe.get(rid) ?? 0}** orders`)
           .join("\n")
         : "_No menu configured yet._";
+      const neededIngredientsBlock = active
+        ? buildTakeoutNeededIngredientsBlock(p, takeout, { maxLines: 8 })
+        : null;
 
       const statusBits = [];
       if (active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0) {
@@ -6193,7 +6466,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const description = [
         banner,
-        "Set your counter menu, start a cozy 12-hour shift, and collect idle earnings. While the shift is active, your main **Order Board** is idle and all service happens from **Take Out Counter**.",
+        "Set your counter menu, start a cozy 12-hour shift, and collect idle earnings. While the shift is active, your main **Order Board** is idle and all service happens from the **Take Out Counter**.",
         "",
         takeoutCatchup?.processedHours > 0
           ? `${getIcon("time")} **${takeoutCatchup.processedHours}h** & earned **${takeoutCatchup.earned}c** while you were away.`
@@ -6201,7 +6474,9 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         "\u200b",
         statusBits.join("\n"),
         "\n**Counter Menu**",
-        counterMenuLines
+        counterMenuLines,
+        "",
+        neededIngredientsBlock
       ].filter(Boolean).join("\n");
 
       const embed = buildMenuEmbed({
@@ -6213,6 +6488,11 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const canOpenShift = !active && takeout.menu_recipe_ids.length >= menuLimits.minRequired;
       const canClaim = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0)) > 0;
+      const canCounterServe = active && takeout.menu_recipe_ids.some((rid) => {
+        const remaining = Math.max(0, Math.floor(Number(countByRecipe.get(rid) || 0) || 0));
+        if (remaining <= 0) return false;
+        return getTotalBowlsForRecipe(p, rid) > 0;
+      });
       const menuPicker = showMenuPicker
         ? buildTakeoutMenuPickerRows(userId, {
             availableRecipeIds,
@@ -6228,7 +6508,12 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         embeds: [embed],
         components: [
           ...(menuPicker?.rows ?? []),
-          noodleTakeoutActionRow(userId, { disableOpen: !canOpenShift, disableClaim: !canClaim }),
+          noodleTakeoutActionRow(userId, {
+            activeShift: active,
+            disableOpen: !canOpenShift,
+            disableClaim: !canClaim,
+            disableServe: !canCounterServe
+          }),
           noodleMainMenuRowNoOrders(userId)
         ],
         ephemeral
@@ -6355,6 +6640,147 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       );
     }
 
+    if (sub === "takeout_cook") {
+      if (!isTakeoutShiftActive(p, now)) {
+        return finalize(renderStatus(`${getIcon("help")} Start a shift to use **Counter Cook**.` , { ephemeral: true }));
+      }
+      const rawPage = Number(opt.getInteger("page") ?? 0);
+      return finalize(buildTakeoutCookPickerPayload({
+        userId,
+        p,
+        takeout,
+        ownerUser: interaction.member ?? interaction.user,
+        page: Number.isFinite(rawPage) ? rawPage : 0
+      }));
+    }
+
+    if (sub === "takeout_serve") {
+      if (!isTakeoutShiftActive(p, now)) {
+        return finalize(renderStatus(`${getIcon("help")} Start a shift to use **Counter Serve**.`, { ephemeral: true }));
+      }
+
+      const selectedRecipeId = resolveCanonicalRecipeId(String(opt.getString("recipe") || "").trim());
+      const snapshot = Array.isArray(takeout.shift?.idle_order_board_snapshot)
+        ? takeout.shift.idle_order_board_snapshot
+        : [];
+      const menuSet = new Set(takeout.menu_recipe_ids || []);
+
+      if (!selectedRecipeId) {
+        return finalize(buildTakeoutServePickerPayload({
+          userId,
+          p,
+          takeout,
+          ownerUser: interaction.member ?? interaction.user
+        }));
+      }
+
+      if (!menuSet.has(selectedRecipeId)) {
+        return finalize(renderStatus(`${getIcon("warning")} That recipe is not on your current takeout menu.`, { ephemeral: true }));
+      }
+
+      const snapshotRow = snapshot.find((x) => String(x?.recipe_id || "") === selectedRecipeId);
+      if (!snapshotRow || Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0)) <= 0) {
+        return finalize(renderStatus(`${getIcon("help")} No remaining counter orders for **${displayRecipeName(selectedRecipeId)}**.`, { ephemeral: true }));
+      }
+
+      const bowlEntry = getBestBowlEntry(p, selectedRecipeId);
+      const bowl = bowlEntry?.bowl ?? null;
+      if (!bowl || (bowl.qty ?? 0) <= 0) {
+        return finalize(renderStatus(`${getIcon("basket")} You need a ready bowl of **${displayRecipeName(selectedRecipeId)}** first.`, { ephemeral: true }));
+      }
+
+      const servedAt = nowTs();
+      const recipe = content.recipes?.[selectedRecipeId] ?? null;
+      const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
+      const activeEventEffects = getActiveEventEffects(eventsContent, s);
+      const rewards = computeServeRewards({
+        serverId,
+        tier: recipe?.tier ?? "common",
+        npcArchetype: null,
+        isLimitedTime: false,
+        servedAtMs: servedAt,
+        acceptedAtMs: servedAt,
+        speedWindowSeconds: 180,
+        player: p,
+        recipe,
+        content,
+        effects: combinedEffects,
+        eventEffects: activeEventEffects
+      });
+
+      const bowlQuality = normalizeQuality(bowl.quality);
+      const qualityMult = getQualityMultiplier(bowlQuality);
+      rewards.coins = Math.floor(rewards.coins * qualityMult);
+      rewards.rep = Math.floor(rewards.rep * qualityMult);
+      rewards.sxp = Math.floor(rewards.sxp * qualityMult);
+
+      bowl.qty -= 1;
+      if (bowl.qty <= 0) delete p.inv_bowls[bowlEntry?.key ?? selectedRecipeId];
+
+      snapshotRow.visible_order_count = Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0) - 1);
+
+      if (!hasHouse247Perk(p)) {
+        const { totalCount, consumedSet } = getOrdersMeta(p);
+        for (let idx = 0; idx < totalCount; idx += 1) {
+          if (!consumedSet.has(idx)) {
+            markOrderConsumed(p, idx);
+            break;
+          }
+        }
+      }
+
+      p.coins = (Number.isFinite(p.coins) ? p.coins : 0) + rewards.coins;
+      p.rep = (Number.isFinite(p.rep) ? p.rep : 0) + rewards.rep;
+      p.sxp_total = (Number.isFinite(p.sxp_total) ? p.sxp_total : 0) + rewards.sxp;
+      p.sxp_progress = (Number.isFinite(p.sxp_progress) ? p.sxp_progress : 0) + rewards.sxp;
+      if (!p.lifetime) p.lifetime = {};
+      p.lifetime.orders_served = (p.lifetime.orders_served ?? 0) + 1;
+      p.lifetime.bowls_served_total = (p.lifetime.bowls_served_total ?? 0) + 1;
+      p.lifetime.coins_earned = (p.lifetime.coins_earned ?? 0) + rewards.coins;
+      const leveledUp = applySxpLevelUp(p);
+
+      const discoveryMessages = [];
+      if (bowlQuality !== "salvage") {
+        const dayKey = dayKeyUTC(servedAt);
+        const discoveryRng = makeStreamRng({
+          mode: "seeded",
+          seed: 12345,
+          streamName: "discovery",
+          serverId,
+          dayKey,
+          extra: `${selectedRecipeId}_${servedAt}`
+        });
+        const discoveries = rollRecipeDiscovery({
+          player: p,
+          content,
+          npcArchetype: null,
+          tier: recipe?.tier ?? "common",
+          rng: discoveryRng,
+          activeSeason: s.season,
+          activeEventId: s.active_event_id ?? null
+        });
+        for (const discovery of discoveries ?? []) {
+          const result = applyDiscovery(p, discovery, content, discoveryRng, { badgesContent });
+          if (result?.message) discoveryMessages.push(result.message);
+        }
+      }
+
+      const remainingForRecipe = Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0));
+      const serveSummary = [
+        `${getIcon("serve")} Served **${displayRecipeName(selectedRecipeId)}** from the takeout counter.`,
+        `${getIcon("coins")} +${rewards.coins}c · ${getIcon("rep")} +${rewards.rep} rep · ${getIcon("sxp")} +${rewards.sxp} sxp`,
+        `${getIcon("orders")} Remaining counter orders for this recipe: **${remainingForRecipe}**`
+      ];
+      if (leveledUp) {
+        serveSummary.push(`${getIcon("status_complete")} Level up! You are now **Lv.${Math.max(1, Number(p.sxp_level || 1))}**.`);
+      }
+      if (discoveryMessages.length > 0) {
+        serveSummary.push(discoveryMessages.join("\n"));
+      }
+
+      return finalize(renderStatus(serveSummary.join("\n\n")));
+    }
+
     if (sub === "takeout_claim") {
       const claimed = claimTakeoutEarnings(p, { now });
       if (!claimed.ok) {
@@ -6376,7 +6802,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         unclaimedCoinsAfter: Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0))
       });
 
-      return finalize(renderStatus(`${getIcon("coins")} Claimed **${claimed.amount}c** from takeout idle earnings.`));
+      return finalize(renderStatus(`${getIcon("coins")} Claimed **${claimed.amount}c** from the takeout idle earnings.`));
     }
 
     return finalize(renderStatus());
@@ -10839,6 +11265,25 @@ if (action === "cook") {
   return componentCommit(interaction, payload);
 }
 
+if (action === "takeout_cook") {
+  const rawPage = Number(parts[4] ?? 0);
+  const page = Number.isFinite(rawPage) ? Math.max(0, rawPage) : 0;
+  return runNoodle(interaction, {
+    sub: "takeout_cook",
+    overrides: {
+      messageId: interaction.message?.id ?? null,
+      integers: { page }
+    }
+  });
+}
+
+if (action === "takeout_serve") {
+  return runNoodle(interaction, {
+    sub: "takeout_serve",
+    overrides: { messageId: interaction.message?.id ?? null }
+  });
+}
+
 return componentCommit(interaction, { content: "Unknown picker action.", ephemeral: true });
 
 }
@@ -10896,6 +11341,14 @@ if (cid.startsWith("noodle:pick:serve_select:")) {
   return await runNoodle(interaction, {
     sub: "serve",
     overrides: { strings: { order_id: orderIds.join(",") } }
+  });
+}
+
+if (cid.startsWith("noodle:pick:takeout_serve_select:")) {
+  const recipeId = interaction.values?.[0] ?? "";
+  return await runNoodle(interaction, {
+    sub: "takeout_serve",
+    overrides: { strings: { recipe: recipeId }, messageId: interaction.message?.id ?? null }
   });
 }
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -4862,15 +4862,14 @@ async function renderMultiBuyPicker({ interaction, userId, s, p }) {
 function buildMultiBuyButtonsRow(userId, selectedIds, sourceMessageId, { limitToBuy1 = false, showBuyNeeded = true } = {}) {
 const selectedNames = formatSelectedItemNames(selectedIds);
 const msgId = sourceMessageId || "none";
-const btnRow = new ActionRowBuilder().addComponents(
-new ButtonBuilder()
+const buyOneButton = new ButtonBuilder()
   .setCustomId(`noodle:multibuy:buy1:${userId}:${msgId}`)
   .setLabel("Buy 1 each")
-  .setStyle(ButtonStyle.Success)
-);
+  .setStyle(ButtonStyle.Success);
+
+let btnRow = new ActionRowBuilder().addComponents(buyOneButton);
 
 if (!limitToBuy1) {
-  const baseBuyOneButton = btnRow.components[0];
   const components = [];
   if (showBuyNeeded) {
     components.push(
@@ -4881,7 +4880,7 @@ if (!limitToBuy1) {
     );
   }
   components.push(
-    baseBuyOneButton,
+    buyOneButton,
     new ButtonBuilder()
       .setCustomId(`noodle:multibuy:buy5:${userId}:${msgId}`)
       .setLabel("Buy 5 each")
@@ -4895,7 +4894,7 @@ if (!limitToBuy1) {
       .setLabel("Clear")
       .setStyle(ButtonStyle.Danger)
   );
-  btnRow.setComponents(...components);
+  btnRow = new ActionRowBuilder().addComponents(...components);
 }
 
 return { selectedNames, btnRow };
@@ -5273,7 +5272,7 @@ if (inDevPath && sub === "wipe_user") {
     });
   }
 
-  const lockKey = `lock:user:${targetServerId}:${targetUserId}`;
+  const lockKey = `lock:user:${targetUserId}`;
   return await withLock(db, lockKey, owner, 8000, async () => {
     const storageServerId = getPlayerStorageServerId(targetServerId);
     const result = db.prepare("DELETE FROM players WHERE server_id=? AND user_id=?").run(storageServerId, targetUserId);
@@ -5387,7 +5386,7 @@ if (inDevPath && sub === "subscriptions") {
     });
   }
 
-  const lockKey = `lock:user:${targetServerId}:${targetUserId}`;
+  const lockKey = `lock:user:${targetUserId}`;
   return await withLock(db, lockKey, owner, 8000, async () => {
     const targetPlayer = getPlayer(db, targetServerId, targetUserId);
     if (!targetPlayer) {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -89,6 +89,7 @@ import { socialMainMenuRow, socialMainMenuRowNoProfile } from "./noodleSocial.js
 import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS } from "../game/social.js";
 import {
   applySubscriptionEntitlementEvent,
+  applyMonthlySubscriptionCoinGrant,
   SUBSCRIPTION_PERKS,
   ensureSubscriptionState,
   getOrderAcceptCap,
@@ -734,6 +735,20 @@ function isDevAdmin(userId) {
 
 function hasHouse247Perk(player) {
   return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, nowTs());
+}
+
+function applyHouse247OrderBoardOverride(player) {
+  const orderCap = Math.max(0, Math.floor(Number(getOrderAcceptCap(player, nowTs()) || 0) || 0));
+  const currentTotal = Math.max(0, Math.floor(Number(player?.orders_total_count || 0) || 0));
+  if (orderCap <= currentTotal) return;
+
+  player.orders_total_count = orderCap;
+  const consumedCount = Array.isArray(player?.orders_consumed_indices)
+    ? player.orders_consumed_indices.length
+    : 0;
+  if (consumedCount < orderCap) {
+    player.orders_depleted_day = null;
+  }
 }
 
 function buildHelpPage({ page, userId, user }) {
@@ -1769,7 +1784,13 @@ function noodleOrdersActionRowWithBack(userId, { highlightAccept = true, disable
   );
 }
 
-function noodleOrdersMenuActionRow(userId, { showCancel = false, highlightAccept = true, disableAccept = false, disableServe = false } = {}) {
+function noodleOrdersMenuActionRow(userId, {
+  showCancel = false,
+  highlightAccept = true,
+  disableAccept = false,
+  disableServe = false,
+  showTakeout = false
+} = {}) {
 const acceptStyle = disableAccept ? ButtonStyle.Secondary : (highlightAccept ? ButtonStyle.Success : ButtonStyle.Secondary);
 const row = new ActionRowBuilder().addComponents(
 new ButtonBuilder().setCustomId(`noodle:pick:accept:${userId}`).setLabel("Accept").setEmoji(getButtonEmoji("status_complete")).setStyle(acceptStyle).setDisabled(disableAccept),
@@ -1780,6 +1801,12 @@ new ButtonBuilder().setCustomId(`noodle:pick:serve:${userId}`).setLabel("Serve")
 if (showCancel) {
   row.addComponents(
     new ButtonBuilder().setCustomId(`noodle:pick:cancel:${userId}`).setLabel("Cancel").setEmoji(getButtonEmoji("cancel")).setStyle(ButtonStyle.Danger)
+  );
+}
+
+if (showTakeout) {
+  row.addComponents(
+    new ButtonBuilder().setCustomId(`noodle:nav:takeout:${userId}`).setLabel("Takeout").setEmoji(getButtonEmoji("orders")).setStyle(ButtonStyle.Success)
   );
 }
 
@@ -3499,6 +3526,7 @@ function buildAcceptPickerPayload({ userId, serverId, p, s, ownerUser, page = 0 
   const activeEventId = s.active_event_id ?? null;
   rollMarket({ serverId, content, serverState: s, eventEffects: activeEventEffects });
   ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, activeEventId);
+  applyHouse247OrderBoardOverride(p);
 
   const pageSize = 25;
   const { totalCount, consumedSet, availableCount } = getOrdersMeta(p);
@@ -4848,6 +4876,7 @@ if (inDevPath && sub === "subscriptions_toggle") {
 
     const beforeStates = {};
     const afterStates = {};
+    let totalGrant = 0;
     for (const perkId of selectedPerkIds) {
       beforeStates[perkId] = hasActivePerk(targetPlayer, perkId, now);
       applySubscriptionEntitlementEvent(targetPlayer, {
@@ -4858,6 +4887,17 @@ if (inDevPath && sub === "subscriptions_toggle") {
         periodEndAt,
         now
       });
+      if (active) {
+        const grantResult = applyMonthlySubscriptionCoinGrant(targetPlayer, {
+          perkId,
+          periodStartAt: now,
+          periodEndAt,
+          now
+        });
+        if (grantResult?.granted) {
+          totalGrant += Math.max(0, Math.floor(Number(grantResult.amount || 0) || 0));
+        }
+      }
       afterStates[perkId] = hasActivePerk(targetPlayer, perkId, now);
     }
 
@@ -4877,6 +4917,7 @@ if (inDevPath && sub === "subscriptions_toggle") {
       `${getIcon("status_complete")} Updated subscriptions for <@${targetUserId}> (${targetUserId}) on server ${targetServerId}.`,
       `Mode: ${active ? `enable (${durationDays} day${durationDays === 1 ? "" : "s"})` : "disable"}`,
       ...stateLines,
+      active ? `Subscription coin grant awarded now: **${totalGrant}c**` : null,
       reason ? `Reason: ${reason}` : null,
       !existingPlayer ? "Note: Created a new player profile for this target." : null
     ].filter(Boolean);
@@ -6098,6 +6139,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const set = buildSettingsMap(settingsCatalog, s.settings);
       s.season = computeActiveSeason(set);
       ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, s.active_event_id ?? null);
+      applyHouse247OrderBoardOverride(p);
 
       const boardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
       const unlimitedOrders = hasHouse247Perk(p);
@@ -6667,6 +6709,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
 
     const prevOrdersDay = p.orders_day;
     ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, activeEventId);
+    applyHouse247OrderBoardOverride(p);
     ensureQuests(p, questsContent, userId, now, questOptions);
 
     // Force market stock refresh to align with daily order reset
@@ -6693,6 +6736,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
     if (resilience.applied && p.resilience?.temp_recipes?.length > 0) {
       p.orders_day = null; // Force regeneration
       ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, activeEventId);
+      applyHouse247OrderBoardOverride(p);
     }
 
     progressionPrepared = true;
@@ -6739,6 +6783,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
       // Regenerate orders for normal play after recovery
       p.orders_day = null;
       ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, activeEventId);
+      applyHouse247OrderBoardOverride(p);
     }
     
     const spoilageMessages = timeCatchup?.spoilage?.messages ?? [];
@@ -7904,6 +7949,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
       unlockLines.push(`${getIcon("sparkle")} New recipes unlocked: ${recipeNames}.`);
       const activeEventId = s.active_event_id ?? null;
       ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, activeEventId);
+      applyHouse247OrderBoardOverride(p);
     }
 
     const rejectedText = Object.keys(rejected || {}).length
@@ -8757,7 +8803,9 @@ ${lines.join("\n")}`;
     if (remaining > 0) {
       parts.push(
         "**Today’s Orders**",
-        `There are **${remaining}** orders available. Tap **Accept** below to start serving customers.`
+        hasHouse247Perk(p)
+          ? `${getIcon("sparkle")} 24/7 House active: unlimited order capacity and market stock. Tap **Accept** below to start serving customers.`
+          : `There are **${remaining}** orders available. Tap **Accept** below to start serving customers.`
       );
     } else if (acceptedLines.length) {
       parts.push(
@@ -8784,13 +8832,11 @@ ${lines.join("\n")}`;
 
     const tutSuffix = tutorialSuffix(p);
     if (tutSuffix) parts.push("", tutSuffix);
-    if (hasHouse247Perk(p)) {
-      parts.push("", `${getIcon("sparkle")} 24/7 House active: unlimited order capacity and market stock.`);
-    }
 
     const showCancel = acceptedEntries.length > 0;
     const highlightAccept = acceptedEntries.length === 0 && remaining > 0;
     const disableAccept = remaining <= 0;
+    const showTakeout = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, nowTs());
     const menuEmbed = buildMenuEmbed({
       title: `${getIcon("orders")} Orders`,
       description: parts.join("\n"),
@@ -8808,7 +8854,13 @@ ${lines.join("\n")}`;
       components: tutorialRows
         ? tutorialRows
         : [
-            noodleOrdersMenuActionRow(userId, { showCancel, highlightAccept, disableAccept, disableServe: acceptedEntries.length === 0 }),
+            noodleOrdersMenuActionRow(userId, {
+              showCancel,
+              highlightAccept,
+              disableAccept,
+              disableServe: acceptedEntries.length === 0,
+              showTakeout
+            }),
             noodleMainMenuRowNoOrders(userId)
           ]
     });
@@ -9609,6 +9661,7 @@ ${lines.join("\n")}`;
     if (recipeUnlocked) {
       const activeEventId = s.active_event_id ?? null;
       ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, activeEventId);
+      applyHouse247OrderBoardOverride(p);
       const friendlyNames = unlockedRecipeNames.length
         ? unlockedRecipeNames.length === 1
           ? unlockedRecipeNames[0]

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -86,7 +86,7 @@ import {
   normalizeNewsClassification,
 } from "../util/news.js";
 import { socialMainMenuRow, socialMainMenuRowNoProfile } from "./noodleSocial.js";
-import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS } from "../game/social.js";
+import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS, repairPartyRecord } from "../game/social.js";
 import {
   applySubscriptionEntitlementEvent,
   applyMonthlySubscriptionCoinGrant,
@@ -97,6 +97,7 @@ import {
   hasActivePerk,
   hasUnlimitedMarketStock
 } from "../game/subscriptions.js";
+import { grantStoreCoinPack, getStoreCoinPack, STORE_COIN_PACKS } from "../game/storeCoinPacks.js";
 import {
   TAKEOUT_SHIFT_DURATION_HOURS,
   TAKEOUT_MENU_MAX_RECIPES,
@@ -278,6 +279,14 @@ function formatSelectedItemNames(selectedIds, { maxNames = 3, maxChars = 80 } = 
   return `${truncatedVisible}${suffix}`;
 }
 
+function getHouse247Label() {
+  return `${getIcon("perk_house_247", getIcon("sparkle"))} 24/7 House`;
+}
+
+function getTakeoutCounterLabel() {
+  return `${getIcon("perk_takeout_counter", getIcon("orders"))} Take Out Counter`;
+}
+
 function applyUnlockNoticeEmbeds(payload = {}, player, user, { consumeSeatingNotice = false, consumeSubscriptionNotice = false } = {}) {
   if (!player) return payload;
 
@@ -353,11 +362,11 @@ function applyUnlockNoticeEmbeds(payload = {}, player, user, { consumeSeatingNot
 
   const subscriptionPerkMeta = {
     [SUBSCRIPTION_PERKS.HOUSE_247]: {
-      name: "24/7 House",
+      name: getHouse247Label(),
       tryLine: "Try it in **/noodle orders** and **/noodle market**."
     },
     [SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]: {
-      name: "Take Out Counter",
+      name: getTakeoutCounterLabel(),
       tryLine: "Try it in **/noodle takeout** from your orders menu."
     }
   };
@@ -828,7 +837,7 @@ function isDevAdmin(userId) {
 }
 
 function hasHouse247Perk(player) {
-  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, nowTs());
+  return hasUnlimitedMarketStock(player, nowTs());
 }
 
 function applyHouse247OrderBoardOverride(player) {
@@ -2996,8 +3005,17 @@ function renderProfileEmbed(player, displayName, partyName, ownerUser) {
     )
     : getIconUrl("decor_set_placeholder");
 
+  const activePerkTitleIcons = [];
+  if (hasUnlimitedMarketStock(player, nowTs())) {
+    activePerkTitleIcons.push(getIcon("perk_house_247", getIcon("sparkle")));
+  }
+  if (hasActivePerk(player, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, nowTs())) {
+    activePerkTitleIcons.push(getIcon("perk_takeout_counter", getIcon("sparkle")));
+  }
+  const titlePrefix = activePerkTitleIcons.length ? `${activePerkTitleIcons.join(" ")} ` : "";
+
   const embed = new EmbedBuilder()
-    .setTitle(`${getIcon("profile")} ${player.profile.shop_name}`)
+    .setTitle(`${titlePrefix}${getIcon("profile")} ${player.profile.shop_name}`)
     .setDescription(description)
     .setColor(theme.colors.primary)
     .addFields(
@@ -3639,7 +3657,7 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
   const descriptionLines = [
     "Select up to **5** items",
     "When you’re done selecting, if on Desktop, press **Esc** to continue",
-    unlimitedMarketStock ? `${getIcon("sparkle")} 24/7 House active: market stock is **unlimited**.` : null,
+    unlimitedMarketStock ? `${getHouse247Label()} active: market stock is **unlimited**.` : null,
     shoppingList ? "" : null,
     shoppingList,
     "",
@@ -5071,7 +5089,7 @@ return componentCommit(interaction, payload);
 
 try {
 const owner = `discord:${interaction.id}`;
-const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "subscriptions" || sub === "subscriptions_toggle" || sub === "dashboard";
+const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "repair_party" || sub === "subscriptions" || sub === "giveaway_winner" || sub === "dashboard";
 const inDevPath = group === "dev" || isDevSubcommand;
 
 const buildDevStatusEmbed = () => {
@@ -5360,6 +5378,73 @@ if (inDevPath && sub === "repair_profile") {
   });
 }
 
+if (inDevPath && sub === "repair_party") {
+  const partyIdInput = opt.getString("party_id")?.trim();
+  const serverOverride = opt.getString("server_id")?.trim() || "";
+  const targetServerId = serverOverride || serverId;
+  const scopedServerId = serverOverride || null;
+
+  if (!partyIdInput) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Provide a party ID or prefix to repair.", isError: true })],
+      ephemeral: true
+    });
+  }
+  if (!db) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Database unavailable in this environment.", isError: true })],
+      ephemeral: true
+    });
+  }
+
+  const lockScope = scopedServerId || "global";
+  const lockKey = `lock:party:${lockScope}:${partyIdInput}`;
+  return await withLock(db, lockKey, owner, 8000, async () => {
+    try {
+      const result = repairPartyRecord(db, partyIdInput, scopedServerId);
+      const summary = [
+        `Party: ${result.partyId} (server ${result.serverId})`,
+        `Status: ${result.statusBefore} -> ${result.statusAfter}`,
+        `Leader: <@${result.leaderBefore}> -> <@${result.leaderAfter}>`,
+        `Active members: ${result.activeMemberCount}`
+      ];
+
+      if (!scopedServerId && result.serverId !== serverId) {
+        summary.push(`Note: repaired party was found in a different server (${result.serverId}).`);
+      }
+
+      if (result.repaired) {
+        summary.push(`Applied fixes: ${result.changes.join(", ")}`);
+        return commit({
+          content: " ",
+          embeds: [buildDevMessageEmbed({ message: `${getIcon("status_complete")} ${summary.join("\n")}` })],
+          ephemeral: true
+        });
+      }
+
+      summary.push("No repair needed.");
+      return commit({
+        content: " ",
+        embeds: [buildDevMessageEmbed({ message: `${getIcon("status_complete")} ${summary.join("\n")}` })],
+        ephemeral: true
+      });
+    } catch (err) {
+      return commit({
+        content: " ",
+        embeds: [
+          buildDevMessageEmbed({
+            message: `${getIcon("error")} Party repair failed: ${err?.message || "unknown error"}`,
+            isError: true
+          })
+        ],
+        ephemeral: true
+      });
+    }
+  });
+}
+
 if (inDevPath && sub === "subscriptions") {
   const targetUser = opt.getUser("user");
   const targetUserId = targetUser?.id || opt.getString("user_id")?.trim() || userId;
@@ -5409,7 +5494,7 @@ if (inDevPath && sub === "subscriptions") {
     const perkLines = Object.values(SUBSCRIPTION_PERKS).map((perkId) => {
       const state = perks[perkId] ?? {};
       const activeNow = hasActivePerk(targetPlayer, perkId, now);
-      const name = perkId === SUBSCRIPTION_PERKS.HOUSE_247 ? "24/7 House" : "Take Out Counter";
+      const name = perkId === SUBSCRIPTION_PERKS.HOUSE_247 ? getHouse247Label() : getTakeoutCounterLabel();
       const status = activeNow ? "ACTIVE" : "inactive";
       return [
         `**${name}** (${perkId})`,
@@ -5446,12 +5531,17 @@ if (inDevPath && sub === "subscriptions") {
   });
 }
 
-if (inDevPath && sub === "subscriptions_toggle") {
+if (inDevPath && sub === "giveaway_winner") {
   const targetUser = opt.getUser("user");
   const targetUserId = targetUser?.id || opt.getString("user_id")?.trim() || userId;
   const targetServerId = opt.getString("server_id")?.trim() || serverId;
+  const rewardType = String(opt.getString("reward_type") || "").trim().toLowerCase();
   const perkSelection = String(opt.getString("perk") || "").trim().toLowerCase();
-  const active = opt.getBoolean("active");
+  const coinPackId = String(opt.getString("coin_pack") || "").trim().toLowerCase();
+  const coinAmountRaw = Number(opt.getInteger("coins"));
+  const coinAmount = Number.isFinite(coinAmountRaw) && coinAmountRaw > 0
+    ? Math.floor(coinAmountRaw)
+    : 0;
   const durationDaysRaw = Number(opt.getInteger("duration_days"));
   const durationDays = Number.isFinite(durationDaysRaw) && durationDaysRaw > 0
     ? Math.floor(durationDaysRaw)
@@ -5465,13 +5555,6 @@ if (inDevPath && sub === "subscriptions_toggle") {
       ephemeral: true
     });
   }
-  if (active == null) {
-    return commit({
-      content: " ",
-      embeds: [buildDevMessageEmbed({ message: "Provide active=true or active=false.", isError: true })],
-      ephemeral: true
-    });
-  }
   if (!db) {
     return commit({
       content: " ",
@@ -5480,15 +5563,10 @@ if (inDevPath && sub === "subscriptions_toggle") {
     });
   }
 
-  let selectedPerkIds;
-  if (perkSelection === "both") {
-    selectedPerkIds = [SUBSCRIPTION_PERKS.HOUSE_247, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER];
-  } else if (perkSelection === SUBSCRIPTION_PERKS.HOUSE_247 || perkSelection === SUBSCRIPTION_PERKS.TAKEOUT_COUNTER) {
-    selectedPerkIds = [perkSelection];
-  } else {
+  if (rewardType !== "perk" && rewardType !== "coin_pack" && rewardType !== "coins") {
     return commit({
       content: " ",
-      embeds: [buildDevMessageEmbed({ message: "Invalid perk selection. Use house_247, takeout_counter, or both.", isError: true })],
+      embeds: [buildDevMessageEmbed({ message: "Invalid reward type. Use perk, coin_pack, or coins.", isError: true })],
       ephemeral: true
     });
   }
@@ -5498,23 +5576,40 @@ if (inDevPath && sub === "subscriptions_toggle") {
     const existingPlayer = getPlayer(db, targetServerId, targetUserId);
     const targetPlayer = existingPlayer || newPlayerProfile(targetUserId);
     const now = nowTs();
-    const periodEndAt = active ? (now + (durationDays * 24 * 60 * 60 * 1000)) : now;
-    const eventType = active ? "ENTITLEMENT_UPDATE" : "ENTITLEMENT_DELETE";
+    const rewardSummaryLines = [];
+    let publicWinnerLine = "";
 
-    const beforeStates = {};
-    const afterStates = {};
-    let totalGrant = 0;
-    for (const perkId of selectedPerkIds) {
-      beforeStates[perkId] = hasActivePerk(targetPlayer, perkId, now);
-      applySubscriptionEntitlementEvent(targetPlayer, {
-        perkId,
-        eventType,
-        entitlementId: `dev_manual:${perkId}:${targetUserId}`,
-        periodStartAt: active ? now : null,
-        periodEndAt,
-        now
-      });
-      if (active) {
+    if (rewardType === "perk") {
+      let selectedPerkIds;
+      if (perkSelection === "both") {
+        selectedPerkIds = [SUBSCRIPTION_PERKS.HOUSE_247, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER];
+      } else if (perkSelection === SUBSCRIPTION_PERKS.HOUSE_247 || perkSelection === SUBSCRIPTION_PERKS.TAKEOUT_COUNTER) {
+        selectedPerkIds = [perkSelection];
+      } else {
+        return commit({
+          content: " ",
+          embeds: [buildDevMessageEmbed({ message: "For perk rewards, choose house_247, takeout_counter, or both.", isError: true })],
+          ephemeral: true
+        });
+      }
+
+      const periodEndAt = now + (durationDays * 24 * 60 * 60 * 1000);
+      let totalGrant = 0;
+      const perkNames = {
+        [SUBSCRIPTION_PERKS.HOUSE_247]: getHouse247Label(),
+        [SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]: getTakeoutCounterLabel()
+      };
+
+      for (const perkId of selectedPerkIds) {
+        applySubscriptionEntitlementEvent(targetPlayer, {
+          perkId,
+          eventType: "ENTITLEMENT_UPDATE",
+          entitlementId: `dev_manual:giveaway:${perkId}:${targetUserId}`,
+          periodStartAt: now,
+          periodEndAt,
+          now
+        });
+
         const grantResult = applyMonthlySubscriptionCoinGrant(targetPlayer, {
           perkId,
           periodStartAt: now,
@@ -5524,35 +5619,69 @@ if (inDevPath && sub === "subscriptions_toggle") {
         if (grantResult?.granted) {
           totalGrant += Math.max(0, Math.floor(Number(grantResult.amount || 0) || 0));
         }
+
+        rewardSummaryLines.push(`• Granted perk: ${perkNames[perkId]} (${perkId}) for ${durationDays} day${durationDays === 1 ? "" : "s"}.`);
       }
-      afterStates[perkId] = hasActivePerk(targetPlayer, perkId, now);
+
+      rewardSummaryLines.push(`• Monthly subscription coins credited now: **${totalGrant}c**.`);
+      const perkRewardIcon = selectedPerkIds.length === 1
+        ? (selectedPerkIds[0] === SUBSCRIPTION_PERKS.HOUSE_247 ? getIcon("perk_house_247", getIcon("sparkle")) : getIcon("perk_takeout_counter", getIcon("orders")))
+        : `${getIcon("perk_house_247", getIcon("sparkle"))} ${getIcon("perk_takeout_counter", getIcon("orders"))}`;
+      publicWinnerLine = `${perkRewardIcon} Giveaway winner reward sent to <@${targetUserId}>: **${selectedPerkIds.length > 1 ? "Perks" : "Perk"}** (${durationDays} day${durationDays === 1 ? "" : "s"}).`;
+    } else if (rewardType === "coin_pack") {
+      const pack = getStoreCoinPack(coinPackId);
+      if (!pack) {
+        return commit({
+          content: " ",
+          embeds: [buildDevMessageEmbed({ message: "For coin pack rewards, choose a valid coin_pack option.", isError: true })],
+          ephemeral: true
+        });
+      }
+
+      const grantResult = grantStoreCoinPack({ player: targetPlayer, coinPackId });
+      if (!grantResult?.ok) {
+        return commit({
+          content: " ",
+          embeds: [buildDevMessageEmbed({ message: `Failed to grant coin pack: ${grantResult?.reason || "unknown error"}.`, isError: true })],
+          ephemeral: true
+        });
+      }
+
+      rewardSummaryLines.push(`• Granted coin pack: ${pack.priceLabel} (${pack.coins.toLocaleString()}c) [${coinPackId}].`);
+      publicWinnerLine = `${getIcon("coins")} Giveaway winner reward sent to <@${targetUserId}>: **${pack.coins.toLocaleString()}c** (${pack.priceLabel} pack).`;
+    } else {
+      if (coinAmount <= 0) {
+        return commit({
+          content: " ",
+          embeds: [buildDevMessageEmbed({ message: "For coin rewards, provide a coins value greater than 0.", isError: true })],
+          ephemeral: true
+        });
+      }
+
+      targetPlayer.coins = (Number(targetPlayer.coins) || 0) + coinAmount;
+      if (!targetPlayer.lifetime || typeof targetPlayer.lifetime !== "object") {
+        targetPlayer.lifetime = {};
+      }
+      targetPlayer.lifetime.coins_earned = (Number(targetPlayer.lifetime.coins_earned) || 0) + coinAmount;
+
+      rewardSummaryLines.push(`• Granted direct coins: **${coinAmount.toLocaleString()}c**.`);
+      publicWinnerLine = `${getIcon("coins")} Giveaway winner reward sent to <@${targetUserId}>: **${coinAmount.toLocaleString()}c**.`;
     }
 
     upsertPlayer(db, targetServerId, targetUserId, targetPlayer, null, targetPlayer.schema_version);
 
-    const perkNames = {
-      [SUBSCRIPTION_PERKS.HOUSE_247]: "24/7 House",
-      [SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]: "Take Out Counter"
-    };
-    const stateLines = selectedPerkIds.map((perkId) => {
-      const before = beforeStates[perkId] ? "ACTIVE" : "inactive";
-      const after = afterStates[perkId] ? "ACTIVE" : "inactive";
-      return `• ${perkNames[perkId]} (${perkId}): ${before} -> ${after}`;
-    });
-
     const messageLines = [
-      `${getIcon("status_complete")} Updated subscriptions for <@${targetUserId}> (${targetUserId}) on server ${targetServerId}.`,
-      `Mode: ${active ? `enable (${durationDays} day${durationDays === 1 ? "" : "s"})` : "disable"}`,
-      ...stateLines,
-      active ? `Subscription coin grant awarded now: **${totalGrant}c**` : null,
+      `${getIcon("status_complete")} Giveaway reward delivered to <@${targetUserId}> (${targetUserId}) on server ${targetServerId}.`,
+      `Reward type: ${rewardType}`,
+      ...rewardSummaryLines,
       reason ? `Reason: ${reason}` : null,
       !existingPlayer ? "Note: Created a new player profile for this target." : null
     ].filter(Boolean);
 
     return commit({
-      content: " ",
+      content: publicWinnerLine,
       embeds: [buildDevMessageEmbed({ message: messageLines.join("\n") })],
-      ephemeral: true
+      ephemeral: false
     });
   });
 }
@@ -5993,7 +6122,16 @@ if (sub === "profile_edit") {
   const specializationsAvailable = getSpecializationAlert(p);
   const embed = buildMenuEmbed({
     title: `${getIcon("customize")} Customize Profile`,
-    description: "• Change your shop name & give it a tagline here.\n\n• You will unlock specializations based on your shop level, when you change your active specialization, it will update your shop's decor!\n\n• Purchase a **premium shop specialization that includes 10,000c** for your shop, head to the **store** now!",
+    description: [
+      "• Change your shop name & give it a tagline here.",
+      "",
+      "• You unlock specializations as your shop levels up. Changing your active specialization updates your shop decor.",
+      "",
+      "• Check out the **Store** to browse all premium options:",
+      "  - Premium Shop Specializations",
+      "  - Coin Packs",
+      `  - ${getTakeoutCounterLabel()} Subscription Perk`
+    ].join("\n"),
     user: interaction.member ?? interaction.user
   });
   return commit({
@@ -6008,6 +6146,7 @@ if (sub === "store") {
   const specializationsAvailable = getSpecializationAlert(p);
   const specState = ensureSpecializationState(p);
   const unlockedSpecIds = new Set(specState?.unlocked_spec_ids ?? []);
+  const takeoutActive = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, nowTs());
   const purchasableSpecs = (specializationsContent?.specializations ?? [])
     .filter((spec) => spec?.requirements?.purchase_required)
     .sort((a, b) => String(a?.name ?? "").localeCompare(String(b?.name ?? "")));
@@ -6019,22 +6158,45 @@ if (sub === "store") {
       : `${specIcon} ${spec.name}`;
   });
 
+  const coinPackLines = Object.values(STORE_COIN_PACKS)
+    .sort((a, b) => Number(a?.priceUsd || 0) - Number(b?.priceUsd || 0))
+    .map((pack) => `${getIcon("coins")} ${pack.priceLabel} — **${Number(pack.coins || 0).toLocaleString()}c**`);
+
+  const takeoutPerkLines = [
+    `${takeoutActive ? getIcon("status_complete") : getIcon("status_pending")} ${getTakeoutCounterLabel()} — ${takeoutActive ? "Active" : "Not active"}`,
+    `${getIcon("coins")} Includes **${SUBSCRIPTION_MONTHLY_COIN_GRANT.toLocaleString()}c** per month while subscription is active.`,
+    `${getIcon("perk_takeout_counter")} Start 12-hour counter shifts where your main shop goes idle and you serve from your Take Out Counter menu, bank **massive extra coins** while you're away with this perk.`
+  ];
+
   const storeEmbed = buildMenuEmbed({
-    title: `${getIcon("cart")} Shop Specialization Store`,
+    title: `${getIcon("cart")} Noodle Story Store`,
     description:
-      `Visit the store to purchase **premium shop specializations** that include **10,000c** for your shop.\n` +
+      "Browse premium content for your shop\n" +
+      `• Premium Shop Specializations include **10,000c** each\n` +
+      `• Coin Packs\n` +
+      `• ${getTakeoutCounterLabel()} Subscription Perk\n\n` +
       `**[Open Store](${DISCORD_STORE_URL})**`,
     user: interaction.member ?? interaction.user
   });
   storeEmbed.setURL(DISCORD_STORE_URL);
-  storeEmbed.setFields(
-    chunkLinesIntoEmbedFields(purchasableLines, {
-      firstFieldName: `${getIcon("sparkle")} Available Specializations`,
-      continuationFieldName: `${getIcon("sparkle")} Available Specializations (cont.)`,
+  storeEmbed.setFields([
+    ...chunkLinesIntoEmbedFields(purchasableLines, {
+      firstFieldName: `${getIcon("sparkle")} Premium Specializations`,
+      continuationFieldName: `${getIcon("sparkle")} Premium Specializations (cont.)`,
       maxFieldLength: 1000,
-      maxFields: 10
-    })
-  );
+      maxFields: 8
+    }),
+    {
+      name: `${getIcon("coins")} Coin Packs`,
+      value: coinPackLines.join("\n") || "_No coin packs configured._",
+      inline: false
+    },
+    {
+      name: `${getIcon("perk_takeout_counter", getIcon("orders"))} Subscription Perk`,
+      value: takeoutPerkLines.join("\n"),
+      inline: false
+    }
+  ]);
 
   const storeLinkRow = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
@@ -6578,7 +6740,7 @@ if (sub === "kitchen" || sub === "kitchen_start" || sub === "kitchen_collect") {
 if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub === "takeout_claim" || sub === "takeout_cook" || sub === "takeout_serve" || sub === "takeout_needs") {
   if (!db) {
     const unavailableEmbed = buildMenuEmbed({
-      title: `${getIcon("orders")} Take Out Counter`,
+      title: getTakeoutCounterLabel(),
       description: `${getIcon("error")} Database unavailable in this environment.`,
       user: interaction.member ?? interaction.user,
       color: theme.colors.warning
@@ -6602,8 +6764,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
     if (!takeoutEnabled) {
       const lockedEmbed = buildMenuEmbed({
-        title: `${getIcon("orders")} Take Out Counter`,
-        description: `${getIcon("lock")} Take Out Counter requires an active subscription entitlement.`,
+        title: getTakeoutCounterLabel(),
+        description: `${getIcon("lock")} ${getTakeoutCounterLabel()} requires an active subscription.`,
         user: interaction.member ?? interaction.user,
         color: theme.colors.warning
       });
@@ -6815,13 +6977,13 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
             "• Tap **Counter** again to load your next shift ingredient cost + expected orders.",
             "• Tap **Start Shift** to begin your first 12h run.",
             "",
-            `${getIcon("orders")} Open **/noodle takeout** any time to manage your Takeout Counter shift.`
+            `${getTakeoutCounterLabel()} Open **/noodle takeout** any time to manage your Take Out Counter shift.`
           ].join("\n")
         : null;
 
       const description = [
         banner,
-        "Set your counter menu, start a cozy 12-hour shift, and collect idle earnings. While the shift is active, your main **Order Board** is idle and all service happens from the **Take Out Counter**.",
+        `Set your counter menu, start a cozy 12-hour shift, and collect idle earnings. While the shift is active, your main **Order Board** is idle and all service happens from **${getTakeoutCounterLabel()}**.`,
         "",
         takeoutCatchup?.processedHours > 0
           ? `${getIcon("time")} **${takeoutCatchup.processedHours}h** & earned **${takeoutCatchup.earned}c** while you were away.`
@@ -6834,14 +6996,14 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       ].filter(Boolean).join("\n");
 
       const embed = buildMenuEmbed({
-        title: `${getIcon("orders")} Take Out Counter`,
+        title: getTakeoutCounterLabel(),
         description,
         user: interaction.member ?? interaction.user,
         color: theme.colors.success
       });
       const firstCounterSetupEmbed = firstCounterSetupGuide
         ? buildMenuEmbed({
-            title: `${getIcon("sparkle")} Take Out Counter Setup`,
+            title: `${getTakeoutCounterLabel()} Setup`,
             description: firstCounterSetupGuide,
             user: interaction.member ?? interaction.user
           })
@@ -8109,6 +8271,9 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
     const status = getVoteRewardStatus(latestPlayer);
     const reward = status.reward;
     const rewardLine = [`${getIcon("coins")} **${reward.coins}c**`, `${getIcon("sxp")} **${reward.sxp} SXP**`, `${getIcon("rep")} **${reward.rep} REP**`].join(" · ");
+    const house247Line = status.house247ExpiresAt
+      ? `<t:${Math.floor(status.house247ExpiresAt / 1000)}:R>`
+      : "Not active";
     const lastVoteLine = status.lastVoteAt ? `<t:${Math.floor(status.lastVoteAt / 1000)}:R>` : "Not detected yet";
     const maxButtonsPerRow = 5;
     const maxLinkRows = 3;
@@ -8165,6 +8330,8 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
         voteLinks,
         "",
         `Per vote reward: ${rewardLine}`,
+        `Per vote bonus: ${getHouse247Label()} **+12h** (unlimited orders + market stock)`,
+        `${getHouse247Label()} remaining: **${house247Line}**`,
         `Ready to claim: **${status.pendingClaims}**`,
         `Last vote: **${lastVoteLine}**`,
         "_After voting, press **Vote Rewards** button to refresh._"
@@ -9514,7 +9681,7 @@ ${lines.join("\n")}`;
 
     const capacityNote = qtyToBuy < qty ? `\n${getIcon("pantry")} Pantry capacity limited your purchase to **${qtyToBuy}**.` : "";
     const subscriptionNote = unlimitedMarketStock
-      ? `\n${getIcon("sparkle")} 24/7 House active: unlimited stock.`
+      ? `\n${getHouse247Label()} active: unlimited stock.`
       : "";
     const buyEmbed = buildMenuEmbed({
       title: `${getIcon("cart")} Purchase Complete`,
@@ -9921,13 +10088,13 @@ ${lines.join("\n")}`;
     if (takeoutShiftActive) {
       parts.push(
         "**Today’s Orders**",
-        `${getIcon("time")} Your shop is idle on the main **Order Board** while your Take Out Counter shift is active. Serve orders from **Take Out Counter** until the shift ends.`
+        `${getTakeoutCounterLabel()} Your shop is idle on the main **Order Board** while your Take Out Counter shift is active. Serve orders from **${getTakeoutCounterLabel()}** until the shift ends.`
       );
     } else if (remaining > 0) {
       parts.push(
         "**Today’s Orders**",
         hasHouse247Perk(p)
-          ? `${getIcon("sparkle")} **24/7 House active: unlimited orders.** Tap **Accept** below to start serving customers.`
+          ? `**${getHouse247Label()} active: unlimited orders.** Tap **Accept** below to start serving customers.`
           : `There are **${remaining}** orders available. Tap **Accept** below to start serving customers.`
       );
     } else if (acceptedLines.length) {
@@ -9936,7 +10103,10 @@ ${lines.join("\n")}`;
         `No new orders left today. Finish your accepted ones and come back ${nextOrdersResetText}.`
       );
     } else {
-      parts.push(`${getIcon("confetti")} You’ve completed all of today’s orders! New orders arrive ${nextOrdersResetText}.`);
+      parts.push(
+        `${getIcon("confetti")} You’ve completed all of today’s orders! New orders arrive ${nextOrdersResetText}.`,
+        `${getIcon("vote")} Want unlimited orders before reset? Vote in **/noodle quests_vote** to activate **${getHouse247Label()}** for **12 hours per vote**.`
+      );
     }
 
 
@@ -9998,7 +10168,7 @@ ${lines.join("\n")}`;
     const takeoutShiftActive = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now2) && isTakeoutShiftActive(p, now2);
     if (takeoutShiftActive) {
       return commitState({
-        content: `${getIcon("time")} Your shop is idle on the main **Order Board** while Take Out Counter is active. Serve orders from **Take Out Counter** until the shift ends.`,
+        content: `${getTakeoutCounterLabel()} Your shop is idle on the main **Order Board** while Take Out Counter is active. Serve orders from **${getTakeoutCounterLabel()}** until the shift ends.`,
         ephemeral: true
       });
     }
@@ -10409,7 +10579,7 @@ ${lines.join("\n")}`;
     const takeoutShiftActive = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now2) && isTakeoutShiftActive(p, now2);
     if (takeoutShiftActive) {
       return commitState({
-        content: `${getIcon("time")} Your shop is idle on the main **Order Board** while Take Out Counter is active. Serve orders from **Take Out Counter** until the shift ends.`,
+        content: `${getTakeoutCounterLabel()} Your shop is idle on the main **Order Board** while Take Out Counter is active. Serve orders from **${getTakeoutCounterLabel()}** until the shift ends.`,
         ephemeral: true
       });
     }
@@ -12698,7 +12868,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
 
         const buyEmbed = buildMenuEmbed({
           title: `${getIcon("cart")} Purchase Complete`,
-          description: `Bought:\n${pretty}\n\nTotal: **${totalCost}c**.${capacityReduced ? `\n${getIcon("pantry")} Pantry capacity limited this purchase.` : ""}${unlimitedMarketStock ? `\n${getIcon("sparkle")} 24/7 House active: stock limit bypassed.` : ""}${tutorialSuffix(p2)}`,
+          description: `Bought:\n${pretty}\n\nTotal: **${totalCost}c**.${capacityReduced ? `\n${getIcon("pantry")} Pantry capacity limited this purchase.` : ""}${unlimitedMarketStock ? `\n${getHouse247Label()} active: stock limit bypassed.` : ""}${tutorialSuffix(p2)}`,
           user: interaction.member ?? interaction.user
         });
         buyEmbed.setFooter({

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6930,102 +6930,135 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         return finalize(renderStatus(`${getIcon("help")} No remaining counter orders for **${displayRecipeName(selectedRecipeId)}**.`, { ephemeral: true }));
       }
 
-      const bowlEntry = getBestBowlEntry(p, selectedRecipeId);
-      const bowl = bowlEntry?.bowl ?? null;
-      if (!bowl || (bowl.qty ?? 0) <= 0) {
+      const readyForRecipe = getTotalBowlsForRecipe(p, selectedRecipeId);
+      if (readyForRecipe <= 0) {
         return finalize(renderStatus(`${getIcon("basket")} You need a ready bowl of **${displayRecipeName(selectedRecipeId)}** first.`, { ephemeral: true }));
       }
 
-      const servedAt = nowTs();
-      const recipe = content.recipes?.[selectedRecipeId] ?? null;
-      const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
-      const activeEventEffects = getActiveEventEffects(eventsContent, s);
-      const rewards = computeServeRewards({
-        serverId,
-        tier: recipe?.tier ?? "common",
-        npcArchetype: null,
-        isLimitedTime: false,
-        servedAtMs: servedAt,
-        acceptedAtMs: servedAt,
-        speedWindowSeconds: 180,
-        player: p,
-        recipe,
-        content,
-        effects: combinedEffects,
-        eventEffects: activeEventEffects
-      });
-
-      const bowlQuality = normalizeQuality(bowl.quality);
-      const qualityMult = getQualityMultiplier(bowlQuality);
-      rewards.coins = Math.floor(rewards.coins * qualityMult);
-      rewards.rep = Math.floor(rewards.rep * qualityMult);
-      rewards.sxp = Math.floor(rewards.sxp * qualityMult);
-
-      bowl.qty -= 1;
-      if (bowl.qty <= 0) delete p.inv_bowls[bowlEntry?.key ?? selectedRecipeId];
-
-      snapshotRow.visible_order_count = Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0) - 1);
-
-      if (!hasHouse247Perk(p)) {
-        const { totalCount, consumedSet } = getOrdersMeta(p);
-        for (let idx = 0; idx < totalCount; idx += 1) {
-          if (!consumedSet.has(idx)) {
-            markOrderConsumed(p, idx);
-            break;
-          }
-        }
+      const availableCounterOrders = Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0));
+      const servingsToProcess = Math.min(readyForRecipe, availableCounterOrders);
+      if (servingsToProcess <= 0) {
+        return finalize(renderStatus(`${getIcon("help")} No remaining counter orders for **${displayRecipeName(selectedRecipeId)}**.`, { ephemeral: true }));
       }
 
-      p.coins = (Number.isFinite(p.coins) ? p.coins : 0) + rewards.coins;
-      p.rep = (Number.isFinite(p.rep) ? p.rep : 0) + rewards.rep;
-      p.sxp_total = (Number.isFinite(p.sxp_total) ? p.sxp_total : 0) + rewards.sxp;
-      p.sxp_progress = (Number.isFinite(p.sxp_progress) ? p.sxp_progress : 0) + rewards.sxp;
-      if (!p.lifetime) p.lifetime = {};
-      p.lifetime.orders_served = (p.lifetime.orders_served ?? 0) + 1;
-      p.lifetime.bowls_served_total = (p.lifetime.bowls_served_total ?? 0) + 1;
-      p.lifetime.coins_earned = (p.lifetime.coins_earned ?? 0) + rewards.coins;
-      const leveledUp = applySxpLevelUp(p);
-
+      let totalCoins = 0;
+      let totalRep = 0;
+      let totalSxp = 0;
+      let servedCount = 0;
+      let leveledUp = false;
       const discoveryMessages = [];
-      if (bowlQuality !== "salvage") {
-        const dayKey = dayKeyUTC(servedAt);
-        const discoveryRng = makeStreamRng({
-          mode: "seeded",
-          seed: 12345,
-          streamName: "discovery",
+
+      for (let i = 0; i < servingsToProcess; i += 1) {
+        const bowlEntry = getBestBowlEntry(p, selectedRecipeId);
+        const bowl = bowlEntry?.bowl ?? null;
+        if (!bowl || (bowl.qty ?? 0) <= 0) break;
+
+        const servedAt = nowTs();
+        const recipe = content.recipes?.[selectedRecipeId] ?? null;
+        const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
+        const activeEventEffects = getActiveEventEffects(eventsContent, s);
+        const rewards = computeServeRewards({
           serverId,
-          dayKey,
-          extra: `${selectedRecipeId}_${servedAt}`
-        });
-        const discoveries = rollRecipeDiscovery({
-          player: p,
-          content,
-          npcArchetype: null,
           tier: recipe?.tier ?? "common",
-          rng: discoveryRng,
-          activeSeason: s.season,
-          activeEventId: s.active_event_id ?? null
+          npcArchetype: null,
+          isLimitedTime: false,
+          servedAtMs: servedAt,
+          acceptedAtMs: servedAt,
+          speedWindowSeconds: 180,
+          player: p,
+          recipe,
+          content,
+          effects: combinedEffects,
+          eventEffects: activeEventEffects
         });
-        for (const discovery of discoveries ?? []) {
-          const result = applyDiscovery(p, discovery, content, discoveryRng, { badgesContent });
-          if (result?.message) discoveryMessages.push(result.message);
+
+        const bowlQuality = normalizeQuality(bowl.quality);
+        const qualityMult = getQualityMultiplier(bowlQuality);
+        rewards.coins = Math.floor(rewards.coins * qualityMult);
+        rewards.rep = Math.floor(rewards.rep * qualityMult);
+        rewards.sxp = Math.floor(rewards.sxp * qualityMult);
+
+        bowl.qty -= 1;
+        if (bowl.qty <= 0) delete p.inv_bowls[bowlEntry?.key ?? selectedRecipeId];
+
+        snapshotRow.visible_order_count = Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0) - 1);
+
+        if (!hasHouse247Perk(p)) {
+          const { totalCount, consumedSet } = getOrdersMeta(p);
+          for (let idx = 0; idx < totalCount; idx += 1) {
+            if (!consumedSet.has(idx)) {
+              markOrderConsumed(p, idx);
+              break;
+            }
+          }
+        }
+
+        p.coins = (Number.isFinite(p.coins) ? p.coins : 0) + rewards.coins;
+        p.rep = (Number.isFinite(p.rep) ? p.rep : 0) + rewards.rep;
+        p.sxp_total = (Number.isFinite(p.sxp_total) ? p.sxp_total : 0) + rewards.sxp;
+        p.sxp_progress = (Number.isFinite(p.sxp_progress) ? p.sxp_progress : 0) + rewards.sxp;
+        if (!p.lifetime) p.lifetime = {};
+        p.lifetime.orders_served = (p.lifetime.orders_served ?? 0) + 1;
+        p.lifetime.bowls_served_total = (p.lifetime.bowls_served_total ?? 0) + 1;
+        p.lifetime.coins_earned = (p.lifetime.coins_earned ?? 0) + rewards.coins;
+        leveledUp = applySxpLevelUp(p) || leveledUp;
+
+        totalCoins += rewards.coins;
+        totalRep += rewards.rep;
+        totalSxp += rewards.sxp;
+        servedCount += 1;
+
+        if (bowlQuality !== "salvage") {
+          const dayKey = dayKeyUTC(servedAt);
+          const discoveryRng = makeStreamRng({
+            mode: "seeded",
+            seed: 12345,
+            streamName: "discovery",
+            serverId,
+            dayKey,
+            extra: `${selectedRecipeId}_${servedAt}_${i}`
+          });
+          const discoveries = rollRecipeDiscovery({
+            player: p,
+            content,
+            npcArchetype: null,
+            tier: recipe?.tier ?? "common",
+            rng: discoveryRng,
+            activeSeason: s.season,
+            activeEventId: s.active_event_id ?? null
+          });
+          for (const discovery of discoveries ?? []) {
+            const result = applyDiscovery(p, discovery, content, discoveryRng, { badgesContent });
+            if (result?.message) discoveryMessages.push(result.message);
+          }
         }
       }
 
       const remainingForRecipe = Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0));
       const serveSummary = [
-        `${getIcon("serve")} Served **${displayRecipeName(selectedRecipeId)}** from the takeout counter.`,
-        `${getIcon("coins")} +${rewards.coins}c · ${getIcon("rep")} +${rewards.rep} rep · ${getIcon("sxp")} +${rewards.sxp} sxp`,
+        `${getIcon("serve")} Served **${servedCount}× ${displayRecipeName(selectedRecipeId)}** from the takeout counter.`,
+        `${getIcon("coins")} +${totalCoins}c · ${getIcon("rep")} +${totalRep} rep · ${getIcon("sxp")} +${totalSxp} sxp`,
         `${getIcon("orders")} Remaining counter orders for this recipe: **${remainingForRecipe}**`
       ];
       if (leveledUp) {
         serveSummary.push(`${getIcon("status_complete")} Level up! You are now **Lv.${Math.max(1, Number(p.sxp_level || 1))}**.`);
       }
       if (discoveryMessages.length > 0) {
-        serveSummary.push(discoveryMessages.join("\n"));
+        serveSummary.push(discoveryMessages.slice(0, 4).join("\n"));
       }
 
-      return finalize(renderStatus(serveSummary.join("\n\n")));
+      const confirmationEmbed = buildMenuEmbed({
+        title: `${getIcon("serve")} Counter Serve`,
+        description: serveSummary.join("\n\n"),
+        user: interaction.member ?? interaction.user,
+        color: theme.colors.success
+      });
+      const statusPayload = renderStatus();
+      return finalize({
+        ...statusPayload,
+        content: " ",
+        embeds: [confirmationEmbed, ...(statusPayload.embeds ?? [])]
+      });
     }
 
     if (sub === "takeout_claim") {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1548,13 +1548,25 @@ function noodleOrdersAcceptOnlyRow(userId, { highlightAccept = true, disableAcce
   );
 }
 
-function noodleMainMenuRowNoProfile(userId, { newsAvailable = false } = {}) {
-  return new ActionRowBuilder().addComponents(
+function noodleMainMenuRowNoProfile(userId, { newsAvailable = false, showTakeout = false } = {}) {
+  const buttons = [
     new ButtonBuilder().setCustomId(`noodle:nav:orders:${userId}`).setLabel("Orders").setEmoji(getButtonEmoji("orders")).setStyle(ButtonStyle.Primary),
     new ButtonBuilder().setCustomId(`noodle:nav:buy:${userId}`).setLabel("Buy").setEmoji(getButtonEmoji("cart")).setStyle(ButtonStyle.Secondary),
     new ButtonBuilder().setCustomId(`noodle:nav:pantry:${userId}`).setLabel("Pantry").setEmoji(getButtonEmoji("pantry")).setStyle(ButtonStyle.Secondary),
     new ButtonBuilder().setCustomId(`noodle:nav:news:${userId}`).setLabel("News").setEmoji(getButtonEmoji("new")).setStyle(newsAvailable ? ButtonStyle.Success : ButtonStyle.Secondary)
-  );
+  ];
+  if (showTakeout) {
+    buttons.splice(
+      1,
+      0,
+      new ButtonBuilder()
+        .setCustomId(`noodle:nav:takeout:${userId}`)
+        .setLabel("Takeout")
+        .setEmoji(getButtonEmoji("orders"))
+        .setStyle(ButtonStyle.Success)
+    );
+  }
+  return new ActionRowBuilder().addComponents(buttons);
 }
 
 function noodleRecipesMenuRow(userId, { kitchenUnlocked = false, kitchenJustUnlocked = false, active = null, allowLockedKitchenInfo = false } = {}) {
@@ -4717,17 +4729,19 @@ const selectedNames = formatSelectedItemNames(selectedIds);
 const msgId = sourceMessageId || "none";
 const btnRow = new ActionRowBuilder().addComponents(
 new ButtonBuilder()
-.setCustomId(`noodle:multibuy:buy1:${userId}:${msgId}`)
-.setLabel("Buy 1 each")
-.setStyle(ButtonStyle.Success)
+  .setCustomId(`noodle:multibuy:buy1:${userId}:${msgId}`)
+  .setLabel("Buy 1 each")
+  .setStyle(ButtonStyle.Success)
 );
 
 if (!limitToBuy1) {
-  btnRow.addComponents(
+  const baseBuyOneButton = btnRow.components[0];
+  btnRow.setComponents(
     new ButtonBuilder()
       .setCustomId(`noodle:multibuy:buyneed:${userId}:${msgId}`)
       .setLabel("Buy Needed")
-      .setStyle(ButtonStyle.Primary),
+      .setStyle(ButtonStyle.Success),
+    baseBuyOneButton,
     new ButtonBuilder()
       .setCustomId(`noodle:multibuy:buy5:${userId}:${msgId}`)
       .setLabel("Buy 5 each")
@@ -5586,6 +5600,7 @@ if (sub === "profile") {
   const questsAvailable = hasDailyRewardAvailable(selfPlayer, nowTs()) || hasClaimableQuests(selfPlayer);
   const specializationsAvailable = getSpecializationAlert(selfPlayer);
   const newsAvailable = viewingSelf && hasUnreadNewsUpdate(selfPlayer, newsContent);
+  const showTakeoutProfileButton = viewingSelf && hasActivePerk(selfPlayer, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, nowTs());
   const party = getUserActiveParty(db, u.id);
   
   const embed = renderProfileEmbed(p, u.displayName, party?.party_name, interaction.member ?? interaction.user);
@@ -5602,7 +5617,7 @@ if (sub === "profile") {
     embed.setFooter({ text: footerText });
   }
   const profileComponents = viewingSelf
-    ? [noodleMainMenuRowNoProfile(userId, { newsAvailable }), socialMainMenuRowNoProfile(userId, { questsAvailable, specializationsAvailable })]
+    ? [noodleMainMenuRowNoProfile(userId, { newsAvailable, showTakeout: showTakeoutProfileButton }), socialMainMenuRowNoProfile(userId, { questsAvailable, specializationsAvailable })]
     : [];
   const embedsWithFooter = applyGreenButtonFooter([embed], profileComponents);
   

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6656,7 +6656,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         statusBits.push(`${getIcon("time")} Completed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
         statusBits.push(`${getIcon("time")} Remaining hours: **${remainingHours}**`);
       }
-      statusBits.push(`${getIcon("help")} Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})`);
 
       const description = [
         banner,
@@ -6668,6 +6667,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         "\u200b",
         statusBits.join("\n"),
         "\n**Counter Menu**",
+        `${getIcon("help")} Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})`,
         counterMenuLines
       ].filter(Boolean).join("\n");
 
@@ -6955,6 +6955,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       let totalRep = 0;
       let totalSxp = 0;
       let servedCount = 0;
+      let seasonalServedCount = 0;
+      let seasonalServedCoins = 0;
       let leveledUp = false;
       const discoveryMessages = [];
 
@@ -7018,6 +7020,14 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         totalSxp += rewards.sxp;
         servedCount += 1;
 
+        const recipeTierForQuest = recipe?.tier ?? "common";
+        const recipeSeasonForQuest = recipe?.season ?? null;
+        const isSeasonalRecipeServe = recipeTierForQuest === "seasonal" && (!recipeSeasonForQuest || recipeSeasonForQuest === s.season);
+        if (isSeasonalRecipeServe) {
+          seasonalServedCount += 1;
+          seasonalServedCoins += rewards.coins;
+        }
+
         if (bowlQuality !== "salvage") {
           const dayKey = dayKeyUTC(servedAt);
           const discoveryRng = makeStreamRng({
@@ -7055,6 +7065,29 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       }
       if (discoveryMessages.length > 0) {
         serveSummary.push(discoveryMessages.slice(0, 4).join("\n"));
+      }
+
+      if (servedCount > 0) {
+        applyQuestProgress(
+          p,
+          questsContent,
+          userId,
+          {
+            type: "serve",
+            amount: servedCount,
+            tierAmounts: { seasonal: seasonalServedCount }
+          },
+          now
+        );
+        if (totalCoins > 0) {
+          applyQuestProgress(
+            p,
+            questsContent,
+            userId,
+            { type: "earn_coins", amount: totalCoins, tierAmounts: { seasonal: seasonalServedCoins } },
+            now
+          );
+        }
       }
 
       const confirmationEmbed = buildMenuEmbed({

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1659,7 +1659,7 @@ function noodleMainMenuRowNoProfile(userId, { newsAvailable = false, showTakeout
         .setStyle(ButtonStyle.Success)
     );
   }
-  return new ActionRowBuilder().addComponents(buttons);
+  return new ActionRowBuilder().addComponents(...buttons);
 }
 
 function noodleRecipesMenuRow(userId, { kitchenUnlocked = false, kitchenJustUnlocked = false, active = null, allowLockedKitchenInfo = false } = {}) {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7353,16 +7353,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
         snapshotRow.visible_order_count = Math.max(0, Math.floor(Number(snapshotRow.visible_order_count || 0) || 0) - 1);
 
-        if (!hasHouse247Perk(p)) {
-          const { totalCount, consumedSet } = getOrdersMeta(p);
-          for (let idx = 0; idx < totalCount; idx += 1) {
-            if (!consumedSet.has(idx)) {
-              markOrderConsumed(p, idx);
-              break;
-            }
-          }
-        }
-
         p.coins = (Number.isFinite(p.coins) ? p.coins : 0) + rewards.coins;
         p.rep = (Number.isFinite(p.rep) ? p.rep : 0) + rewards.rep;
         p.sxp_total = (Number.isFinite(p.sxp_total) ? p.sxp_total : 0) + rewards.sxp;

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -103,6 +103,7 @@ import {
   setTakeoutMenu,
   isTakeoutShiftActive,
   claimTakeoutEarnings,
+  openTakeoutShift,
   startTakeoutShiftWithCoverage,
   processTakeoutCatchup
 } from "../game/takeout.js";
@@ -6371,6 +6372,78 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     const menuLimits = getTakeoutMenuLimits(availableRecipeIds.length);
     const requestedMenuPageRaw = Number(opt.getInteger("page") ?? 0);
     const requestedMenuPage = Number.isFinite(requestedMenuPageRaw) ? Math.max(0, requestedMenuPageRaw) : 0;
+    const TAKEOUT_QUOTE_TTL_MS = 10 * 60 * 1000;
+    const menuKey = (ids = []) => (Array.isArray(ids) ? ids.map((id) => String(id || "").trim()).filter(Boolean).join("|") : "");
+    const currentMenuKey = menuKey(takeout.menu_recipe_ids || []);
+
+    const clearTakeoutQuote = () => {
+      takeout.next_shift_quote = null;
+    };
+
+    const readValidTakeoutQuote = ({ nowMs }) => {
+      const quote = takeout?.next_shift_quote;
+      if (!quote || typeof quote !== "object") return null;
+      const quoteExpiresAt = Number(quote.expires_at || 0);
+      const quoteCreatedAt = Number(quote.created_at || 0);
+      const quoteMenuKey = String(quote.menu_key || "");
+      const snapshot = Array.isArray(quote.snapshot) ? quote.snapshot : [];
+      const requiredIngredients = (quote.required_ingredients && typeof quote.required_ingredients === "object")
+        ? quote.required_ingredients
+        : {};
+      const snapshotOrderTotal = Math.max(0, Math.floor(Number(quote.snapshot_order_total || 0) || 0));
+      const operatingCost = Math.max(0, Math.floor(Number(quote.operating_cost || 0) || 0));
+      if (!Number.isFinite(quoteExpiresAt) || quoteExpiresAt <= nowMs) return null;
+      if (!Number.isFinite(quoteCreatedAt) || quoteCreatedAt <= 0) return null;
+      if (!quoteMenuKey || quoteMenuKey !== currentMenuKey) return null;
+      if (!snapshot.length) return null;
+      return {
+        createdAt: quoteCreatedAt,
+        expiresAt: quoteExpiresAt,
+        menuKey: quoteMenuKey,
+        snapshotOrderTotal,
+        operatingCost,
+        requiredIngredients,
+        snapshot
+      };
+    };
+
+    const buildAndStoreTakeoutQuote = ({ nowMs }) => {
+      const set = buildSettingsMap(settingsCatalog, s.settings);
+      s.season = computeActiveSeason(set);
+      ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, s.active_event_id ?? null);
+      applyHouse247OrderBoardOverride(p);
+
+      const boardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
+      const unlimitedOrders = hasHouse247Perk(p);
+      const previewPlayer = JSON.parse(JSON.stringify(p));
+      const previewResult = startTakeoutShiftWithCoverage(previewPlayer, {
+        now: nowMs,
+        boardOrderTotal,
+        unlimitedOrders,
+        recipes: content.recipes ?? {},
+        marketPrices: s.market_prices ?? {},
+        items: content.items ?? {}
+      });
+
+      const quote = {
+        created_at: nowMs,
+        expires_at: nowMs + TAKEOUT_QUOTE_TTL_MS,
+        menu_key: currentMenuKey,
+        board_order_total: boardOrderTotal,
+        unlimited_orders: unlimitedOrders,
+        snapshot_order_total: Math.max(0, Math.floor(Number(previewResult?.snapshotOrderTotal || 0) || 0)),
+        operating_cost: Math.max(0, Math.floor(Number(previewResult?.operatingCost || 0) || 0)),
+        required_ingredients: previewResult?.requiredIngredients ?? {},
+        snapshot: Array.isArray(previewResult?.snapshot) ? previewResult.snapshot : []
+      };
+
+      if (!quote.snapshot.length || quote.snapshot_order_total <= 0) {
+        return null;
+      }
+
+      takeout.next_shift_quote = quote;
+      return readValidTakeoutQuote({ nowMs });
+    };
 
     const renderStatus = (banner = null, { ephemeral = false, showMenuPicker = false, menuPage = requestedMenuPage } = {}) => {
       const active = isTakeoutShiftActive(p, nowTs());
@@ -6387,30 +6460,14 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const shiftSnapshotOrderCount = snapshot
         .reduce((sum, row) => sum + Math.max(0, Math.floor(Number(row?.total_orders || row?.visible_order_count || 0) || 0)), 0);
 
-      const previewNow = active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0
-        ? shiftEndsAt + 1000
-        : now;
-      const previewPlayer = JSON.parse(JSON.stringify(p));
-      const previewBoardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
-      const previewResult = startTakeoutShiftWithCoverage(previewPlayer, {
-        now: previewNow,
-        boardOrderTotal: previewBoardOrderTotal,
-        unlimitedOrders: hasHouse247Perk(p),
-        recipes: content.recipes ?? {},
-        marketPrices: s.market_prices ?? {},
-        items: content.items ?? {}
-      });
-
-      const projectedOperatingCost = Math.max(
-        0,
-        Math.floor(Number(previewResult?.operatingCost || 0) || 0)
-      );
-      const projectedOrders = Math.max(
-        0,
-        Math.floor(Number(previewResult?.snapshotOrderTotal || 0) || 0)
-      );
-
-      const nextShiftSnapshot = Array.isArray(previewResult?.snapshot) ? previewResult.snapshot : [];
+      const quoteNow = nowTs();
+      let nextShiftQuote = readValidTakeoutQuote({ nowMs: quoteNow });
+      if (!active && !nextShiftQuote) {
+        nextShiftQuote = buildAndStoreTakeoutQuote({ nowMs: quoteNow });
+      }
+      const projectedOperatingCost = Math.max(0, Math.floor(Number(nextShiftQuote?.operatingCost || 0) || 0));
+      const projectedOrders = Math.max(0, Math.floor(Number(nextShiftQuote?.snapshotOrderTotal || 0) || 0));
+      const nextShiftSnapshot = Array.isArray(nextShiftQuote?.snapshot) ? nextShiftQuote.snapshot : [];
       const counterMenuSnapshot = active
         ? snapshot
         : (nextShiftSnapshot.length > 0 ? nextShiftSnapshot : snapshot);
@@ -6559,6 +6616,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
           recipe_id: rid,
           visible_order_count: 0
         }));
+        clearTakeoutQuote();
       }
 
       return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`, {
@@ -6579,15 +6637,63 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const boardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
       const unlimitedOrders = hasHouse247Perk(p);
+      const validQuote = readValidTakeoutQuote({ nowMs: now }) ?? buildAndStoreTakeoutQuote({ nowMs: now });
+      let openResult = null;
 
-      const openResult = startTakeoutShiftWithCoverage(p, {
-        now,
-        boardOrderTotal,
-        unlimitedOrders,
-        recipes: content.recipes ?? {},
-        marketPrices: s.market_prices ?? {},
-        items: content.items ?? {}
-      });
+      if (validQuote) {
+        const playerCoins = Math.max(0, Math.floor(Number(p.coins || 0) || 0));
+        if (playerCoins < validQuote.operatingCost) {
+          openResult = {
+            ok: false,
+            reason: "insufficient_coins",
+            operatingCost: validQuote.operatingCost,
+            snapshotOrderTotal: validQuote.snapshotOrderTotal,
+            requiredIngredients: validQuote.requiredIngredients,
+            snapshot: validQuote.snapshot
+          };
+        } else {
+          p.coins = playerCoins - validQuote.operatingCost;
+          const opened = openTakeoutShift(p, {
+            now,
+            snapshot: validQuote.snapshot,
+            snapshotOrderTotal: validQuote.snapshotOrderTotal,
+            requiredIngredients: validQuote.requiredIngredients,
+            coveredIngredients: validQuote.requiredIngredients,
+            operatingCost: validQuote.operatingCost,
+            operatingCostMarker: `takeout_shift:${validQuote.createdAt}`
+          });
+          if (!opened.ok) {
+            p.coins = playerCoins;
+            openResult = {
+              ok: false,
+              reason: opened.reason,
+              operatingCost: validQuote.operatingCost,
+              snapshotOrderTotal: validQuote.snapshotOrderTotal,
+              requiredIngredients: validQuote.requiredIngredients,
+              snapshot: validQuote.snapshot
+            };
+          } else {
+            openResult = {
+              ok: true,
+              startedAt: opened.startedAt,
+              endsAt: opened.endsAt,
+              snapshotOrderTotal: validQuote.snapshotOrderTotal,
+              operatingCost: validQuote.operatingCost,
+              requiredIngredients: validQuote.requiredIngredients,
+              snapshot: validQuote.snapshot
+            };
+          }
+        }
+      } else {
+        openResult = startTakeoutShiftWithCoverage(p, {
+          now,
+          boardOrderTotal,
+          unlimitedOrders,
+          recipes: content.recipes ?? {},
+          marketPrices: s.market_prices ?? {},
+          items: content.items ?? {}
+        });
+      }
       if (!openResult.ok && openResult.reason === "shift_active") {
         emitTelemetry("takeout_shift_start_blocked", {
           userId,
@@ -6631,6 +6737,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         startsAt: openResult.startedAt,
         endsAt: openResult.endsAt
       });
+
+      clearTakeoutQuote();
 
       return finalize(
         renderStatus(
@@ -9387,7 +9495,7 @@ ${lines.join("\n")}`;
       parts.push(
         "**Today’s Orders**",
         hasHouse247Perk(p)
-          ? `${getIcon("sparkle")} 24/7 House active: unlimited order capacity and market stock. Tap **Accept** below to start serving customers.`
+          ? `${getIcon("sparkle")} 24/7 House active: unlimited orders. Tap **Accept** below to start serving customers.`
           : `There are **${remaining}** orders available. Tap **Accept** below to start serving customers.`
       );
     } else if (acceptedLines.length) {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -90,6 +90,7 @@ import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_
 import {
   applySubscriptionEntitlementEvent,
   applyMonthlySubscriptionCoinGrant,
+  SUBSCRIPTION_MONTHLY_COIN_GRANT,
   SUBSCRIPTION_PERKS,
   ensureSubscriptionState,
   getOrderAcceptCap,
@@ -276,7 +277,7 @@ function formatSelectedItemNames(selectedIds, { maxNames = 3, maxChars = 80 } = 
   return `${truncatedVisible}${suffix}`;
 }
 
-function applyUnlockNoticeEmbeds(payload = {}, player, user, { consumeSeatingNotice = false } = {}) {
+function applyUnlockNoticeEmbeds(payload = {}, player, user, { consumeSeatingNotice = false, consumeSubscriptionNotice = false } = {}) {
   if (!player) return payload;
 
   const garden = getGardenUnlockState(player);
@@ -347,6 +348,88 @@ function applyUnlockNoticeEmbeds(payload = {}, player, user, { consumeSeatingNot
       }
       player.notifications.seating_unlock_notice_seen = true;
     }
+  }
+
+  const subscriptionPerkMeta = {
+    [SUBSCRIPTION_PERKS.HOUSE_247]: {
+      name: "24/7 House",
+      tryLine: "Try it in **/noodle orders** and **/noodle market**."
+    },
+    [SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]: {
+      name: "Take Out Counter",
+      tryLine: "Try it in **/noodle takeout** from your orders menu."
+    }
+  };
+
+  const toNoticeKey = (state = {}) => [
+    String(state?.entitlement_id ?? "-"),
+    String(state?.period_start_at ?? "-"),
+    String(state?.period_end_at ?? "-"),
+    String(state?.last_coin_grant_period ?? "-")
+  ].join("|");
+
+  const subscriptions = ensureSubscriptionState(player);
+  const existingNoticeKeys = (player?.notifications?.subscription_perk_notice_keys
+    && typeof player.notifications.subscription_perk_notice_keys === "object"
+    && !Array.isArray(player.notifications.subscription_perk_notice_keys))
+    ? player.notifications.subscription_perk_notice_keys
+    : {};
+
+  const grantedPerkLines = [];
+  let totalCoinReward = 0;
+  let sawCoinGrant = false;
+  const perkIds = [SUBSCRIPTION_PERKS.HOUSE_247, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER];
+  for (const perkId of perkIds) {
+    const state = subscriptions?.perks?.[perkId] ?? {};
+    const activeNow = hasActivePerk(player, perkId, nowTs());
+    if (!activeNow) continue;
+
+    const noticeKey = toNoticeKey(state);
+    const seenNoticeKey = String(existingNoticeKeys?.[perkId] ?? "");
+    if (!noticeKey || noticeKey === seenNoticeKey) continue;
+
+    const meta = subscriptionPerkMeta[perkId] ?? { name: perkId, tryLine: "" };
+    grantedPerkLines.push(`• **${meta.name}** unlocked. ${meta.tryLine}`);
+
+    if (state?.last_coin_grant_period) {
+      totalCoinReward += SUBSCRIPTION_MONTHLY_COIN_GRANT;
+      sawCoinGrant = true;
+    }
+
+    if (consumeSubscriptionNotice) {
+      if (!player.notifications) {
+        player.notifications = {
+          pending_pantry_messages: [],
+          dm_reminders_opt_out: false,
+          last_daily_reminder_day: null,
+          last_noodle_channel_id: null,
+          last_noodle_guild_id: null
+        };
+      }
+      if (!player.notifications.subscription_perk_notice_keys
+        || typeof player.notifications.subscription_perk_notice_keys !== "object"
+        || Array.isArray(player.notifications.subscription_perk_notice_keys)) {
+        player.notifications.subscription_perk_notice_keys = {};
+      }
+      player.notifications.subscription_perk_notice_keys[perkId] = noticeKey;
+    }
+  }
+
+  if (grantedPerkLines.length > 0) {
+    const coinLine = sawCoinGrant
+      ? `${getIcon("coins")} Subscription coin reward credited: **${totalCoinReward}c**`
+      : `${getIcon("coins")} Subscription coin reward credited this cycle: **0c**`;
+    notices.push(
+      buildMenuEmbed({
+        title: `${getIcon("sparkle")} Subscription Perks Unlocked`,
+        description: [
+          ...grantedPerkLines,
+          "",
+          coinLine
+        ].join("\n"),
+        user
+      })
+    );
   }
 
   if (!notices.length) return payload;
@@ -4868,7 +4951,8 @@ const commit = async (payload) => {
   const unlockApplied = payload?.__unlockNoticeApplied;
   if (!unlockApplied) {
     payload = applyUnlockNoticeEmbeds(payload, unlockNoticePlayer, interaction.member ?? interaction.user, {
-      consumeSeatingNotice: false
+      consumeSeatingNotice: false,
+      consumeSubscriptionNotice: false
     });
   }
   payload = withSeasonNotice(payload);
@@ -6657,6 +6741,21 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         statusBits.push(`${getIcon("time")} Remaining hours: **${remainingHours}**`);
       }
 
+      const hasStartedFirstTakeoutShift = Number.isFinite(Number(takeout.first_shift_started_at || 0))
+        && Number(takeout.first_shift_started_at || 0) > 0;
+      const minMenuRequired = Math.max(0, Math.floor(Number(menuLimits.minRequired || 0) || 0));
+      const firstCounterSetupGuide = !hasStartedFirstTakeoutShift
+        ? [
+            minMenuRequired > 0
+              ? `• Set your counter **Menu** with at least **${minMenuRequired}** recipe${minMenuRequired === 1 ? "" : "s"}.`
+              : "• Set your counter **Menu** once you have learned recipes.",
+            "• Tap **Counter** again to load your next shift ingredient cost + expected orders.",
+            "• Tap **Start Shift** to begin your first 12h run.",
+            "",
+            `${getIcon("orders")} Open **/noodle takeout** any time to manage your Takeout Counter shift.`
+          ].join("\n")
+        : null;
+
       const description = [
         banner,
         "Set your counter menu, start a cozy 12-hour shift, and collect idle earnings. While the shift is active, your main **Order Board** is idle and all service happens from the **Take Out Counter**.",
@@ -6666,8 +6765,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
           : null,
         "\u200b",
         statusBits.join("\n"),
-        "\n**Counter Menu**",
-        `${getIcon("help")} Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})`,
+        `\n${getIcon("recipes")} **Counter Menu**`,
+        `*Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})*`,
         counterMenuLines
       ].filter(Boolean).join("\n");
 
@@ -6677,6 +6776,13 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         user: interaction.member ?? interaction.user,
         color: theme.colors.success
       });
+      const firstCounterSetupEmbed = firstCounterSetupGuide
+        ? buildMenuEmbed({
+            title: `${getIcon("sparkle")} Take Out Counter Setup`,
+            description: firstCounterSetupGuide,
+            user: interaction.member ?? interaction.user
+          })
+        : null;
 
       const canOpenShift = !active && takeout.menu_recipe_ids.length >= menuLimits.minRequired;
       const canClaim = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0)) > 0;
@@ -6697,7 +6803,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       return {
         content: " ",
-        embeds: [embed],
+        embeds: firstCounterSetupEmbed ? [embed, firstCounterSetupEmbed] : [embed],
         components: [
           ...(menuPicker?.rows ?? []),
           noodleTakeoutActionRow(userId, {
@@ -7678,7 +7784,8 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
   const commitState = async (replyObj) => {
 
     const replyWithUnlock = applyUnlockNoticeEmbeds(replyObj ?? {}, unlockNoticePlayer, interaction.member ?? interaction.user, {
-      consumeSeatingNotice: true
+      consumeSeatingNotice: true,
+      consumeSubscriptionNotice: true
     });
     if (replyWithUnlock && typeof replyWithUnlock === "object") {
       Object.defineProperty(replyWithUnlock, "__unlockNoticeApplied", { value: true, enumerable: false });

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -4114,7 +4114,7 @@ function buildCookPickerPayload({ userId, p, s, ownerUser, page = 0 }) {
     : "";
 
   const menu = new StringSelectMenuBuilder()
-    .setCustomId(`noodle:pick:takeout_cook_select:${userId}:${safePage}:${Date.now().toString(36)}`)
+    .setCustomId(`noodle:pick:cook_select:${userId}:${safePage}:${Date.now().toString(36)}`)
     .setPlaceholder("Select a recipe to cook")
     .setMinValues(1)
     .setMaxValues(1)
@@ -4301,7 +4301,7 @@ function buildTakeoutCookPickerPayload({ userId, p, takeout, ownerUser, page = 0
     : "";
 
   const menu = new StringSelectMenuBuilder()
-    .setCustomId(`noodle:pick:cook_select:${userId}:${safePage}:${Date.now().toString(36)}`)
+    .setCustomId(`noodle:pick:takeout_cook_select:${userId}:${safePage}:${Date.now().toString(36)}`)
     .setPlaceholder("Select a recipe to cook")
     .setMinValues(1)
     .setMaxValues(1)
@@ -7785,7 +7785,7 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
 
     const replyWithUnlock = applyUnlockNoticeEmbeds(replyObj ?? {}, unlockNoticePlayer, interaction.member ?? interaction.user, {
       consumeSeatingNotice: true,
-      consumeSubscriptionNotice: true
+      consumeSubscriptionNotice: sub === "orders"
     });
     if (replyWithUnlock && typeof replyWithUnlock === "object") {
       Object.defineProperty(replyWithUnlock, "__unlockNoticeApplied", { value: true, enumerable: false });

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7061,7 +7061,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         `${getIcon("orders")} Remaining counter orders for this recipe: **${remainingForRecipe}**`
       ];
       if (leveledUp) {
-        serveSummary.push(`${getIcon("status_complete")} Level up! You are now **Lv.${Math.max(1, Number(p.sxp_level || 1))}**.`);
+        serveSummary.push(`${getIcon("status_complete")} Level up! You are now **Lv.${Math.max(1, Number(p.shop_level || 1))}**.`);
       }
       if (discoveryMessages.length > 0) {
         serveSummary.push(discoveryMessages.slice(0, 4).join("\n"));

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1788,13 +1788,14 @@ function noodleOrdersMenuActionRow(userId, {
   showCancel = false,
   highlightAccept = true,
   disableAccept = false,
+  disableCook = false,
   disableServe = false,
   showTakeout = false
 } = {}) {
 const acceptStyle = disableAccept ? ButtonStyle.Secondary : (highlightAccept ? ButtonStyle.Success : ButtonStyle.Secondary);
 const row = new ActionRowBuilder().addComponents(
 new ButtonBuilder().setCustomId(`noodle:pick:accept:${userId}`).setLabel("Accept").setEmoji(getButtonEmoji("status_complete")).setStyle(acceptStyle).setDisabled(disableAccept),
-new ButtonBuilder().setCustomId(`noodle:pick:cook:${userId}`).setLabel("Cook").setEmoji(getButtonEmoji("cook")).setStyle(ButtonStyle.Primary),
+new ButtonBuilder().setCustomId(`noodle:pick:cook:${userId}`).setLabel("Cook").setEmoji(getButtonEmoji("cook")).setStyle(disableCook ? ButtonStyle.Secondary : ButtonStyle.Primary).setDisabled(disableCook),
 new ButtonBuilder().setCustomId(`noodle:pick:serve:${userId}`).setLabel("Serve").setEmoji(getButtonEmoji("serve")).setStyle(disableServe ? ButtonStyle.Secondary : ButtonStyle.Primary).setDisabled(disableServe)
 );
 
@@ -6186,7 +6187,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const description = [
         banner,
-        "Run a cozy 12-hour counter shift with your selected menu, pay ingredient costs up front, and claim idle coin earnings when ready.",
+        "Set your counter menu, start a cozy 12-hour shift, and collect idle earnings. While the shift is active, your main **Order Board** is idle and all service happens from **Take Out Counter**.",
         "",
         takeoutCatchup?.processedHours > 0
           ? `${getIcon("time")} Catch-up processed **${takeoutCatchup.processedHours}h** and accrued **${takeoutCatchup.earned}c** while you were away.`
@@ -8838,6 +8839,7 @@ ${lines.join("\n")}`;
   if (sub === "orders") {
     const now2 = nowTs();
     const sweep2 = sweepExpiredAcceptedOrders(p, s, content, now2);
+    const takeoutShiftActive = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now2) && isTakeoutShiftActive(p, now2);
 
     const acceptedEntries = Object.entries(p.orders?.accepted ?? {});
 
@@ -8943,7 +8945,12 @@ ${lines.join("\n")}`;
     const nextOrdersResetMs = parseYYYYMMDD(ordersDayKey) + (24 * 60 * 60 * 1000);
     const nextOrdersResetTs = Math.floor(nextOrdersResetMs / 1000);
     const nextOrdersResetText = `<t:${nextOrdersResetTs}:f> (<t:${nextOrdersResetTs}:R>)`;
-    if (remaining > 0) {
+    if (takeoutShiftActive) {
+      parts.push(
+        "**Today’s Orders**",
+        `${getIcon("time")} Your shop is idle on the main **Order Board** while your Take Out Counter shift is active. Serve orders from **Take Out Counter** until the shift ends.`
+      );
+    } else if (remaining > 0) {
       parts.push(
         "**Today’s Orders**",
         hasHouse247Perk(p)
@@ -8977,8 +8984,10 @@ ${lines.join("\n")}`;
     if (tutSuffix) parts.push("", tutSuffix);
 
     const showCancel = acceptedEntries.length > 0;
-    const highlightAccept = acceptedEntries.length === 0 && remaining > 0;
-    const disableAccept = remaining <= 0;
+    const highlightAccept = !takeoutShiftActive && acceptedEntries.length === 0 && remaining > 0;
+    const disableAccept = takeoutShiftActive || remaining <= 0;
+    const disableCook = takeoutShiftActive;
+    const disableServe = takeoutShiftActive || acceptedEntries.length === 0;
     const showTakeout = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, nowTs());
     const menuEmbed = buildMenuEmbed({
       title: `${getIcon("orders")} Orders`,
@@ -9001,7 +9010,8 @@ ${lines.join("\n")}`;
               showCancel,
               highlightAccept,
               disableAccept,
-              disableServe: acceptedEntries.length === 0,
+              disableCook,
+              disableServe,
               showTakeout
             }),
             noodleMainMenuRowNoOrders(userId)
@@ -9011,6 +9021,15 @@ ${lines.join("\n")}`;
 
   /* ---------------- ACCEPT -------- */
   if (sub === "accept") {
+    const now2 = nowTs();
+    const takeoutShiftActive = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now2) && isTakeoutShiftActive(p, now2);
+    if (takeoutShiftActive) {
+      return commitState({
+        content: `${getIcon("time")} Your shop is idle on the main **Order Board** while Take Out Counter is active. Serve orders from **Take Out Counter** until the shift ends.`,
+        ephemeral: true
+      });
+    }
+
     const rawInput = String(opt.getString("order_id") ?? "").trim();
     if (!rawInput) {
       const payload = buildAcceptPickerPayload({
@@ -9413,6 +9432,15 @@ ${lines.join("\n")}`;
 
   /* ---------------- SERVE ---------------- */
   if (sub === "serve") {
+    const now2 = nowTs();
+    const takeoutShiftActive = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now2) && isTakeoutShiftActive(p, now2);
+    if (takeoutShiftActive) {
+      return commitState({
+        content: `${getIcon("time")} Your shop is idle on the main **Order Board** while Take Out Counter is active. Serve orders from **Take Out Counter** until the shift ends.`,
+        ephemeral: true
+      });
+    }
+
     const rawInput = String(opt.getString("order_id") ?? "").trim();
     const bowlKey = opt.getString("bowl_key") ?? null;
     const tokens = rawInput

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -99,6 +99,7 @@ import {
 } from "../game/subscriptions.js";
 import {
   TAKEOUT_SHIFT_DURATION_HOURS,
+  TAKEOUT_MENU_MAX_RECIPES,
   ensureTakeoutState,
   getTakeoutMenuLimits,
   setTakeoutMenu,
@@ -2044,6 +2045,44 @@ function buildTakeoutMenuPickerRows(userId, {
   }
 
   return { rows, safePage, totalPages };
+}
+
+function mergeTakeoutMenuPageSelection({
+  availableRecipeIds = [],
+  currentSelectedRecipeIds = [],
+  pageSelectedRecipeIds = [],
+  page = 0,
+  maxAllowed = TAKEOUT_MENU_MAX_RECIPES
+} = {}) {
+  const pageSize = 25;
+  const normalizedAvailable = [...availableRecipeIds]
+    .map((id) => String(id || "").trim())
+    .filter(Boolean)
+    .sort((a, b) => displayRecipeName(a).localeCompare(displayRecipeName(b), undefined, { sensitivity: "base" }));
+  const availableSet = new Set(normalizedAvailable);
+
+  const totalPages = Math.max(1, Math.ceil(normalizedAvailable.length / pageSize));
+  const safePage = Math.max(0, Math.min(Number.isFinite(page) ? page : 0, totalPages - 1));
+  const pageRecipeIds = new Set(normalizedAvailable.slice(safePage * pageSize, (safePage + 1) * pageSize));
+
+  const dedupeOrdered = (ids = []) => {
+    const out = [];
+    const seen = new Set();
+    for (const rawId of ids) {
+      const id = String(rawId || "").trim();
+      if (!id || seen.has(id) || !availableSet.has(id)) continue;
+      seen.add(id);
+      out.push(id);
+    }
+    return out;
+  };
+
+  const current = dedupeOrdered(currentSelectedRecipeIds);
+  const pageSelected = dedupeOrdered(pageSelectedRecipeIds).filter((id) => pageRecipeIds.has(id));
+  const keepFromOtherPages = current.filter((id) => !pageRecipeIds.has(id));
+
+  const merged = [...keepFromOtherPages, ...pageSelected].slice(0, Math.max(1, Math.floor(Number(maxAllowed) || TAKEOUT_MENU_MAX_RECIPES)));
+  return merged;
 }
 
 /* ------------------------------------------------------------------ */
@@ -11784,10 +11823,21 @@ if (cid.startsWith("noodle:takeout:menu_select:")) {
     return componentCommit(interaction, { content: "That menu isn’t for you.", ephemeral: true });
   }
 
-  const selectedRecipeIds = (interaction.values ?? []).filter(Boolean);
-  if (!selectedRecipeIds.length) {
+  const pageSelectedRecipeIds = (interaction.values ?? []).filter(Boolean);
+  if (!pageSelectedRecipeIds.length) {
     return componentCommit(interaction, { content: `${getIcon("help")} Pick at least one recipe.`, ephemeral: true });
   }
+
+  const p = ensurePlayer(serverId, interaction.user.id);
+  const availableRecipeIds = getValidAvailableRecipeIds(p);
+  const menuLimits = getTakeoutMenuLimits(availableRecipeIds.length);
+  const selectedRecipeIds = mergeTakeoutMenuPageSelection({
+    availableRecipeIds,
+    currentSelectedRecipeIds: p?.takeout?.menu_recipe_ids ?? [],
+    pageSelectedRecipeIds,
+    page,
+    maxAllowed: menuLimits.maxAllowed
+  });
 
   return runNoodle(interaction, {
     sub: "takeout_menu",

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -3427,6 +3427,22 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
     });
   }
 
+  const takeoutState = ensureTakeoutState(p);
+  const takeoutActive = isTakeoutShiftActive(p, nowTs());
+  if (takeoutActive) {
+    const takeoutNeedRows = getTakeoutRecipeNeedRows(p, takeoutState).filter((entry) => entry.short > 0);
+    for (const entry of takeoutNeedRows) {
+      const recipe = content.recipes?.[entry.recipeId];
+      if (!recipe?.ingredients) continue;
+      getRelevantRecipeIngredients(p, recipe).forEach((ing) => {
+        if (isIngredientOptionalForPlayer(p, ing)) return;
+        const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+        if (qty <= 0) return;
+        allNeeded[ing.item_id] = (allNeeded[ing.item_id] ?? 0) + (qty * entry.short);
+      });
+    }
+  }
+
   const shortages = Object.entries(allNeeded)
     .map(([id, needed]) => {
       const have = p.inv_ingredients?.[id] ?? 0;
@@ -3439,7 +3455,7 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
     (s) => MARKET_ITEM_IDS.includes(s.id) && !FORAGE_ITEM_IDS.includes(s.id)
   );
 
-  const showShoppingList = acceptedEntries.length > 0;
+  const showShoppingList = acceptedEntries.length > 0 || takeoutActive;
   const maxShoppingLines = 8;
   const shoppingLines = shoppingShortages
     .slice(0, maxShoppingLines)
@@ -4073,13 +4089,10 @@ function getTakeoutRecipeNeedRows(player, takeoutState) {
   });
 }
 
-function buildTakeoutNeededIngredientsBlock(player, takeoutState, { maxLines = 10 } = {}) {
+function getTakeoutIngredientShortages(player, takeoutState) {
   const recipeNeeds = getTakeoutRecipeNeedRows(player, takeoutState).filter((entry) => entry.short > 0);
-  if (!recipeNeeds.length) {
-    return `${getIcon("basket")} **Needed Ingredients (Counter Orders)**\n_All ingredients currently ready for remaining counter orders._`;
-  }
-
   const neededByIngredient = {};
+
   for (const entry of recipeNeeds) {
     const recipe = content.recipes?.[entry.recipeId];
     if (!recipe) continue;
@@ -4091,7 +4104,7 @@ function buildTakeoutNeededIngredientsBlock(player, takeoutState, { maxLines = 1
     });
   }
 
-  const shortageRows = Object.entries(neededByIngredient)
+  return Object.entries(neededByIngredient)
     .map(([itemId, needed]) => {
       const have = Math.max(0, Math.floor(Number(player.inv_ingredients?.[itemId] || 0) || 0));
       const short = Math.max(0, needed - have);
@@ -4099,7 +4112,10 @@ function buildTakeoutNeededIngredientsBlock(player, takeoutState, { maxLines = 1
     })
     .filter((row) => row.short > 0)
     .sort((a, b) => displayItemName(a.itemId).localeCompare(displayItemName(b.itemId), "en", { sensitivity: "base" }));
+}
 
+function buildTakeoutNeededIngredientsBlock(player, takeoutState, { maxLines = 10 } = {}) {
+  const shortageRows = getTakeoutIngredientShortages(player, takeoutState);
   if (!shortageRows.length) {
     return `${getIcon("basket")} **Needed Ingredients (Counter Orders)**\n_All ingredients currently ready for remaining counter orders._`;
   }
@@ -4109,7 +4125,7 @@ function buildTakeoutNeededIngredientsBlock(player, takeoutState, { maxLines = 1
   ));
   const more = shortageRows.length > maxLines ? `\n…and **${shortageRows.length - maxLines}** more` : "";
 
-  return `${getIcon("basket")} **Needed Ingredients (Counter Orders)**\n${lines.join("\n")}${more}`;
+  return `${getIcon("basket")} **Needed Ingredients**\n${lines.join("\n")}${more}`;
 }
 
 function buildTakeoutCookPickerPayload({ userId, p, takeout, ownerUser, page = 0 }) {
@@ -4287,34 +4303,48 @@ function buildTakeoutServePickerPayload({ userId, p, takeout, ownerUser }) {
   };
 }
 
-function buildTakeoutNeedsPayload({ userId, p, takeout, ownerUser }) {
+function buildTakeoutNeedsPayload({ userId, p, takeout, ownerUser, page = 0 }) {
   const needRows = getTakeoutRecipeNeedRows(p, takeout)
     .filter((entry) => entry.need > 0)
     .sort((a, b) => {
       if (b.short !== a.short) return b.short - a.short;
       return displayRecipeName(a.recipeId).localeCompare(displayRecipeName(b.recipeId), "en", { sensitivity: "base" });
     });
+  const shortageRows = getTakeoutIngredientShortages(p, takeout);
+  const perPage = 14;
+  const totalPages = Math.max(1, Math.ceil(shortageRows.length / perPage));
+  const safePage = Math.min(Math.max(Number(page) || 0, 0), totalPages - 1);
+  const pageRows = shortageRows.slice(safePage * perPage, (safePage + 1) * perPage);
+
+  const neededIngredientLines = pageRows.length
+    ? pageRows
+      .map((row) => `• ${displayItemName(row.itemId)} — need **${row.needed}**, have **${row.have}** (short **${row.short}**)`)
+      .join("\n")
+    : "_All ingredients currently ready for remaining counter orders._";
 
   const remainingOrderLines = needRows.length
     ? needRows
-      .slice(0, 10)
+      .slice(0, 12)
       .map((entry) => `• ${displayRecipeName(entry.recipeId)} — need **${entry.need}**, ready **${entry.ready}** (cook **${entry.short}** more)`)
       .join("\n")
     : "_No remaining active counter orders._";
+  const hiddenOrderCount = Math.max(0, needRows.length - 12);
+  const hiddenOrderSuffix = hiddenOrderCount > 0 ? `\n…and **${hiddenOrderCount}** more order lines` : "";
+  const ingredientPageSuffix = shortageRows.length > 0 ? `\n\nPage **${safePage + 1}/${totalPages}**` : "";
 
-  const neededIngredientsBlock = buildTakeoutNeededIngredientsBlock(p, takeout, { maxLines: 20 });
   const description = [
-    "Needed ingredients for your remaining active counter orders (after counting ready bowls).",
+    "Ingredients needed for your remaining active counter orders (after counting ready bowls).",
     "",
     "**Remaining Counter Orders**",
-    remainingOrderLines,
+    `${remainingOrderLines}${hiddenOrderSuffix}`,
     "",
-    neededIngredientsBlock
+    `${getIcon("basket")} **Needed Ingredients**`,
+    `${neededIngredientLines}${ingredientPageSuffix}`
   ].join("\n");
 
   const canCounterServe = needRows.some((entry) => entry.ready > 0);
   const embed = buildMenuEmbed({
-    title: `${getIcon("basket")} Counter Ingredients`,
+    title: `${getIcon("basket")} Counter Order Ingredients`,
     description,
     user: ownerUser,
     color: theme.colors.success
@@ -4324,6 +4354,22 @@ function buildTakeoutNeedsPayload({ userId, p, takeout, ownerUser }) {
     content: " ",
     embeds: [embed],
     components: [
+      ...(totalPages > 1
+        ? [
+            new ActionRowBuilder().addComponents(
+              new ButtonBuilder()
+                .setCustomId(`noodle:nav:takeout_needs:${userId}:${safePage <= 0 ? totalPages - 1 : safePage - 1}`)
+                .setLabel("Prev")
+                .setEmoji(getButtonEmoji("back"))
+                .setStyle(ButtonStyle.Secondary),
+              new ButtonBuilder()
+                .setCustomId(`noodle:nav:takeout_needs:${userId}:${safePage >= totalPages - 1 ? 0 : safePage + 1}`)
+                .setLabel("Next")
+                .setEmoji(getButtonEmoji("next"))
+                .setStyle(ButtonStyle.Secondary)
+            )
+          ]
+        : []),
       noodleTakeoutActionRow(userId, {
         activeShift: true,
         disableClaim: Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) <= 0,
@@ -6561,7 +6607,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         statusBits.push(`${getIcon("basket")} Ingredients reserved for idle shift: **${coveredIngredientsCount}** units`);
       }
       if (shiftSnapshotOrderCount > 0) {
-        statusBits.push(`${getIcon("orders")} Shift orders: **${shiftSnapshotOrderCount}** total`);
+        statusBits.push(`${getIcon("orders")} Idle orders: **${shiftSnapshotOrderCount}** total`);
       }
       if (active) {
         statusBits.push(`${getIcon("time")} Completed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
@@ -6810,13 +6856,15 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
     if (sub === "takeout_needs") {
       if (!isTakeoutShiftActive(p, now)) {
-        return finalize(renderStatus(`${getIcon("help")} Start a shift to view **Counter Ingredients**.`, { ephemeral: true }));
+        return finalize(renderStatus(`${getIcon("help")} Start a shift to view **Counter Order Ingredients**.`, { ephemeral: true }));
       }
+      const rawPage = Number(opt.getInteger("page") ?? 0);
       return finalize(buildTakeoutNeedsPayload({
         userId,
         p,
         takeout,
-        ownerUser: interaction.member ?? interaction.user
+        ownerUser: interaction.member ?? interaction.user,
+        page: Number.isFinite(rawPage) ? rawPage : 0
       }));
     }
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -5499,7 +5499,7 @@ if (inDevPath && sub === "subscriptions_toggle") {
     });
   }
 
-  const lockKey = `lock:user:${targetServerId}:${targetUserId}`;
+  const lockKey = `lock:user:${targetUserId}`;
   return await withLock(db, lockKey, owner, 8000, async () => {
     const existingPlayer = getPlayer(db, targetServerId, targetUserId);
     const targetPlayer = existingPlayer || newPlayerProfile(targetUserId);
@@ -6691,7 +6691,12 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
 
       const boardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
       const unlimitedOrders = hasHouse247Perk(p);
-      const previewPlayer = JSON.parse(JSON.stringify(p));
+      const previewPlayer = {
+        coins: Math.max(0, Math.floor(Number(p.coins || 0) || 0)),
+        takeout: {
+          menu_recipe_ids: Array.isArray(takeout?.menu_recipe_ids) ? [...takeout.menu_recipe_ids] : []
+        }
+      };
       const previewResult = startTakeoutShiftWithCoverage(previewPlayer, {
         now: nowMs,
         boardOrderTotal,

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -11662,20 +11662,25 @@ const noodleCommandData = new SlashCommandBuilder()
   .addSubcommand((sc) => sc.setName("quests_daily").setDescription("Claim your daily reward."))
   .addSubcommand((sc) => sc.setName("quests_claim").setDescription("Claim completed quest rewards."))
   .addSubcommand((sc) => sc.setName("quests_vote").setDescription("View and claim bot-list vote rewards."))
-  .addSubcommand((sc) => sc.setName("takeout").setDescription("View your Take Out Counter status."))
-  .addSubcommand((sc) =>
-    sc
-      .setName("takeout_menu")
-      .setDescription("Set your Take Out Counter menu (comma-separated recipe ids).")
-      .addStringOption((o) =>
-        o
-          .setName("recipes")
-          .setDescription("Comma-separated recipe ids (max 10).")
-          .setRequired(true)
+  .addSubcommandGroup((sg) =>
+    sg
+      .setName("takeout")
+      .setDescription("Take Out Counter actions.")
+      .addSubcommand((sc) => sc.setName("status").setDescription("View your Take Out Counter status."))
+      .addSubcommand((sc) =>
+        sc
+          .setName("menu")
+          .setDescription("Set your Take Out Counter menu (comma-separated recipe ids).")
+          .addStringOption((o) =>
+            o
+              .setName("recipes")
+              .setDescription("Comma-separated recipe ids (max 10).")
+              .setRequired(true)
+          )
       )
+      .addSubcommand((sc) => sc.setName("open").setDescription("Open a 12-hour takeout shift."))
+      .addSubcommand((sc) => sc.setName("claim").setDescription("Claim idle takeout earnings."))
   )
-  .addSubcommand((sc) => sc.setName("takeout_open").setDescription("Open a 12-hour takeout shift."))
-  .addSubcommand((sc) => sc.setName("takeout_claim").setDescription("Claim idle takeout earnings."))
   .addSubcommand((sc) =>
     sc
       .setName("buy")
@@ -11736,8 +11741,19 @@ export const noodleCommand = {
   data: noodleCommandData,
 
   async execute(interaction) {
-    const sub = interaction.options.getSubcommand();
+    const rawSub = interaction.options.getSubcommand();
     const group = interaction.options.getSubcommandGroup(false);
+    const sub = group === "takeout"
+      ? (rawSub === "status"
+          ? "takeout"
+          : rawSub === "menu"
+            ? "takeout_menu"
+            : rawSub === "open"
+              ? "takeout_open"
+              : rawSub === "claim"
+                ? "takeout_claim"
+                : rawSub)
+      : rawSub;
     return runNoodle(interaction, { sub, group });
   },
 

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7088,6 +7088,9 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       let seasonalServedCoins = 0;
       let leveledUp = false;
       const discoveryMessages = [];
+      const recipe = content.recipes?.[selectedRecipeId] ?? null;
+      const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
+      const activeEventEffects = getActiveEventEffects(eventsContent, s);
 
       for (let i = 0; i < servingsToProcess; i += 1) {
         const bowlEntry = getBestBowlEntry(p, selectedRecipeId);
@@ -7095,9 +7098,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         if (!bowl || (bowl.qty ?? 0) <= 0) break;
 
         const servedAt = nowTs();
-        const recipe = content.recipes?.[selectedRecipeId] ?? null;
-        const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
-        const activeEventEffects = getActiveEventEffects(eventsContent, s);
         const rewards = computeServeRewards({
           serverId,
           tier: recipe?.tier ?? "common",

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -4027,7 +4027,7 @@ function buildCookPickerPayload({ userId, p, s, ownerUser, page = 0 }) {
     : "";
 
   const menu = new StringSelectMenuBuilder()
-    .setCustomId(`noodle:pick:cook_select:${userId}:${safePage}:${Date.now().toString(36)}`)
+    .setCustomId(`noodle:pick:takeout_cook_select:${userId}:${safePage}:${Date.now().toString(36)}`)
     .setPlaceholder("Select a recipe to cook")
     .setMinValues(1)
     .setMaxValues(1)
@@ -9484,8 +9484,9 @@ ${lines.join("\n")}`;
       ? `${getIcon("warning")} **Cook failure**: ${outcome.failed} bowl(s) failed. Lost: ${lostLine}. Cause: recipe tier risk.${salvageLine}`
       : null;
 
+    const counterCookFlow = Boolean(opt.getBoolean("counter_cook"));
     const cookEmbed = buildMenuEmbed({
-      title: `${getIcon("cook")} Cooked`,
+      title: counterCookFlow ? `${getIcon("cook")} Counter Cook` : `${getIcon("cook")} Cooked`,
       description: [
         `You cooked **${batchOutput}× ${r.name}**.`,
         qtyToCook < qty ? `${getIcon("basket")} Bowl storage limited this cook to **${qtyToCook}**.` : null,
@@ -9505,6 +9506,25 @@ ${lines.join("\n")}`;
       fallbackValue: false
     });
     const hasAcceptedOrders = Object.keys(p.orders?.accepted ?? {}).length > 0;
+
+    if (counterCookFlow) {
+      const takeout = ensureTakeoutState(p);
+      const canCounterServe = getTakeoutRecipeNeedRows(p, takeout)
+        .some((entry) => entry.need > 0 && entry.ready > 0);
+      const canClaim = Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) > 0;
+      return commitState({
+        content: " ",
+        embeds: [cookEmbed],
+        components: [
+          noodleTakeoutActionRow(userId, {
+            activeShift: true,
+            disableClaim: !canClaim,
+            disableServe: !canCounterServe
+          }),
+          noodleMainMenuRowNoOrdersWithBack(userId)
+        ]
+      });
+    }
 
     return commitState({
       content: " ",
@@ -11599,6 +11619,48 @@ if (cid.startsWith("noodle:pick:takeout_serve_select:")) {
   });
 }
 
+if (cid.startsWith("noodle:pick:takeout_cook_select:")) {
+  const idParts = cid.split(":");
+  const owner = idParts[3];
+  const recipeId = interaction.values?.[0];
+
+  if (owner && owner !== interaction.user.id) {
+    return componentCommit(interaction, { content: "That menu isn’t for you.", ephemeral: true });
+  }
+
+  if (interaction.deferred || interaction.replied) {
+    return componentCommit(interaction, { content: "That menu expired, tap again.", ephemeral: true });
+  }
+
+  const sourceMessageId = interaction.message?.id ?? "none";
+  const modal = new ModalBuilder()
+    .setCustomId(`noodle:pick:takeout_cook_qty:${userId}:${recipeId}:${sourceMessageId}`)
+    .setTitle("Counter cook bowls");
+
+  const input = new TextInputBuilder()
+    .setCustomId("qty")
+    .setLabel("Quantity")
+    .setStyle(TextInputStyle.Short)
+    .setRequired(true)
+    .setPlaceholder("1");
+
+  modal.addComponents(new ActionRowBuilder().addComponents(input));
+
+  try {
+    return await interaction.showModal(modal);
+  } catch (e) {
+    console.log(`⚠️ showModal failed for takeout cook:`, e?.message);
+    const code = e?.code ?? e?.message;
+    if (code === 10062 || e?.message?.includes("Unknown interaction") || e?.message?.includes("already been acknowledged")) {
+      return;
+    }
+    return componentCommit(interaction, {
+      content: `${getIcon("warning")} Discord couldn't show the modal. Try using Counter Cook again.`,
+      ephemeral: true
+    });
+  }
+}
+
 // cook picker -> open qty modal
 if (cid.startsWith("noodle:pick:cook_select:")) {
   const recipeId = interaction.values?.[0];
@@ -11757,6 +11819,44 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
     });
 
     return result;
+  }
+
+  /* ---------------- TAKEOUT COOK QTY MODAL ---------------- */
+  if (interaction.isModalSubmit?.() && interaction.customId.startsWith("noodle:pick:takeout_cook_qty:")) {
+    const parts2 = interaction.customId.split(":");
+    // noodle:pick:takeout_cook_qty:<ownerId>:<recipeId>:<messageId>
+    const owner = parts2[4];
+    const recipeId = parts2[5];
+    const messageId = parts2[6] && parts2[6] !== "none" ? parts2[6] : null;
+
+    if (owner && owner !== interaction.user.id) {
+      return componentCommit(interaction, { content: "That counter cook prompt isn’t for you.", ephemeral: true });
+    }
+
+    const rawQty = String(interaction.fields.getTextInputValue("qty") ?? "").trim();
+    const qty = Number(rawQty);
+
+    if (!Number.isInteger(qty) || qty < 1 || qty > 99) {
+      return componentCommit(interaction, { content: "Enter a whole number quantity (1–99).", ephemeral: true });
+    }
+
+    if (messageId) {
+      try {
+        await interaction.deferReply({ ephemeral: true });
+      } catch (e) {
+        // ignore
+      }
+    }
+
+    return runNoodle(interaction, {
+      sub: "cook",
+      overrides: {
+        strings: { recipe: recipeId },
+        integers: { quantity: qty },
+        booleans: { counter_cook: true },
+        messageId
+      }
+    });
   }
 
   /* ---------------- FORAGE QTY MODAL ---------------- */

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -1817,17 +1817,17 @@ function noodleTakeoutActionRow(userId, { disableOpen = false, disableClaim = fa
   return new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(`noodle:nav:takeout:${userId}`)
-      .setLabel("Status")
+      .setLabel("Counter")
       .setEmoji(getButtonEmoji("orders"))
       .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
       .setCustomId(`noodle:nav:takeout_menu:${userId}`)
-      .setLabel("Set Menu")
+      .setLabel("Menu")
       .setEmoji(getButtonEmoji("recipes"))
       .setStyle(ButtonStyle.Secondary),
     new ButtonBuilder()
       .setCustomId(`noodle:nav:takeout_open:${userId}`)
-      .setLabel("Open")
+      .setLabel("Start Shift")
       .setEmoji(getButtonEmoji("status_complete"))
       .setStyle(disableOpen ? ButtonStyle.Secondary : ButtonStyle.Success)
       .setDisabled(disableOpen),
@@ -6244,7 +6244,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       }
 
       return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`, {
-        showMenuPicker: true,
+        showMenuPicker: false,
         menuPage: requestedMenuPage
       }));
     }

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -822,15 +822,24 @@ function hasHouse247Perk(player) {
 }
 
 function applyHouse247OrderBoardOverride(player) {
+  if (!hasHouse247Perk(player)) return;
+
   const orderCap = Math.max(0, Math.floor(Number(getOrderAcceptCap(player, nowTs()) || 0) || 0));
   const currentTotal = Math.max(0, Math.floor(Number(player?.orders_total_count || 0) || 0));
-  if (orderCap <= currentTotal) return;
-
-  player.orders_total_count = orderCap;
   const consumedCount = Array.isArray(player?.orders_consumed_indices)
     ? player.orders_consumed_indices.length
     : 0;
-  if (consumedCount < orderCap) {
+
+  // Keep a rolling board chunk available while preserving stable order IDs within a day.
+  // This makes 24/7 House effectively unlimited without allocating a giant board upfront.
+  const boardChunk = Math.max(1, orderCap || 500);
+  const minimumTotal = Math.max(currentTotal, boardChunk);
+  const consumedChunks = Math.floor(consumedCount / boardChunk);
+  const desiredTotal = Math.max(minimumTotal, (consumedChunks + 1) * boardChunk);
+  if (desiredTotal <= currentTotal) return;
+
+  player.orders_total_count = desiredTotal;
+  if (consumedCount < desiredTotal) {
     player.orders_depleted_day = null;
   }
 }

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -369,6 +369,13 @@ function applyUnlockNoticeEmbeds(payload = {}, player, user, { consumeSeatingNot
     String(state?.last_coin_grant_period ?? "-")
   ].join("|");
 
+  const getNoticeCoinGrantPeriod = (noticeKey) => {
+    const key = String(noticeKey ?? "");
+    if (!key) return "-";
+    const parts = key.split("|");
+    return String(parts[3] ?? "-");
+  };
+
   const subscriptions = ensureSubscriptionState(player);
   const existingNoticeKeys = (player?.notifications?.subscription_perk_notice_keys
     && typeof player.notifications.subscription_perk_notice_keys === "object"
@@ -392,7 +399,9 @@ function applyUnlockNoticeEmbeds(payload = {}, player, user, { consumeSeatingNot
     const meta = subscriptionPerkMeta[perkId] ?? { name: perkId, tryLine: "" };
     grantedPerkLines.push(`• **${meta.name}** unlocked. ${meta.tryLine}`);
 
-    if (state?.last_coin_grant_period) {
+    const currentCoinGrantPeriod = String(state?.last_coin_grant_period ?? "-");
+    const previousCoinGrantPeriod = getNoticeCoinGrantPeriod(seenNoticeKey);
+    if (currentCoinGrantPeriod !== "-" && currentCoinGrantPeriod !== previousCoinGrantPeriod) {
       totalCoinReward += SUBSCRIPTION_MONTHLY_COIN_GRANT;
       sawCoinGrant = true;
     }
@@ -3470,7 +3479,7 @@ if (idMatches.length === 1) return idMatches[0];
 return null;
 }
 
-function computeMarketShoppingShortages(player, serverState) {
+function computeMarketShoppingShortages(player, _serverState) {
   const acceptedEntries = Object.entries(player.orders?.accepted ?? {});
   const allNeeded = {};
   let hasTakeoutOrders = false;

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -9,7 +9,7 @@ import {
   FORAGE_ITEM_IDS,
   RARE_FORAGE_ITEM_IDS
 } from "../game/forage.js";
-import { addIngredientsToInventory, removeIngredientsFromInventory } from "../game/inventory.js";
+import { addIngredientsToInventory, removeIngredientsFromInventory, checkIngredientCapacity } from "../game/inventory.js";
 import {
   advanceTutorial,
   ensureTutorial,
@@ -12350,7 +12350,9 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
           const stock = p2.market_stock?.[id3] ?? 0;
           const type = normalizeIngredientType(id3);
           const remaining = remainingByType[type] ?? 0;
-          const qtyToBuy = Math.min(qty3, remaining);
+          const capacity = checkIngredientCapacity(p2, id3, 0);
+          const stackRemaining = Math.max(0, (capacity.maxCapacity ?? 0) - (capacity.currentQty ?? 0));
+          const qtyToBuy = Math.min(qty3, remaining, stackRemaining);
 
           if (qtyToBuy <= 0) {
             capacityReduced = true;

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -3342,6 +3342,7 @@ return null;
 function computeMarketShoppingShortages(player, serverState) {
   const acceptedEntries = Object.entries(player.orders?.accepted ?? {});
   const allNeeded = {};
+  let hasTakeoutOrders = false;
 
   const neededCountsByRecipe = {};
   acceptedEntries.forEach(([, entry]) => {
@@ -3366,7 +3367,9 @@ function computeMarketShoppingShortages(player, serverState) {
   const takeoutState = ensureTakeoutState(player);
   const takeoutActive = isTakeoutShiftActive(player, nowTs());
   if (takeoutActive) {
-    const takeoutNeedRows = getTakeoutRecipeNeedRows(player, takeoutState).filter((entry) => entry.short > 0);
+    const takeoutAllNeedRows = getTakeoutRecipeNeedRows(player, takeoutState);
+    hasTakeoutOrders = takeoutAllNeedRows.some((entry) => entry.need > 0);
+    const takeoutNeedRows = takeoutAllNeedRows.filter((entry) => entry.short > 0);
     for (const entry of takeoutNeedRows) {
       const recipe = content.recipes?.[entry.recipeId];
       if (!recipe?.ingredients) continue;
@@ -3395,7 +3398,8 @@ function computeMarketShoppingShortages(player, serverState) {
     acceptedEntries,
     shortages,
     shoppingShortages,
-    takeoutActive
+    takeoutActive,
+    hasActiveOrders: acceptedEntries.length > 0 || hasTakeoutOrders
   };
 }
 
@@ -4724,7 +4728,7 @@ async function renderMultiBuyPicker({ interaction, userId, s, p }) {
   return componentCommit(interaction, payload);
 }
 
-function buildMultiBuyButtonsRow(userId, selectedIds, sourceMessageId, { limitToBuy1 = false } = {}) {
+function buildMultiBuyButtonsRow(userId, selectedIds, sourceMessageId, { limitToBuy1 = false, showBuyNeeded = true } = {}) {
 const selectedNames = formatSelectedItemNames(selectedIds);
 const msgId = sourceMessageId || "none";
 const btnRow = new ActionRowBuilder().addComponents(
@@ -4736,11 +4740,16 @@ new ButtonBuilder()
 
 if (!limitToBuy1) {
   const baseBuyOneButton = btnRow.components[0];
-  btnRow.setComponents(
-    new ButtonBuilder()
-      .setCustomId(`noodle:multibuy:buyneed:${userId}:${msgId}`)
-      .setLabel("Buy Needed")
-      .setStyle(ButtonStyle.Success),
+  const components = [];
+  if (showBuyNeeded) {
+    components.push(
+      new ButtonBuilder()
+        .setCustomId(`noodle:multibuy:buyneed:${userId}:${msgId}`)
+        .setLabel("Buy Needed")
+        .setStyle(ButtonStyle.Success)
+    );
+  }
+  components.push(
     baseBuyOneButton,
     new ButtonBuilder()
       .setCustomId(`noodle:multibuy:buy5:${userId}:${msgId}`)
@@ -4755,6 +4764,7 @@ if (!limitToBuy1) {
       .setLabel("Clear")
       .setStyle(ButtonStyle.Danger)
   );
+  btnRow.setComponents(...components);
 }
 
 return { selectedNames, btnRow };
@@ -7091,7 +7101,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         unclaimedCoinsAfter: Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0))
       });
 
-      return finalize(renderStatus(`${getIcon("coins")} Claimed **${claimed.amount}c** from the takeout idle earnings.`));
+      return finalize(renderStatus(`${getIcon("coins")} Claimed **${claimed.amount}c** from your shop's idle earnings.`));
     }
 
     return finalize(renderStatus());
@@ -12119,7 +12129,12 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
       gate: "multiBuySelectionShowSellButton",
       fallbackValue: true
     });
-    const { selectedNames, btnRow } = buildMultiBuyButtonsRow(interaction.user.id, picked, sourceMessageId, { limitToBuy1: limitMultiBuyToBuy1 });
+    const serverState = ensureServer(serverId);
+    const { hasActiveOrders } = computeMarketShoppingShortages(p, serverState);
+    const { selectedNames, btnRow } = buildMultiBuyButtonsRow(interaction.user.id, picked, sourceMessageId, {
+      limitToBuy1: limitMultiBuyToBuy1,
+      showBuyNeeded: hasActiveOrders
+    });
 
     const sellButton = new ActionRowBuilder().addComponents(
       new ButtonBuilder()
@@ -12266,7 +12281,11 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
         gate: "multiBuySelectionShowSellButton",
         fallbackValue: true
       });
-      const { selectedNames, btnRow } = buildMultiBuyButtonsRow(interaction.user.id, selectedIds, sourceId, { limitToBuy1: limitMultiBuyToBuy1 });
+      const { hasActiveOrders } = computeMarketShoppingShortages(p, serverState);
+      const { selectedNames, btnRow } = buildMultiBuyButtonsRow(interaction.user.id, selectedIds, sourceId, {
+        limitToBuy1: limitMultiBuyToBuy1,
+        showBuyNeeded: hasActiveOrders
+      });
       const sellButton = new ActionRowBuilder().addComponents(
         new ButtonBuilder()
           .setCustomId(`noodle:nav:sell:${interaction.user.id}`)
@@ -12467,7 +12486,11 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
             ? [noodleTutorialForageRow(userId)]
             : [noodleMainMenuRow(userId), noodleSecondaryMenuRow(userId, { questsAvailable })];
         } else {
-          const { btnRow } = buildMultiBuyButtonsRow(interaction.user.id, selectedIds, sourceMessageId, { limitToBuy1: false });
+          const { hasActiveOrders } = computeMarketShoppingShortages(p2, s);
+          const { btnRow } = buildMultiBuyButtonsRow(interaction.user.id, selectedIds, sourceMessageId, {
+            limitToBuy1: false,
+            showBuyNeeded: hasActiveOrders
+          });
           const sellRow = new ActionRowBuilder().addComponents(
             new ButtonBuilder()
               .setCustomId(`noodle:nav:sell:${interaction.user.id}`)

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -7053,11 +7053,20 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         user: interaction.member ?? interaction.user,
         color: theme.colors.success
       });
-      const statusPayload = renderStatus();
+      const canCounterServe = getTakeoutRecipeNeedRows(p, takeout)
+        .some((entry) => entry.need > 0 && entry.ready > 0);
+      const canClaim = Math.max(0, Math.floor(Number(takeout?.earned_unclaimed_coins || 0) || 0)) > 0;
       return finalize({
-        ...statusPayload,
         content: " ",
-        embeds: [confirmationEmbed, ...(statusPayload.embeds ?? [])]
+        embeds: [confirmationEmbed],
+        components: [
+          noodleTakeoutActionRow(userId, {
+            activeShift: true,
+            disableClaim: !canClaim,
+            disableServe: !canCounterServe
+          }),
+          noodleMainMenuRowNoOrdersWithBack(userId)
+        ]
       });
     }
 
@@ -11697,6 +11706,10 @@ if (cid.startsWith("noodle:pick:takeout_cook_select:")) {
 // cook picker -> open qty modal
 if (cid.startsWith("noodle:pick:cook_select:")) {
   const recipeId = interaction.values?.[0];
+  const title = interaction.message?.embeds?.[0]?.data?.title
+    ?? interaction.message?.embeds?.[0]?.title
+    ?? "";
+  const fromCounterCook = String(title).includes("Counter Cook");
 
   if (interaction.deferred || interaction.replied) {
     return componentCommit(interaction, { content: "That menu expired, tap again.", ephemeral: true });
@@ -11704,8 +11717,10 @@ if (cid.startsWith("noodle:pick:cook_select:")) {
 
   const sourceMessageId = interaction.message?.id ?? "none";
   const modal = new ModalBuilder()
-    .setCustomId(`noodle:pick:cook_qty:${userId}:${recipeId}:${sourceMessageId}`)
-    .setTitle("Cook bowls");
+    .setCustomId(fromCounterCook
+      ? `noodle:pick:takeout_cook_qty:${userId}:${recipeId}:${sourceMessageId}`
+      : `noodle:pick:cook_qty:${userId}:${recipeId}:${sourceMessageId}`)
+    .setTitle(fromCounterCook ? "Counter cook bowls" : "Cook bowls");
 
   const input = new TextInputBuilder()
     .setCustomId("qty")
@@ -11858,9 +11873,9 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
   if (interaction.isModalSubmit?.() && interaction.customId.startsWith("noodle:pick:takeout_cook_qty:")) {
     const parts2 = interaction.customId.split(":");
     // noodle:pick:takeout_cook_qty:<ownerId>:<recipeId>:<messageId>
-    const owner = parts2[4];
-    const recipeId = parts2[5];
-    const messageId = parts2[6] && parts2[6] !== "none" ? parts2[6] : null;
+    const owner = parts2[3];
+    const recipeId = parts2[4];
+    const messageId = parts2[5] && parts2[5] !== "none" ? parts2[5] : null;
 
     if (owner && owner !== interaction.user.id) {
       return componentCommit(interaction, { content: "That counter cook prompt isn’t for you.", ephemeral: true });

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6941,6 +6941,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         return finalize(renderStatus(`${getIcon("warning")} Configure your counter menu first with /noodle takeout_menu.` , { ephemeral: true }));
       }
 
+      sweepExpiredAcceptedOrders(p, s, content, now);
       const acceptedOrderCount = Object.keys(p.orders?.accepted ?? {}).length;
       if (acceptedOrderCount > 0) {
         return finalize(renderStatus(

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -4280,20 +4280,6 @@ function getTakeoutIngredientShortages(player, takeoutState) {
     .sort((a, b) => displayItemName(a.itemId).localeCompare(displayItemName(b.itemId), "en", { sensitivity: "base" }));
 }
 
-function buildTakeoutNeededIngredientsBlock(player, takeoutState, { maxLines = 10 } = {}) {
-  const shortageRows = getTakeoutIngredientShortages(player, takeoutState);
-  if (!shortageRows.length) {
-    return `${getIcon("basket")} **Needed Ingredients (Counter Orders)**\n_All ingredients currently ready for remaining counter orders._`;
-  }
-
-  const lines = shortageRows.slice(0, maxLines).map((row) => (
-    `• ${displayItemName(row.itemId)} — need **${row.needed}**, have **${row.have}** (short **${row.short}**)`
-  ));
-  const more = shortageRows.length > maxLines ? `\n…and **${shortageRows.length - maxLines}** more` : "";
-
-  return `${getIcon("basket")} **Needed Ingredients**\n${lines.join("\n")}${more}`;
-}
-
 function buildTakeoutCookPickerPayload({ userId, p, takeout, ownerUser, page = 0 }) {
   const menuRecipeIds = (takeout?.menu_recipe_ids ?? []).filter((rid) => content.recipes?.[rid]);
   if (!menuRecipeIds.length) {
@@ -6648,10 +6634,13 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
     }
 
     const availableRecipeIds = getValidAvailableRecipeIds(p);
-    const availableRecipeSet = new Set(availableRecipeIds);
-    const existingMenu = (takeout.menu_recipe_ids || []).filter((recipeId) => availableRecipeSet.has(recipeId));
-    if (existingMenu.length !== (takeout.menu_recipe_ids || []).length) {
-      takeout.menu_recipe_ids = existingMenu;
+    const shiftActiveForMenu = isTakeoutShiftActive(p, now);
+    if (!shiftActiveForMenu) {
+      const availableRecipeSet = new Set(availableRecipeIds);
+      const existingMenu = (takeout.menu_recipe_ids || []).filter((recipeId) => availableRecipeSet.has(recipeId));
+      if (existingMenu.length !== (takeout.menu_recipe_ids || []).length) {
+        takeout.menu_recipe_ids = existingMenu;
+      }
     }
 
     const menuLimits = getTakeoutMenuLimits(availableRecipeIds.length);
@@ -12497,6 +12486,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
     if (mode === "qty") {
       const sourceId = cacheEntry.sourceMessageId || interaction.message?.id || "none";
       const p = ensurePlayer(serverId, userId);
+      const serverState = ensureServer(serverId);
       const limitMultiBuyToBuy1 = resolveTutorialGateValue({
         player: p,
         gate: "limitMultiBuyToBuy1",

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -88,6 +88,23 @@ import {
 import { socialMainMenuRow, socialMainMenuRowNoProfile } from "./noodleSocial.js";
 import { getUserActiveParty, getActiveBlessing, clearExpiredBlessings, BLESSING_EFFECTS } from "../game/social.js";
 import {
+  SUBSCRIPTION_PERKS,
+  ensureSubscriptionState,
+  getOrderAcceptCap,
+  hasActivePerk,
+  hasUnlimitedMarketStock
+} from "../game/subscriptions.js";
+import {
+  TAKEOUT_SHIFT_DURATION_HOURS,
+  ensureTakeoutState,
+  getTakeoutMenuLimits,
+  setTakeoutMenu,
+  isTakeoutShiftActive,
+  claimTakeoutEarnings,
+  startTakeoutShiftWithCoverage,
+  processTakeoutCatchup
+} from "../game/takeout.js";
+import {
   applyResilienceMechanics,
   getAvailableRecipes,
   clearTemporaryRecipes,
@@ -712,6 +729,10 @@ function buildMarketRefreshFooterText(existingFooterText, marketRestockMs, nowMs
 
 function isDevAdmin(userId) {
   return String(userId ?? "") === DEV_ADMIN_USER_ID;
+}
+
+function hasHouse247Perk(player) {
+  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, nowTs());
 }
 
 function buildHelpPage({ page, userId, user }) {
@@ -2576,6 +2597,7 @@ function ensurePlayer(serverId, userId) {
   if (!p.seasons) {
     p.seasons = { last_seen: null, last_rewarded_from: null, last_rewarded_at: null };
   }
+  ensureTakeoutState(p);
   return p;
 }
 
@@ -3151,6 +3173,7 @@ return null;
 function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSellButton = true }) {
   if (!s.market_prices) s.market_prices = {};
   if (!p.market_stock) p.market_stock = {};
+  const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
 
   const allowed = getUnlockedIngredientIds(p, content);
 
@@ -3162,8 +3185,8 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
       if (!it) return null;
 
       const price = s.market_prices?.[id] ?? it.base_price ?? 0;
-      const stock = p.market_stock?.[id] ?? 0;
-      if (stock <= 0) return null;
+      const stock = unlimitedMarketStock ? "unlimited" : (p.market_stock?.[id] ?? 0);
+      if (!unlimitedMarketStock && Number(stock) <= 0) return null;
 
       const ownedQty = p.inv_ingredients?.[id] ?? 0;
       const labelRaw = `${it.name} — ${price}c (stock ${stock}, you have ${ownedQty})`;
@@ -3278,6 +3301,7 @@ function buildMultiBuyPickerPayload({ userId, p, s, ownerUser, page = 0, showSel
   const descriptionLines = [
     "Select up to **5** items",
     "When you’re done selecting, if on Desktop, press **Esc** to continue",
+    unlimitedMarketStock ? `${getIcon("sparkle")} 24/7 House active: market stock is **unlimited**.` : null,
     shoppingList ? "" : null,
     shoppingList,
     "",
@@ -4391,7 +4415,7 @@ return componentCommit(interaction, payload);
 
 try {
 const owner = `discord:${interaction.id}`;
-const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "dashboard";
+const isDevSubcommand = sub === "reset_tutorial" || sub === "wipe_user" || sub === "repair_profile" || sub === "subscriptions" || sub === "dashboard";
 const inDevPath = group === "dev" || isDevSubcommand;
 
 const buildDevStatusEmbed = () => {
@@ -4675,6 +4699,92 @@ if (inDevPath && sub === "repair_profile") {
             `(legacyScore=${result.legacyScore}, globalScore=${result.globalScore}).`
         })
       ],
+      ephemeral: true
+    });
+  });
+}
+
+if (inDevPath && sub === "subscriptions") {
+  const targetUser = opt.getUser("user");
+  const targetUserId = targetUser?.id || opt.getString("user_id")?.trim() || userId;
+  const targetServerId = opt.getString("server_id")?.trim() || serverId;
+
+  if (!targetUserId) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Provide a user or user ID to inspect.", isError: true })],
+      ephemeral: true
+    });
+  }
+  if (!db) {
+    return commit({
+      content: " ",
+      embeds: [buildDevMessageEmbed({ message: "Database unavailable in this environment.", isError: true })],
+      ephemeral: true
+    });
+  }
+
+  const lockKey = `lock:user:${targetServerId}:${targetUserId}`;
+  return await withLock(db, lockKey, owner, 8000, async () => {
+    const targetPlayer = getPlayer(db, targetServerId, targetUserId);
+    if (!targetPlayer) {
+      return commit({
+        content: " ",
+        embeds: [
+          buildDevMessageEmbed({
+            message: `${getIcon("error")} No profile found for <@${targetUserId}> on server ${targetServerId}.`,
+            isError: true
+          })
+        ],
+        ephemeral: true
+      });
+    }
+
+    const subscriptions = ensureSubscriptionState(targetPlayer);
+    const perks = subscriptions.perks ?? {};
+    const now = nowTs();
+
+    const formatTime = (ts) => {
+      const n = Number(ts);
+      if (!Number.isFinite(n) || n <= 0) return "-";
+      return `<t:${Math.floor(n / 1000)}:f> (<t:${Math.floor(n / 1000)}:R>)`;
+    };
+
+    const perkLines = Object.values(SUBSCRIPTION_PERKS).map((perkId) => {
+      const state = perks[perkId] ?? {};
+      const activeNow = hasActivePerk(targetPlayer, perkId, now);
+      const name = perkId === SUBSCRIPTION_PERKS.HOUSE_247 ? "24/7 House" : "Take Out Counter";
+      const status = activeNow ? "ACTIVE" : "inactive";
+      return [
+        `**${name}** (${perkId})`,
+        `• status: ${status}`,
+        `• entitlement_id: ${state.entitlement_id ?? "-"}`,
+        `• period_start_at: ${formatTime(state.period_start_at)}`,
+        `• period_end_at: ${formatTime(state.period_end_at)}`,
+        `• last_coin_grant_period: ${state.last_coin_grant_period ?? "-"}`,
+        `• last_coin_grant_at: ${formatTime(state.last_coin_grant_at)}`,
+        `• last_event_type: ${state.last_event_type ?? "-"}`,
+        `• last_event_at: ${formatTime(state.last_event_at)}`
+      ].join("\n");
+    });
+
+    const description = [
+      `User: <@${targetUserId}> (${targetUserId})`,
+      `Server: ${targetServerId}`,
+      `Coins: ${Number(targetPlayer.coins || 0).toLocaleString()}`,
+      "",
+      ...perkLines
+    ].join("\n\n");
+
+    const embed = buildMenuEmbed({
+      title: `${getIcon("stats")} Subscription State`,
+      description,
+      user: interaction.member ?? interaction.user
+    });
+
+    return commit({
+      content: " ",
+      embeds: [embed],
       ephemeral: true
     });
   });
@@ -5697,6 +5807,293 @@ if (sub === "kitchen" || sub === "kitchen_start" || sub === "kitchen_collect") {
 }
 
 /* ---------------- RECIPES ---------------- */
+if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub === "takeout_claim") {
+  if (!db) {
+    const unavailableEmbed = buildMenuEmbed({
+      title: `${getIcon("orders")} Take Out Counter`,
+      description: `${getIcon("error")} Database unavailable in this environment.`,
+      user: interaction.member ?? interaction.user,
+      color: theme.colors.warning
+    });
+    return commit({ content: " ", embeds: [unavailableEmbed], ephemeral: true });
+  }
+
+  const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, async () => {
+    const p = ensurePlayer(serverId, userId);
+    const s = ensureServer(serverId);
+    unlockNoticePlayer = p;
+    const now = nowTs();
+    const takeoutEnabled = hasActivePerk(p, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now);
+
+    const finalize = (payload) => {
+      if (db) {
+        upsertPlayer(db, serverId, userId, p, null, p.schema_version);
+      }
+      return payload;
+    };
+
+    if (!takeoutEnabled) {
+      const lockedEmbed = buildMenuEmbed({
+        title: `${getIcon("orders")} Take Out Counter`,
+        description: `${getIcon("lock")} Take Out Counter requires an active subscription entitlement.`,
+        user: interaction.member ?? interaction.user,
+        color: theme.colors.warning
+      });
+      return finalize({
+        content: " ",
+        embeds: [lockedEmbed],
+        ephemeral: true
+      });
+    }
+
+    const takeout = ensureTakeoutState(p);
+    const takeoutCatchup = processTakeoutCatchup(p, {
+      now,
+      recipes: content.recipes ?? {},
+      marketPrices: s.market_prices ?? {},
+      items: content.items ?? {}
+    });
+    if ((takeoutCatchup?.processedHours ?? 0) > 0) {
+      emitTelemetry("takeout_shift_catchup", {
+        userId,
+        serverId,
+        processedHours: takeoutCatchup.processedHours,
+        earnedCoins: takeoutCatchup.earned,
+        totalProcessedHours: takeoutCatchup.totalProcessedHours,
+        completed: Boolean(takeoutCatchup.completed)
+      });
+    }
+
+    const availableRecipeIds = getValidAvailableRecipeIds(p);
+    const availableRecipeSet = new Set(availableRecipeIds);
+    const existingMenu = (takeout.menu_recipe_ids || []).filter((recipeId) => availableRecipeSet.has(recipeId));
+    if (existingMenu.length !== (takeout.menu_recipe_ids || []).length) {
+      takeout.menu_recipe_ids = existingMenu;
+    }
+
+    const menuLimits = getTakeoutMenuLimits(availableRecipeIds.length);
+
+    const renderStatus = (banner = null, { ephemeral = false } = {}) => {
+      const active = isTakeoutShiftActive(p, nowTs());
+      const shiftEndsAt = Number(takeout.shift?.ends_at || 0);
+      const shiftStartedAt = Number(takeout.shift?.started_at || 0);
+      const processedHours = Math.max(0, Math.floor(Number(takeout.shift?.last_processed_hour_index || 0) || 0));
+      const remainingHours = Math.max(0, TAKEOUT_SHIFT_DURATION_HOURS - processedHours);
+      const snapshot = Array.isArray(takeout.shift?.idle_order_board_snapshot)
+        ? takeout.shift.idle_order_board_snapshot
+        : [];
+      const shiftOperatingCost = Math.max(0, Math.floor(Number(takeout.shift?.operating_cost || 0) || 0));
+      const coveredIngredientsCount = Object.values(takeout.shift?.covered_ingredients ?? {})
+        .reduce((sum, qty) => sum + Math.max(0, Math.floor(Number(qty || 0) || 0)), 0);
+      const shiftSnapshotOrderCount = snapshot
+        .reduce((sum, row) => sum + Math.max(0, Math.floor(Number(row?.total_orders || row?.visible_order_count || 0) || 0)), 0);
+
+      const menuLine = takeout.menu_recipe_ids.length > 0
+        ? takeout.menu_recipe_ids.map((rid) => `• ${displayRecipeName(rid)}`).join("\n")
+        : "_No menu configured yet._";
+
+      const countByRecipe = new Map();
+      for (const row of snapshot) {
+        const rid = String(row?.recipe_id || "").trim();
+        if (!rid) continue;
+        const count = Math.max(0, Math.floor(Number(row?.visible_order_count) || 0));
+        countByRecipe.set(rid, count);
+      }
+
+      const visibleCounts = takeout.menu_recipe_ids.length > 0
+        ? takeout.menu_recipe_ids
+          .map((rid) => `• ${displayRecipeName(rid)}: **${countByRecipe.get(rid) ?? 0}**`)
+          .join("\n")
+        : "_No counter orders to show yet._";
+
+      const statusBits = [];
+      if (active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0) {
+        statusBits.push(`${getIcon("time")} **Shift Active** until <t:${Math.floor(shiftEndsAt / 1000)}:R> (<t:${Math.floor(shiftEndsAt / 1000)}:f>)`);
+        statusBits.push(`${getIcon("refresh")} Next eligible shift: <t:${Math.floor(shiftEndsAt / 1000)}:R>`);
+      } else {
+        statusBits.push(`${getIcon("status_pending")} **Shift Inactive**`);
+        statusBits.push(`${getIcon("refresh")} Next eligible shift: **Now**`);
+      }
+      if (Number.isFinite(shiftStartedAt) && shiftStartedAt > 0) {
+        statusBits.push(`${getIcon("calendar")} Last start: <t:${Math.floor(shiftStartedAt / 1000)}:f>`);
+      }
+      statusBits.push(`${getIcon("coins")} Unclaimed idle coins: **${takeout.earned_unclaimed_coins || 0}c**`);
+      if (shiftOperatingCost > 0) {
+        statusBits.push(`${getIcon("coins")} Fixed shift operating cost paid: **${shiftOperatingCost}c**`);
+      }
+      if (coveredIngredientsCount > 0) {
+        statusBits.push(`${getIcon("basket")} Covered ingredients reserved for idle shift: **${coveredIngredientsCount}** units`);
+      }
+      if (shiftSnapshotOrderCount > 0) {
+        statusBits.push(`${getIcon("orders")} Shift snapshot orders: **${shiftSnapshotOrderCount}** total`);
+      }
+      statusBits.push(`${getIcon("time")} Processed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
+      statusBits.push(`${getIcon("time")} Remaining hours: **${remainingHours}**`);
+      statusBits.push(`${getIcon("help")} Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})`);
+
+      const description = [
+        banner,
+        takeoutCatchup?.processedHours > 0
+          ? `${getIcon("time")} Catch-up processed **${takeoutCatchup.processedHours}h** and accrued **${takeoutCatchup.earned}c** while you were away.`
+          : null,
+        statusBits.join("\n"),
+        "\n**Counter Menu**",
+        menuLine,
+        "\n**Visible Order Counts**",
+        visibleCounts
+      ].filter(Boolean).join("\n");
+
+      const embed = buildMenuEmbed({
+        title: `${getIcon("orders")} Take Out Counter`,
+        description,
+        user: interaction.member ?? interaction.user,
+        color: theme.colors.success
+      });
+
+      return { content: " ", embeds: [embed], ephemeral };
+    };
+
+    if (sub === "takeout_menu") {
+      const rawRecipes = String(opt.getString("recipes") || "").trim();
+      if (!rawRecipes) {
+        return finalize(renderStatus(`${getIcon("help")} Provide recipe ids via the recipes option (comma-separated).`, { ephemeral: true }));
+      }
+
+      const requestedIds = rawRecipes
+        .split(",")
+        .map((id) => resolveCanonicalRecipeId(id))
+        .filter(Boolean);
+
+      const menuResult = setTakeoutMenu(p, {
+        menuRecipeIds: requestedIds,
+        learnedRecipeIds: availableRecipeIds,
+        now
+      });
+
+      if (!menuResult.ok) {
+        if (menuResult.reason === "no_learned_recipes") {
+          return finalize(renderStatus(`${getIcon("warning")} You need at least one learned recipe before setting a takeout menu.`, { ephemeral: true }));
+        }
+        if (menuResult.reason === "menu_too_small") {
+          const needed = menuResult.limits?.minRequired ?? 0;
+          return finalize(renderStatus(`${getIcon("warning")} Menu too small. Select at least **${needed}** recipe${needed === 1 ? "" : "s"}.`, { ephemeral: true }));
+        }
+        return finalize(renderStatus(`${getIcon("warning")} Could not update menu. Check recipe ids and try again.`, { ephemeral: true }));
+      }
+
+      if (!isTakeoutShiftActive(p, nowTs())) {
+        takeout.shift.idle_order_board_snapshot = takeout.menu_recipe_ids.map((rid) => ({
+          recipe_id: rid,
+          visible_order_count: 0
+        }));
+      }
+
+      return finalize(renderStatus(`${getIcon("status_complete")} Counter menu updated.`));
+    }
+
+    if (sub === "takeout_open") {
+      if (takeout.menu_recipe_ids.length <= 0) {
+        return finalize(renderStatus(`${getIcon("warning")} Configure your counter menu first with /noodle takeout_menu.` , { ephemeral: true }));
+      }
+
+      const set = buildSettingsMap(settingsCatalog, s.settings);
+      s.season = computeActiveSeason(set);
+      ensureDailyOrdersForPlayer(p, set, content, s.season, serverId, userId, s.active_event_id ?? null);
+
+      const boardOrderTotal = Math.max(0, Math.floor(Number(p.orders_total_count || 0) || 0));
+      const unlimitedOrders = hasHouse247Perk(p);
+
+      const openResult = startTakeoutShiftWithCoverage(p, {
+        now,
+        boardOrderTotal,
+        unlimitedOrders,
+        recipes: content.recipes ?? {},
+        marketPrices: s.market_prices ?? {},
+        items: content.items ?? {}
+      });
+      if (!openResult.ok && openResult.reason === "shift_active") {
+        emitTelemetry("takeout_shift_start_blocked", {
+          userId,
+          serverId,
+          reason: "shift_active"
+        });
+        return finalize(renderStatus(`${getIcon("time")} Your current takeout shift is still active.`, { ephemeral: true }));
+      }
+      if (!openResult.ok && openResult.reason === "insufficient_coins") {
+        const needed = Math.max(0, Math.floor(Number(openResult.operatingCost || 0) || 0));
+        const has = Math.max(0, Math.floor(Number(p.coins || 0) || 0));
+        emitTelemetry("takeout_shift_start_blocked", {
+          userId,
+          serverId,
+          reason: "insufficient_coins",
+          neededCoins: needed,
+          hasCoins: has
+        });
+        return finalize(renderStatus(`${getIcon("warning")} You need **${needed}c** to open this 12h shift, but only have **${has}c**.`, { ephemeral: true }));
+      }
+      if (!openResult.ok) {
+        emitTelemetry("takeout_shift_start_blocked", {
+          userId,
+          serverId,
+          reason: String(openResult.reason || "unknown")
+        });
+        return finalize(renderStatus(`${getIcon("warning")} Could not open your takeout shift right now.`, { ephemeral: true }));
+      }
+
+      const coveredUnits = Object.values(openResult.requiredIngredients ?? {})
+        .reduce((sum, qty) => sum + Math.max(0, Math.floor(Number(qty || 0) || 0)), 0);
+      emitTelemetry("takeout_shift_started", {
+        userId,
+        serverId,
+        boardOrderTotal,
+        unlimitedOrders,
+        snapshotOrderTotal: openResult.snapshotOrderTotal,
+        operatingCost: openResult.operatingCost,
+        coveredUnits,
+        menuSize: takeout.menu_recipe_ids.length,
+        startsAt: openResult.startedAt,
+        endsAt: openResult.endsAt
+      });
+
+      return finalize(
+        renderStatus(
+          `${getIcon("status_complete")} Shift opened for **${TAKEOUT_SHIFT_DURATION_HOURS}h** with **${openResult.snapshotOrderTotal}** snapshot orders and a fixed operating cost of **${openResult.operatingCost}c**. ` +
+          `Idle ingredients are pre-covered and isolated from your pantry, and you can start another shift after this one ends.`
+        )
+      );
+    }
+
+    if (sub === "takeout_claim") {
+      const claimed = claimTakeoutEarnings(p, { now });
+      if (!claimed.ok) {
+        emitTelemetry("takeout_claim_attempt", {
+          userId,
+          serverId,
+          ok: false,
+          reason: String(claimed.reason || "unknown"),
+          unclaimedCoins: Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0))
+        });
+        return finalize(renderStatus(`${getIcon("help")} No idle earnings to claim yet.`, { ephemeral: true }));
+      }
+
+      emitTelemetry("takeout_claim_attempt", {
+        userId,
+        serverId,
+        ok: true,
+        amount: claimed.amount,
+        unclaimedCoinsAfter: Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0))
+      });
+
+      return finalize(renderStatus(`${getIcon("coins")} Claimed **${claimed.amount}c** from takeout idle earnings.`));
+    }
+
+    return finalize(renderStatus());
+  });
+
+  return commit(lockedPayload);
+}
+
+/* ---------------- RECIPES ---------------- */
 if (sub === "recipes") {
   const p = ensurePlayer(serverId, userId);
   const allRecipeIds = new Set(Object.keys(content.recipes ?? {}));
@@ -6138,6 +6535,13 @@ const lockedPayload = await withLock(db, `lock:user:${userId}`, owner, 8000, asy
     const effects = prepareCombinedEffects();
     const lastActiveAt = db ? (getLastActiveAt(db, serverId, userId) || now) : now;
     activeEventEffects = getActiveEventEffects(eventsContent, s);
+
+    processTakeoutCatchup(p, {
+      now,
+      recipes: content.recipes ?? {},
+      marketPrices: s.market_prices ?? {},
+      items: content.items ?? {}
+    });
 
     // Apply time catch-up (spoilage, inactivity messages, cooldown checks)
     timeCatchup = applyTimeCatchup(p, s, set, content, lastActiveAt, now, effects);
@@ -7818,7 +8222,8 @@ ${lines.join("\n")}`;
     const pityPrice = getPityDiscount(p, itemId);
     const basePrice = pityPrice ?? (s.market_prices?.[itemId] ?? item.base_price);
     const price = applyMarketDiscount(basePrice, combinedEffects);
-    const stock = p.market_stock?.[itemId] ?? 0;
+    const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
+    const stock = unlimitedMarketStock ? Number.MAX_SAFE_INTEGER : (p.market_stock?.[itemId] ?? 0);
     const type = normalizeIngredientType(itemId);
     const perTypeCap = getIngredientCapacitiesByType(p, combinedEffects);
     const remaining = (perTypeCap[type] ?? perTypeCap.topping ?? 0) - getIngredientCountForType(p, type);
@@ -7833,7 +8238,7 @@ ${lines.join("\n")}`;
     const qtyToBuy = Math.min(qty, remaining);
     const cost = price * qtyToBuy;
 
-    if (stock < qtyToBuy) {
+    if (!unlimitedMarketStock && stock < qtyToBuy) {
       const friendly = displayItemName(itemId);
       return commitState({ content: `Only ${stock} in stock today for **${friendly}**.`, ephemeral: true });
     }
@@ -7852,7 +8257,9 @@ ${lines.join("\n")}`;
 
     p.coins -= cost;
     p.inv_ingredients[itemId] = (p.inv_ingredients[itemId] ?? 0) + qtyToBuy;
-    p.market_stock[itemId] = stock - qtyToBuy;
+    if (!unlimitedMarketStock) {
+      p.market_stock[itemId] = stock - qtyToBuy;
+    }
 
     applyQuestProgress(p, questsContent, userId, { type: "buy", amount: qtyToBuy }, now);
 
@@ -7864,9 +8271,12 @@ ${lines.join("\n")}`;
     });
 
     const capacityNote = qtyToBuy < qty ? `\n${getIcon("pantry")} Pantry capacity limited your purchase to **${qtyToBuy}**.` : "";
+    const subscriptionNote = unlimitedMarketStock
+      ? `\n${getIcon("sparkle")} 24/7 House active: unlimited stock.`
+      : "";
     const buyEmbed = buildMenuEmbed({
       title: `${getIcon("cart")} Purchase Complete`,
-      description: `${getIcon("cart")} Bought **${qtyToBuy}× ${item.name}** for **${cost}c**.${capacityNote}${tutorialSuffix(p)}`,
+      description: `${getIcon("cart")} Bought **${qtyToBuy}× ${item.name}** for **${cost}c**.${capacityNote}${subscriptionNote}${tutorialSuffix(p)}`,
       user: interaction.member ?? interaction.user
     });
     return commitState({
@@ -8239,7 +8649,8 @@ ${lines.join("\n")}`;
     const remaining = availableCount;
     const marketRestockDay = p.market_stock_day ?? s.market_day ?? dayKeyUTC(now2);
     const marketRestockMs = parseYYYYMMDD(marketRestockDay) + (24 * 60 * 60 * 1000);
-    const hasMarketStock = Object.values(p.market_stock ?? {}).some((qty) => Number(qty) > 0);
+    const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
+    const hasMarketStock = unlimitedMarketStock || Object.values(p.market_stock ?? {}).some((qty) => Number(qty) > 0);
     const ordersDayKey = p.orders_day ?? dayKeyUTC(now2);
     const nextOrdersResetMs = parseYYYYMMDD(ordersDayKey) + (24 * 60 * 60 * 1000);
     const nextOrdersResetTs = Math.floor(nextOrdersResetMs / 1000);
@@ -8274,6 +8685,9 @@ ${lines.join("\n")}`;
 
     const tutSuffix = tutorialSuffix(p);
     if (tutSuffix) parts.push("", tutSuffix);
+    if (hasHouse247Perk(p)) {
+      parts.push("", `${getIcon("sparkle")} 24/7 House active: unlimited order capacity and market stock.`);
+    }
 
     const showCancel = acceptedEntries.length > 0;
     const highlightAccept = acceptedEntries.length === 0 && remaining > 0;
@@ -8322,7 +8736,7 @@ ${lines.join("\n")}`;
 
     if (!tokens.length) return commitState({ content: "Pick at least one order to accept.", ephemeral: true });
 
-    const cap = 5;
+    const cap = getOrderAcceptCap(p, nowTs());
     // Ensure orders is a valid object (handle case where it might be an array or null)
     if (!p.orders || typeof p.orders !== 'object' || Array.isArray(p.orders)) {
       p.orders = { accepted: {}, seasonal_served_today: 0, epic_served_today: 0 };
@@ -8419,6 +8833,7 @@ ${lines.join("\n")}`;
 
       const inventoryAvailable = { ...(p.inv_ingredients ?? {}) };
       const stockRemaining = { ...(p.market_stock ?? {}) };
+      const unlimitedMarketStock = hasUnlimitedMarketStock(p, nowTs());
       const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
       const perTypeCap = getIngredientCapacitiesByType(p, combinedEffects);
       const countsByType = getIngredientCountsByType(p);
@@ -8498,7 +8913,7 @@ ${lines.join("\n")}`;
             }
 
             const stock = stockRemaining[itemId] ?? 0;
-            if (stock < missing) {
+            if (!unlimitedMarketStock && stock < missing) {
               blockedByStock = true;
               orderOk = false;
               break;
@@ -8531,7 +8946,9 @@ ${lines.join("\n")}`;
 
         for (const needItem of neededItems) {
           remainingByType[needItem.type] = Math.max(0, (remainingByType[needItem.type] ?? 0) - needItem.qty);
-          stockRemaining[needItem.itemId] = Math.max(0, (stockRemaining[needItem.itemId] ?? 0) - needItem.qty);
+          if (!unlimitedMarketStock) {
+            stockRemaining[needItem.itemId] = Math.max(0, (stockRemaining[needItem.itemId] ?? 0) - needItem.qty);
+          }
           purchasedByItem[needItem.itemId] = (purchasedByItem[needItem.itemId] ?? 0) + needItem.qty;
         }
 
@@ -8549,7 +8966,9 @@ ${lines.join("\n")}`;
         if (!p.market_stock) p.market_stock = {};
         for (const [id, qty] of Object.entries(purchasedByItem)) {
           p.inv_ingredients[id] = (p.inv_ingredients[id] ?? 0) + qty;
-          p.market_stock[id] = (p.market_stock[id] ?? 0) - qty;
+          if (!unlimitedMarketStock) {
+            p.market_stock[id] = (p.market_stock[id] ?? 0) - qty;
+          }
         }
         p.coins = coinsRemaining;
         results.push(`${getIcon("chef")} Prep Chef auto-bought: ${purchasedItems} (Total **${totalAutoCost}c**).`);
@@ -10698,6 +11117,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
         let s = ensureServer(serverId);
         let p2 = ensurePlayer(serverId, userId);
         if (!p2.market_stock) p2.market_stock = {};
+        const unlimitedMarketStock = hasUnlimitedMarketStock(p2, nowTs());
 
         const combinedEffects = calculateCombinedEffects(p2, upgradesContent, staffContent, calculateStaffEffects);
         const perTypeCap = getIngredientCapacitiesByType(p2, combinedEffects);
@@ -10741,7 +11161,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
             continue;
           }
 
-          if (stock < qtyToBuy) {
+          if (!unlimitedMarketStock && stock < qtyToBuy) {
             const friendly = displayItemName(id3);
             return {
               content: `Only ${stock} in stock today for **${friendly}**.`,
@@ -10789,7 +11209,9 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
         p2.coins -= totalCost;
 
         for (const x of buyLines) {
-          p2.market_stock[x.id] = (p2.market_stock[x.id] ?? 0) - x.qty;
+          if (!unlimitedMarketStock) {
+            p2.market_stock[x.id] = (p2.market_stock[x.id] ?? 0) - x.qty;
+          }
         }
 
         const totalBought = buyLines.reduce((sum, entry) => sum + entry.qty, 0);
@@ -10809,7 +11231,7 @@ if (cid.startsWith("noodle:pick:fishing_item_select:")) {
 
         const buyEmbed = buildMenuEmbed({
           title: `${getIcon("cart")} Purchase Complete`,
-          description: `Bought:\n${pretty}\n\nTotal: **${totalCost}c**.${capacityReduced ? `\n${getIcon("pantry")} Pantry capacity limited this purchase.` : ""}${tutorialSuffix(p2)}`,
+          description: `Bought:\n${pretty}\n\nTotal: **${totalCost}c**.${capacityReduced ? `\n${getIcon("pantry")} Pantry capacity limited this purchase.` : ""}${unlimitedMarketStock ? `\n${getIcon("sparkle")} 24/7 House active: stock limit bypassed.` : ""}${tutorialSuffix(p2)}`,
           user: interaction.member ?? interaction.user
         });
         buyEmbed.setFooter({
@@ -11141,6 +11563,20 @@ const noodleCommandData = new SlashCommandBuilder()
   .addSubcommand((sc) => sc.setName("quests_daily").setDescription("Claim your daily reward."))
   .addSubcommand((sc) => sc.setName("quests_claim").setDescription("Claim completed quest rewards."))
   .addSubcommand((sc) => sc.setName("quests_vote").setDescription("View and claim bot-list vote rewards."))
+  .addSubcommand((sc) => sc.setName("takeout").setDescription("View your Take Out Counter status."))
+  .addSubcommand((sc) =>
+    sc
+      .setName("takeout_menu")
+      .setDescription("Set your Take Out Counter menu (comma-separated recipe ids).")
+      .addStringOption((o) =>
+        o
+          .setName("recipes")
+          .setDescription("Comma-separated recipe ids (max 10).")
+          .setRequired(true)
+      )
+  )
+  .addSubcommand((sc) => sc.setName("takeout_open").setDescription("Open a 12-hour takeout shift."))
+  .addSubcommand((sc) => sc.setName("takeout_claim").setDescription("Claim idle takeout earnings."))
   .addSubcommand((sc) =>
     sc
       .setName("buy")

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6117,20 +6117,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const shiftSnapshotOrderCount = snapshot
         .reduce((sum, row) => sum + Math.max(0, Math.floor(Number(row?.total_orders || row?.visible_order_count || 0) || 0)), 0);
 
-      const countByRecipe = new Map();
-      for (const row of snapshot) {
-        const rid = String(row?.recipe_id || "").trim();
-        if (!rid) continue;
-        const count = Math.max(0, Math.floor(Number(row?.visible_order_count) || 0));
-        countByRecipe.set(rid, count);
-      }
-
-      const counterMenuLines = takeout.menu_recipe_ids.length > 0
-        ? takeout.menu_recipe_ids
-          .map((rid) => `• ${displayRecipeName(rid)} — **${countByRecipe.get(rid) ?? 0}** orders`)
-          .join("\n")
-        : "_No menu configured yet._";
-
       const previewNow = active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0
         ? shiftEndsAt + 1000
         : now;
@@ -6154,10 +6140,30 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         Math.floor(Number(previewResult?.snapshotOrderTotal || 0) || 0)
       );
 
+      const nextShiftSnapshot = Array.isArray(previewResult?.snapshot) ? previewResult.snapshot : [];
+      const counterMenuSnapshot = active
+        ? snapshot
+        : (nextShiftSnapshot.length > 0 ? nextShiftSnapshot : snapshot);
+
+      const countByRecipe = new Map();
+      for (const row of counterMenuSnapshot) {
+        const rid = String(row?.recipe_id || "").trim();
+        if (!rid) continue;
+        const rawCount = active ? row?.visible_order_count : (row?.total_orders ?? row?.visible_order_count);
+        const count = Math.max(0, Math.floor(Number(rawCount) || 0));
+        countByRecipe.set(rid, count);
+      }
+
+      const counterMenuLines = takeout.menu_recipe_ids.length > 0
+        ? takeout.menu_recipe_ids
+          .map((rid) => `• ${displayRecipeName(rid)} — **${countByRecipe.get(rid) ?? 0}** orders`)
+          .join("\n")
+        : "_No menu configured yet._";
+
       const statusBits = [];
       if (active && Number.isFinite(shiftEndsAt) && shiftEndsAt > 0) {
         statusBits.push(`${getIcon("time")} **Shift Active** until <t:${Math.floor(shiftEndsAt / 1000)}:R> (<t:${Math.floor(shiftEndsAt / 1000)}:f>)`);
-        statusBits.push(`${getIcon("orders")} Your main order board is resting right now. Cozy up here and serve through the counter while this shift runs.`);
+        statusBits.push(`${getIcon("orders")} Your Shop's Order Board is idle right now. Serve from the Takeout Counter while this shift runs.`);
       } else {
         statusBits.push(`${getIcon("status_pending")} **Shift Inactive**`);
       }
@@ -6171,16 +6177,16 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         statusBits.push(`${getIcon("coins")} Unclaimed idle coins: **${unclaimedIdleCoins}c**`);
       }
       if (shiftOperatingCost > 0) {
-        statusBits.push(`${getIcon("coins")} Fixed shift operating cost paid: **${shiftOperatingCost}c**`);
+        statusBits.push(`${getIcon("coins")} Ingredients cost paid: **${shiftOperatingCost}c**`);
       }
       if (coveredIngredientsCount > 0) {
-        statusBits.push(`${getIcon("basket")} Covered ingredients reserved for idle shift: **${coveredIngredientsCount}** units`);
+        statusBits.push(`${getIcon("basket")} Ingredients reserved for idle shift: **${coveredIngredientsCount}** units`);
       }
       if (shiftSnapshotOrderCount > 0) {
-        statusBits.push(`${getIcon("orders")} Shift snapshot orders: **${shiftSnapshotOrderCount}** total`);
+        statusBits.push(`${getIcon("orders")} Shift orders: **${shiftSnapshotOrderCount}** total`);
       }
       if (active) {
-        statusBits.push(`${getIcon("time")} Processed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
+        statusBits.push(`${getIcon("time")} Completed hours: **${processedHours}/${TAKEOUT_SHIFT_DURATION_HOURS}**`);
         statusBits.push(`${getIcon("time")} Remaining hours: **${remainingHours}**`);
       }
       statusBits.push(`${getIcon("help")} Menu size: **${takeout.menu_recipe_ids.length}** (min ${menuLimits.minRequired}, max ${menuLimits.maxAllowed})`);
@@ -6190,8 +6196,9 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         "Set your counter menu, start a cozy 12-hour shift, and collect idle earnings. While the shift is active, your main **Order Board** is idle and all service happens from **Take Out Counter**.",
         "",
         takeoutCatchup?.processedHours > 0
-          ? `${getIcon("time")} Catch-up processed **${takeoutCatchup.processedHours}h** and accrued **${takeoutCatchup.earned}c** while you were away.`
+          ? `${getIcon("time")} **${takeoutCatchup.processedHours}h** & earned **${takeoutCatchup.earned}c** while you were away.`
           : null,
+        "\u200b",
         statusBits.join("\n"),
         "\n**Counter Menu**",
         counterMenuLines

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -2024,12 +2024,11 @@ function buildTakeoutMenuPickerRows(userId, {
     }));
 
   const safeMax = Math.max(1, Math.min(maxAllowed, options.length));
-  const safeMin = Math.max(1, Math.min(minRequired, safeMax));
 
   const menu = new StringSelectMenuBuilder()
     .setCustomId(`noodle:takeout:menu_select:${userId}:${safePage}`)
     .setPlaceholder("Pick recipes for your takeout menu")
-    .setMinValues(safeMin)
+    .setMinValues(0)
     .setMaxValues(safeMax)
     .addOptions(options);
 
@@ -6945,7 +6944,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const acceptedOrderCount = Object.keys(p.orders?.accepted ?? {}).length;
       if (acceptedOrderCount > 0) {
         return finalize(renderStatus(
-          `${getIcon("warning")} You still have **${acceptedOrderCount}** accepted Shop order${acceptedOrderCount === 1 ? "" : "s"}. Serve or cancel them before opening a takeout shift.`,
+          `${getIcon("warning")} You still have **${acceptedOrderCount}** accepted order${acceptedOrderCount === 1 ? "" : "s"}. Serve or cancel them before opening a takeout shift.`,
           { ephemeral: true }
         ));
       }
@@ -7174,6 +7173,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         rewards.coins = Math.floor(rewards.coins * qualityMult);
         rewards.rep = Math.floor(rewards.rep * qualityMult);
         rewards.sxp = Math.floor(rewards.sxp * qualityMult);
+
+        consumeFailStreakRelief(p);
 
         bowl.qty -= 1;
         if (bowl.qty <= 0) delete p.inv_bowls[bowlEntry?.key ?? selectedRecipeId];
@@ -11841,9 +11842,6 @@ if (cid.startsWith("noodle:takeout:menu_select:")) {
   }
 
   const pageSelectedRecipeIds = (interaction.values ?? []).filter(Boolean);
-  if (!pageSelectedRecipeIds.length) {
-    return componentCommit(interaction, { content: `${getIcon("help")} Pick at least one recipe.`, ephemeral: true });
-  }
 
   const p = ensurePlayer(serverId, interaction.user.id);
   const availableRecipeIds = getValidAvailableRecipeIds(p);

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -2010,7 +2010,7 @@ function noodleTakeoutActionRow(userId, { activeShift = false, disableOpen = fal
 function buildTakeoutMenuPickerRows(userId, {
   availableRecipeIds = [],
   selectedRecipeIds = [],
-  minRequired = 1,
+  minRequired: _minRequired = 1,
   maxAllowed = 1,
   page = 0
 } = {}) {

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6945,7 +6945,7 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       const acceptedOrderCount = Object.keys(p.orders?.accepted ?? {}).length;
       if (acceptedOrderCount > 0) {
         return finalize(renderStatus(
-          `${getIcon("warning")} You still have **${acceptedOrderCount}** accepted main-board order${acceptedOrderCount === 1 ? "" : "s"}. Serve or cancel them before opening a takeout shift.`,
+          `${getIcon("warning")} You still have **${acceptedOrderCount}** accepted Shop order${acceptedOrderCount === 1 ? "" : "s"}. Serve or cancel them before opening a takeout shift.`,
           { ephemeral: true }
         ));
       }

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -165,6 +165,13 @@ export const noodleDevCommand = {
   },
 
   async handleComponent(interaction) {
+    const denyOwnerMismatch = async (message) => {
+      if (interaction.deferred || interaction.replied) {
+        return interaction.followUp({ content: message, ephemeral: true });
+      }
+      return interaction.reply({ content: message, ephemeral: true });
+    };
+
     const customId = String(interaction.customId || "");
     const parts = customId.split(":");
     // Legacy: noodle-dev:dashboard:page:<ownerUserId>:<tabPage>
@@ -178,10 +185,7 @@ export const noodleDevCommand = {
     const page = Number(parts[4] ?? 0);
     const serverPage = mode === "nav" ? Number(parts[5] ?? 0) : 0;
     if (ownerUserId && ownerUserId !== interaction.user.id) {
-      return {
-        content: "That dashboard isn’t for you.",
-        ephemeral: true
-      };
+      return denyOwnerMismatch("That dashboard isn’t for you.");
     }
 
     return runNoodle(interaction, {

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -65,6 +65,55 @@ const noodleDevData = new SlashCommandBuilder()
           .setDescription("Override server ID (defaults to current guild)")
           .setRequired(false)
       )
+  )
+  .addSubcommand((sc) =>
+    sc
+      .setName("subscriptions_toggle")
+      .setDescription("Dev only.")
+      .addUserOption((o) => o.setName("user").setDescription("User to update").setRequired(false))
+      .addStringOption((o) =>
+        o
+          .setName("user_id")
+          .setDescription("User ID (use if the user left the server)")
+          .setRequired(false)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("server_id")
+          .setDescription("Override server ID (defaults to current guild)")
+          .setRequired(false)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("perk")
+          .setDescription("Perk to toggle")
+          .setRequired(true)
+          .addChoices(
+            { name: "24/7 House", value: "house_247" },
+            { name: "Take Out Counter", value: "takeout_counter" },
+            { name: "Both Perks", value: "both" }
+          )
+      )
+      .addBooleanOption((o) =>
+        o
+          .setName("active")
+          .setDescription("Set perk state (true=enable, false=disable)")
+          .setRequired(true)
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName("duration_days")
+          .setDescription("When enabling, perk duration in days (default 30)")
+          .setRequired(false)
+          .setMinValue(1)
+          .setMaxValue(365)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("reason")
+          .setDescription("Optional audit reason")
+          .setRequired(false)
+      )
   );
 
 export const noodleDevCommand = {

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -47,6 +47,24 @@ const noodleDevData = new SlashCommandBuilder()
           .setDescription("Force repair even if global profile score is not lower")
           .setRequired(false)
       )
+  )
+  .addSubcommand((sc) =>
+    sc
+      .setName("subscriptions")
+      .setDescription("Dev only.")
+      .addUserOption((o) => o.setName("user").setDescription("User to inspect").setRequired(false))
+      .addStringOption((o) =>
+        o
+          .setName("user_id")
+          .setDescription("User ID (use if the user left the server)")
+          .setRequired(false)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("server_id")
+          .setDescription("Override server ID (defaults to current guild)")
+          .setRequired(false)
+      )
   );
 
 export const noodleDevCommand = {

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -70,19 +70,6 @@ const noodleDevData = new SlashCommandBuilder()
     sc
       .setName("subscriptions_toggle")
       .setDescription("Dev only.")
-      .addUserOption((o) => o.setName("user").setDescription("User to update").setRequired(false))
-      .addStringOption((o) =>
-        o
-          .setName("user_id")
-          .setDescription("User ID (use if the user left the server)")
-          .setRequired(false)
-      )
-      .addStringOption((o) =>
-        o
-          .setName("server_id")
-          .setDescription("Override server ID (defaults to current guild)")
-          .setRequired(false)
-      )
       .addStringOption((o) =>
         o
           .setName("perk")
@@ -99,6 +86,19 @@ const noodleDevData = new SlashCommandBuilder()
           .setName("active")
           .setDescription("Set perk state (true=enable, false=disable)")
           .setRequired(true)
+      )
+      .addUserOption((o) => o.setName("user").setDescription("User to update").setRequired(false))
+      .addStringOption((o) =>
+        o
+          .setName("user_id")
+          .setDescription("User ID (use if the user left the server)")
+          .setRequired(false)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("server_id")
+          .setDescription("Override server ID (defaults to current guild)")
+          .setRequired(false)
       )
       .addIntegerOption((o) =>
         o

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -167,6 +167,16 @@ export const noodleDevCommand = {
   async handleComponent(interaction) {
     const denyOwnerMismatch = async (message) => {
       if (interaction.deferred || interaction.replied) {
+        try {
+          // Complete deferred component interaction first so the original response does not hang.
+          await interaction.editReply({
+            content: interaction.message?.content ?? " ",
+            embeds: interaction.message?.embeds ?? [],
+            components: interaction.message?.components ?? []
+          });
+        } catch {
+          // Best-effort: if edit fails, still attempt to notify the user.
+        }
         return interaction.followUp({ content: message, ephemeral: true });
       }
       return interaction.reply({ content: message, ephemeral: true });

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -50,6 +50,23 @@ const noodleDevData = new SlashCommandBuilder()
   )
   .addSubcommand((sc) =>
     sc
+      .setName("repair_party")
+      .setDescription("Dev only.")
+      .addStringOption((o) =>
+        o
+          .setName("party_id")
+          .setDescription("Party ID or prefix (e.g. first 8 chars)")
+          .setRequired(true)
+      )
+      .addStringOption((o) =>
+        o
+          .setName("server_id")
+          .setDescription("Override server ID (defaults to current guild)")
+          .setRequired(false)
+      )
+  )
+  .addSubcommand((sc) =>
+    sc
       .setName("subscriptions")
       .setDescription("Dev only.")
       .addUserOption((o) => o.setName("user").setDescription("User to inspect").setRequired(false))
@@ -68,24 +85,48 @@ const noodleDevData = new SlashCommandBuilder()
   )
   .addSubcommand((sc) =>
     sc
-      .setName("subscriptions_toggle")
+      .setName("giveaway_winner")
       .setDescription("Dev only.")
       .addStringOption((o) =>
         o
-          .setName("perk")
-          .setDescription("Perk to toggle")
+          .setName("reward_type")
+          .setDescription("Type of reward to grant")
           .setRequired(true)
+          .addChoices(
+            { name: "Perk", value: "perk" },
+            { name: "Coin Pack", value: "coin_pack" },
+            { name: "Coins", value: "coins" }
+          )
+      )
+      .addStringOption((o) =>
+        o
+          .setName("perk")
+          .setDescription("Perk to grant (required when reward_type=perk)")
+          .setRequired(false)
           .addChoices(
             { name: "24/7 House", value: "house_247" },
             { name: "Take Out Counter", value: "takeout_counter" },
             { name: "Both Perks", value: "both" }
           )
       )
-      .addBooleanOption((o) =>
+      .addStringOption((o) =>
         o
-          .setName("active")
-          .setDescription("Set perk state (true=enable, false=disable)")
-          .setRequired(true)
+          .setName("coin_pack")
+          .setDescription("Coin pack to grant (required when reward_type=coin_pack)")
+          .setRequired(false)
+          .addChoices(
+            { name: "Chef's Coin Crate (10,000c)", value: "coin_pack_099" },
+            { name: "Brothkeeper's Savings (25,000c)", value: "coin_pack_199" },
+            { name: "Greedy Noodle Goblin Hoard (100,000c)", value: "coin_pack_499" }
+          )
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName("coins")
+          .setDescription("Coins to grant (required when reward_type=coins)")
+          .setRequired(false)
+          .setMinValue(1)
+          .setMaxValue(1000000000)
       )
       .addUserOption((o) => o.setName("user").setDescription("User to update").setRequired(false))
       .addStringOption((o) =>
@@ -103,7 +144,7 @@ const noodleDevData = new SlashCommandBuilder()
       .addIntegerOption((o) =>
         o
           .setName("duration_days")
-          .setDescription("When enabling, perk duration in days (default 30)")
+          .setDescription("When rewarding a perk, duration in days (default 30)")
           .setRequired(false)
           .setMinValue(1)
           .setMaxValue(365)

--- a/src/commands/noodleSocial.js
+++ b/src/commands/noodleSocial.js
@@ -1315,7 +1315,7 @@ async function handleParty(interaction) {
         applyOwnerFooter(embed, interaction.member ?? interaction.user);
 
         const replyObj = {
-          content: " ",
+          content: null,
           embeds: [embed],
           components: [partyCreationRow(userId), socialMainMenuRow(userId)]
         };
@@ -2888,7 +2888,7 @@ async function handleComponent(interaction) {
             )
             .addFields({
               name: `${getIcon("idea")} How It Works`,
-              value: "Party members tap **Contribute** to add ingredients. When complete, everyone who helped gets rewarded!",
+              value: "All party members must already know the selected recipe. Party members tap **Contribute** to add ingredients. When complete, everyone who helped gets rewarded!",
               inline: false
             })
             .setColor(theme.colors.success);

--- a/src/commands/noodleSocial.js
+++ b/src/commands/noodleSocial.js
@@ -1315,7 +1315,6 @@ async function handleParty(interaction) {
         applyOwnerFooter(embed, interaction.member ?? interaction.user);
 
         const replyObj = {
-          content: null,
           embeds: [embed],
           components: [partyCreationRow(userId), socialMainMenuRow(userId)]
         };
@@ -3554,7 +3553,6 @@ async function handleComponent(interaction) {
         applyOwnerFooter(embed, interaction.member ?? interaction.user);
 
         return componentCommit(interaction, {
-          content: null,
           embeds: [embed],
           components: [socialMainMenuRow(userId)]
         });

--- a/src/commands/noodleSocial.js
+++ b/src/commands/noodleSocial.js
@@ -3545,9 +3545,17 @@ async function handleComponent(interaction) {
 
       try {
         leaveParty(db, currentParty.party_id, userId);
+
+        const embed = new EmbedBuilder()
+          .setTitle(`${getIcon("party")} Party`)
+          .setDescription(`${getIcon("status_complete")} You've left the party **${currentParty.party_name}**.`)
+          .setColor(theme.colors.info);
+
+        applyOwnerFooter(embed, interaction.member ?? interaction.user);
+
         return componentCommit(interaction, {
-          content: `${getIcon("status_complete")} You've left the party **${currentParty.party_name}**.`,
-          embeds: [],
+          content: null,
+          embeds: [embed],
           components: [socialMainMenuRow(userId)]
         });
       } catch (err) {

--- a/src/commands/noodleSocial.js
+++ b/src/commands/noodleSocial.js
@@ -1216,7 +1216,7 @@ async function handleParty(interaction) {
       }
 
       // Check if already in a party
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (currentParty) {
         return { ok: false, error: `${getIcon("error")} You're already in party **${currentParty.party_name}**. Leave it first to create a new one.` };
       }
@@ -1271,7 +1271,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "leave") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1302,7 +1302,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "info") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1335,7 +1335,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "rename") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1364,7 +1364,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "transfer_leader") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1430,7 +1430,7 @@ async function handleParty(interaction) {
     }
 
     if (action === "kick") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return { ok: false, error: `${getIcon("error")} You're not in any party.` };
       }
@@ -1792,7 +1792,7 @@ async function handleStats(interaction) {
     const player = ensurePlayer(serverId, userId);
     touchLastKitchen(player, serverId, channelId, userId);
     const tipStats = getUserTipStats(db, serverId, userId);
-    const party = getUserActiveParty(db, userId);
+    const party = getUserActiveParty(db, userId, serverId);
     const blessing = getActiveBlessing(player);
 
     const embed = new EmbedBuilder()
@@ -2115,7 +2115,7 @@ async function handleComponent(interaction) {
             }
             noteRecentSocialUser(serverId, targetId);
 
-            const party = getUserActiveParty(db, userId);
+            const party = getUserActiveParty(db, userId, serverId);
             const isLeader = party?.leader_user_id === userId;
             const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
             const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2195,7 +2195,7 @@ async function handleComponent(interaction) {
             }
             noteRecentSocialUser(serverId, targetId);
 
-            const party = getUserActiveParty(db, userId);
+            const party = getUserActiveParty(db, userId, serverId);
             const isLeader = party?.leader_user_id === userId;
             const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
             const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2287,7 +2287,7 @@ async function handleComponent(interaction) {
             };
             const blessingName = blessingNames[blessingType] || blessingType;
 
-            const party = getUserActiveParty(db, userId);
+            const party = getUserActiveParty(db, userId, serverId);
             const isLeader = party?.leader_user_id === userId;
             const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
             const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2379,7 +2379,7 @@ async function handleComponent(interaction) {
       }
       const lockedResult = await withLock(db, `lock:user:${userId}`, ownerLock, 8000, async () => {
         try {
-          const party = getUserActiveParty(db, userId);
+          const party = getUserActiveParty(db, userId, serverId);
           if (!party) {
             return { ok: false, payload: { content: `${getIcon("error")} You're not in a party.`, ephemeral: true } };
           }
@@ -2628,7 +2628,7 @@ async function handleComponent(interaction) {
               };
               const blessingName = blessingNames[blessingType] || blessingType;
 
-              const party = getUserActiveParty(db, userId);
+              const party = getUserActiveParty(db, userId, serverId);
               const isLeader = party?.leader_user_id === userId;
               const existingOrder = party ? getActiveSharedOrderByParty(db, party.party_id) : null;
               const partyRow = party ? partyActionRow(userId, true, isLeader, !!existingOrder) : partyCreationRow(userId);
@@ -2672,7 +2672,7 @@ async function handleComponent(interaction) {
         const ownerLock = `discord:${interaction.id}`;
         const lockedResult = await withLock(db, `lock:user:${userId}`, ownerLock, 8000, async () => {
           try {
-            const currentParty = getUserActiveParty(db, userId);
+            const currentParty = getUserActiveParty(db, userId, serverId);
             if (!currentParty) {
               return { ok: false, payload: { content: `${getIcon("error")} You're not in any party.`, ephemeral: true } };
             }
@@ -2724,7 +2724,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_recipe") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -2806,7 +2806,7 @@ async function handleComponent(interaction) {
 
       const lockedResult = await withLock(db, `lock:user:${userId}`, ownerLock, 8000, async () => {
         try {
-          const party = getUserActiveParty(db, userId);
+          const party = getUserActiveParty(db, userId, serverId);
           if (!party) {
             return { ok: false, payload: { content: `${getIcon("error")} You're not in a party.`, ephemeral: true } };
           }
@@ -2858,7 +2858,7 @@ async function handleComponent(interaction) {
             )
             .addFields({
               name: `${getIcon("idea")} How It Works`,
-              value: "Party members tap **Contribute** to add ingredients. When complete, everyone who helped gets rewarded!",
+              value: "You can only start shared orders with recipes known by your whole party. Party members tap **Contribute** to add ingredients. When complete, everyone who helped gets rewarded!",
               inline: false
             })
             .setColor(theme.colors.success);
@@ -2888,7 +2888,7 @@ async function handleComponent(interaction) {
         return componentCommit(interaction, { content: `${getIcon("error")} Invalid selection.`, ephemeral: true });
       }
 
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, { content: `${getIcon("error")} You're not in a party.`, ephemeral: true });
       }
@@ -2971,7 +2971,7 @@ async function handleComponent(interaction) {
       if (!db) {
         return componentCommit(interaction, { content: "Database unavailable in this environment.", ephemeral: true });
       }
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         const embed = new EmbedBuilder()
           .setTitle(`${getIcon("party")} Party`)
@@ -3032,7 +3032,7 @@ async function handleComponent(interaction) {
       const player = ensurePlayer(serverId, userId);
       const newsAvailable = hasUnreadNewsUpdate(player, newsContent);
       const tipStats = getUserTipStats(db, serverId, userId);
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       const blessing = getActiveBlessing(player);
 
       const embed = new EmbedBuilder()
@@ -3150,7 +3150,7 @@ async function handleComponent(interaction) {
     if (action === "profile") {
       const player = ensurePlayer(serverId, userId);
       const server = ensureServer(serverId);
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       const questsAvailable = hasDailyRewardAvailable(player, nowTs())
         || Object.values(player?.quests?.active ?? {}).some((quest) => quest?.completed_at && !quest?.claimed_at);
       const specializationsAvailable = hasNewShopLevelSpecialization(player, specializationsContent);
@@ -3245,7 +3245,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3328,7 +3328,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_refresh") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3407,7 +3407,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_create") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3463,7 +3463,7 @@ async function handleComponent(interaction) {
 
       const createEmbed = new EmbedBuilder()
         .setTitle(`${getIcon("serve")} Create Shared Order`)
-        .setDescription("Step 1: Pick a recipe that your party members know.")
+        .setDescription("Step 1: Pick a recipe known by your whole party.")
         .setColor(theme.colors.info);
 
       applyOwnerFooter(createEmbed, interaction.member ?? interaction.user);
@@ -3475,7 +3475,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_info") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in any party.`,
@@ -3505,7 +3505,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_leave") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in any party.`,
@@ -3529,7 +3529,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_invite") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (!currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in any party.`,
@@ -3559,7 +3559,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_contribute") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3651,7 +3651,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_complete") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3733,7 +3733,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_cancel") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3797,7 +3797,7 @@ async function handleComponent(interaction) {
       }
 
       const targetMessageId = interaction.message?.id ?? null;
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3946,7 +3946,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_cancel_complete") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -3977,7 +3977,7 @@ async function handleComponent(interaction) {
       if (!db) {
         return componentCommit(interaction, { content: "Database unavailable in this environment.", ephemeral: true });
       }
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -4049,7 +4049,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "shared_order_abort_cancel") {
-      const party = getUserActiveParty(db, userId);
+      const party = getUserActiveParty(db, userId, serverId);
       if (!party) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're not in a party.`,
@@ -4087,7 +4087,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_create") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're already in party **${currentParty.party_name}**. Leave it first to create a new one.`,
@@ -4130,7 +4130,7 @@ async function handleComponent(interaction) {
     }
 
     if (action === "party_join") {
-      const currentParty = getUserActiveParty(db, userId);
+      const currentParty = getUserActiveParty(db, userId, serverId);
       if (currentParty) {
         return componentCommit(interaction, {
           content: `${getIcon("error")} You're already in party **${currentParty.party_name}**. Leave it first to join another.`,

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,6 +41,9 @@ export const DISCOVERY_SCROLL_CHANCE_BASE = {
   quest_complete: 0.01
 };
 
+// Safety net for long dry streaks: force a clue after this many no-drop serves.
+export const DISCOVERY_PITY_NO_DROP_SERVES = 40;
+
 export const CLUES_TO_UNLOCK_RECIPE = 3;
 export const CLUE_DUPLICATE_COINS = 25;
 export const CLUE_DUPLICATE_WHILE_UNDISCOVERED_CHANCE = 0.10;

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -585,35 +585,39 @@ export function recordStorePurchaseEvent(
     externalEventId,
     userId,
     serverId = null,
-    specId,
+    purchaseId,
     status = "granted",
     purchasedAt = nowTs()
   }
 ) {
-  if (!db || !source || !externalEventId || !userId || !specId) return false;
+  if (!db || !source || !externalEventId || !userId || !purchaseId) return false;
   const res = measureDbWrite(() => prepareCached(
     db,
+    // Legacy column name `spec_id` stores generic store purchase ids (specializations + coin packs).
     "INSERT OR IGNORE INTO store_purchase_events(source, external_event_id, user_id, server_id, spec_id, status, purchased_at) VALUES (?,?,?,?,?,?,?)"
   ).run(
     String(source),
     String(externalEventId),
     String(userId),
     serverId ? String(serverId) : null,
-    String(specId),
+    String(purchaseId),
     String(status || "granted"),
     Number.isFinite(Number(purchasedAt)) ? Number(purchasedAt) : nowTs()
   ));
   return Number(res?.changes ?? 0) > 0;
 }
 
-export function getAllTimeSpecializationPurchaseCount(db, specId) {
-  if (!db || !specId) return 0;
+export function getAllTimeStorePurchaseCount(db, purchaseId) {
+  if (!db || !purchaseId) return 0;
   const row = measureDbRead(() => prepareCached(
     db,
     "SELECT COUNT(*) AS cnt FROM store_purchase_events WHERE spec_id=? AND status='granted'"
-  ).get(String(specId)));
+  ).get(String(purchaseId)));
   return Number(row?.cnt ?? 0);
 }
+
+// Backwards-compatible aliases for older call sites.
+export const getAllTimeSpecializationPurchaseCount = getAllTimeStorePurchaseCount;
 
 export function recordRecentSocialInteraction(db, serverId, userId, seenAt = nowTs()) {
   if (!db || !serverId || !userId) return false;

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -5,6 +5,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { nowTs } from "../util/time.js";
+import { ORDER_ACCEPT_CAP_HOUSE_247 } from "../game/subscriptions.js";
 import { recordDbRead, recordDbWrite } from "../infra/perfMetrics.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -470,7 +471,7 @@ function prunePlayerBeforePersist(player) {
 
     // Safety cap: keep the most recent accepted orders.
     // 24/7 House expands active order capacity, so this must be comfortably higher than base mode.
-    const ACCEPTED_CAP = 500;
+    const ACCEPTED_CAP = ORDER_ACCEPT_CAP_HOUSE_247;
     const acceptedEntries = Object.entries(orders.accepted);
     if (acceptedEntries.length > ACCEPTED_CAP) {
       const sorted = acceptedEntries.sort((a, b) => {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -468,8 +468,9 @@ function prunePlayerBeforePersist(player) {
       }
     }
 
-    // Safety cap: keep the most recent accepted orders (should normally stay under 5).
-    const ACCEPTED_CAP = 10;
+    // Safety cap: keep the most recent accepted orders.
+    // 24/7 House expands active order capacity, so this must be comfortably higher than base mode.
+    const ACCEPTED_CAP = 500;
     const acceptedEntries = Object.entries(orders.accepted);
     if (acceptedEntries.length > ACCEPTED_CAP) {
       const sorted = acceptedEntries.sort((a, b) => {

--- a/src/game/discovery.js
+++ b/src/game/discovery.js
@@ -2,6 +2,7 @@ import {
   DISCOVERY_HOOKS, 
   DISCOVERY_CHANCE_BASE, 
   DISCOVERY_SCROLL_CHANCE_BASE,
+  DISCOVERY_PITY_NO_DROP_SERVES,
   CLUES_TO_UNLOCK_RECIPE,
   CLUE_DUPLICATE_COINS,
   CLUE_DUPLICATE_WHILE_UNDISCOVERED_CHANCE,
@@ -124,6 +125,8 @@ export function rollRecipeDiscovery({ player, content, npcArchetype, tier, rng, 
   if (!DISCOVERY_HOOKS.on_serve) return [];
 
   const discoveries = [];
+  const pityThreshold = Math.max(1, Math.floor(Number(DISCOVERY_PITY_NO_DROP_SERVES) || 40));
+  const currentNoDropStreak = Math.max(0, Math.floor(Number(player?.discovery?.no_drop_serve_streak || 0) || 0));
   let clueChance = DISCOVERY_CHANCE_BASE.serve;
   let scrollChance = DISCOVERY_SCROLL_CHANCE_BASE.serve;
   const dropRateMult = 1;
@@ -161,10 +164,8 @@ export function rollRecipeDiscovery({ player, content, npcArchetype, tier, rng, 
     }
   }
 
-  if (discoveries.length > 0) return discoveries;
-
   // Moonlit Spirit: extra independent 1% scroll chance on Epic tier
-  if (npcArchetype === "moonlit_spirit" && tier === "epic") {
+  if (!discoveries.length && npcArchetype === "moonlit_spirit" && tier === "epic") {
     const roll = rng();
     if (roll < 0.01) {
       const scroll = rollScroll(player, content, rng, activeSeason, activeEventId);
@@ -172,22 +173,50 @@ export function rollRecipeDiscovery({ player, content, npcArchetype, tier, rng, 
     }
   }
 
-  if (discoveries.length > 0) return discoveries;
-
   // Base roll: only one drop (clue OR scroll)
-  const totalChance = clueChance + scrollChance;
-  const dropRoll = rng();
-  if (dropRoll < totalChance) {
-    const pick = rng();
-    if (pick < (clueChance / totalChance)) {
-      const clue = rollClue(player, content, rng, activeSeason, activeEventId);
-      if (clue) {
-        discoveries.push(clue);
+  if (!discoveries.length) {
+    const totalChance = clueChance + scrollChance;
+    const dropRoll = rng();
+    if (dropRoll < totalChance) {
+      const pick = rng();
+      if (pick < (clueChance / totalChance)) {
+        const clue = rollClue(player, content, rng, activeSeason, activeEventId);
+        if (clue) {
+          discoveries.push(clue);
+        }
+      } else {
+        const scroll = rollScroll(player, content, rng, activeSeason, activeEventId);
+        if (scroll) {
+          discoveries.push(scroll);
+        }
+      }
+    }
+  }
+
+  // Pity safety net: force a clue after a long no-drop streak.
+  if (!discoveries.length) {
+    const nextNoDropStreak = currentNoDropStreak + 1;
+    if (nextNoDropStreak >= pityThreshold) {
+      const pityClue = rollClue(player, content, rng, activeSeason, activeEventId);
+      if (pityClue) {
+        pityClue.pityGranted = true;
+        discoveries.push(pityClue);
+      } else {
+        player.discovery = player.discovery || {};
+        player.discovery.no_drop_serve_streak = nextNoDropStreak;
       }
     } else {
-      const scroll = rollScroll(player, content, rng, activeSeason, activeEventId);
-      if (scroll) {
-        discoveries.push(scroll);
+      player.discovery = player.discovery || {};
+      player.discovery.no_drop_serve_streak = nextNoDropStreak;
+    }
+  }
+
+  if (discoveries.length > 0) {
+    player.discovery = player.discovery || {};
+    player.discovery.no_drop_serve_streak = 0;
+    for (const d of discoveries) {
+      if (d?.pityGranted) {
+        d.pityNoDropStreak = currentNoDropStreak + 1;
       }
     }
   }
@@ -368,7 +397,7 @@ export function applyDiscovery(player, discovery, content, rng = Math.random, op
         unlockedRecipeId: discovery.recipeId,
         unlockedRecipeName: discovery.recipeName,
         reward: null,
-        message: `${getIcon("search")}${getIcon("sparkle")} Collected ${CLUES_TO_UNLOCK_RECIPE} clues - learned **${discovery.recipeName}**!${ingredientMsg}${badgeLine ? `\n${badgeLine}` : ""}`
+        message: `${discovery.pityGranted ? `${getIcon("rescue")} Pity clue granted!\n` : ""}${getIcon("search")}${getIcon("sparkle")} Collected ${CLUES_TO_UNLOCK_RECIPE} clues - learned **${discovery.recipeName}**!${ingredientMsg}${badgeLine ? `\n${badgeLine}` : ""}`
       };
     }
     
@@ -378,7 +407,7 @@ export function applyDiscovery(player, discovery, content, rng = Math.random, op
       isDuplicate: false,
       recipeUnlocked: false,
       reward: null,
-      message: `${getIcon("search")} Clue ${clueCount}/${CLUES_TO_UNLOCK_RECIPE} for **${discovery.recipeName}** (${remaining} more)${ingredientMsg}`
+      message: `${discovery.pityGranted ? `${getIcon("rescue")} Pity clue granted! ` : ""}${getIcon("search")} Clue ${clueCount}/${CLUES_TO_UNLOCK_RECIPE} for **${discovery.recipeName}** (${remaining} more)${ingredientMsg}`
     };
   }
   

--- a/src/game/player.js
+++ b/src/game/player.js
@@ -1,5 +1,7 @@
 import { STARTER_PROFILE, DATA_SCHEMA_VERSION, TUTORIAL_QUESTS } from "../constants.js";
 import { nowTs } from "../util/time.js";
+import { createDefaultSubscriptionState } from "./subscriptions.js";
+import { createDefaultTakeoutState } from "./takeout.js";
 
 export function newPlayerProfile(userId) {
   return {
@@ -82,6 +84,10 @@ export function newPlayerProfile(userId) {
       active_blessing: null,
       last_blessing_at: null
     },
+
+    subscriptions: createDefaultSubscriptionState(),
+
+    takeout: createDefaultTakeoutState(),
 
     notifications: {
       pending_pantry_messages: [],

--- a/src/game/social.js
+++ b/src/game/social.js
@@ -305,6 +305,98 @@ export function getParty(db, partyId) {
 }
 
 /**
+ * Repair party integrity for a party id (or id prefix) in a server.
+ * Fixes:
+ * 1) Leader is not an active member.
+ * 2) Party status and active-member rows are inconsistent.
+ */
+export function repairPartyRecord(db, partyIdPrefix, serverId = null) {
+  const normalizedPrefix = String(partyIdPrefix ?? "").trim();
+  if (!normalizedPrefix) {
+    throw new Error("Party ID is required");
+  }
+
+  const lookupSql = serverId
+    ? "SELECT * FROM guild_parties WHERE party_id LIKE ? AND server_id = ? ORDER BY created_at DESC"
+    : "SELECT * FROM guild_parties WHERE party_id LIKE ? ORDER BY created_at DESC";
+  const matches = serverId
+    ? db.prepare(lookupSql).all(`${normalizedPrefix}%`, serverId)
+    : db.prepare(lookupSql).all(`${normalizedPrefix}%`);
+
+  if (!matches.length) {
+    throw new Error("Party not found");
+  }
+  if (matches.length > 1) {
+    throw new Error("Party ID prefix is ambiguous");
+  }
+
+  const now = nowTs();
+  const initial = matches[0];
+
+  const repairResult = db.transaction(() => {
+    let party = db.prepare("SELECT * FROM guild_parties WHERE party_id = ?").get(initial.party_id);
+    const members = db.prepare(
+      "SELECT user_id, joined_at FROM party_members WHERE party_id = ? AND left_at IS NULL ORDER BY joined_at, user_id"
+    ).all(initial.party_id);
+
+    const updates = [];
+    const activeMemberIds = new Set(members.map((m) => m.user_id));
+
+    const statusBefore = party.status;
+    const leaderBefore = party.leader_user_id;
+
+    // Keep status aligned with whether active member rows exist.
+    if (party.status === "active" && members.length === 0) {
+      db.prepare("UPDATE guild_parties SET status = 'disbanded', disbanded_at = COALESCE(disbanded_at, ?) WHERE party_id = ?")
+        .run(now, party.party_id);
+      updates.push("status:active_to_disbanded");
+      party = { ...party, status: "disbanded", disbanded_at: party.disbanded_at ?? now };
+    } else if (party.status !== "active" && members.length > 0) {
+      db.prepare("UPDATE guild_parties SET status = 'active', disbanded_at = NULL WHERE party_id = ?")
+        .run(party.party_id);
+      updates.push("status:non_active_to_active");
+      party = { ...party, status: "active", disbanded_at: null };
+    }
+
+    // Clean disbanded_at for active parties and ensure it exists for inactive ones.
+    if (party.status === "active" && party.disbanded_at != null) {
+      db.prepare("UPDATE guild_parties SET disbanded_at = NULL WHERE party_id = ?")
+        .run(party.party_id);
+      updates.push("disbanded_at:cleared_for_active");
+      party = { ...party, disbanded_at: null };
+    } else if (party.status !== "active" && party.disbanded_at == null) {
+      db.prepare("UPDATE guild_parties SET disbanded_at = ? WHERE party_id = ?")
+        .run(now, party.party_id);
+      updates.push("disbanded_at:set_for_inactive");
+      party = { ...party, disbanded_at: now };
+    }
+
+    // For active parties, leader must be an active member.
+    if (party.status === "active" && members.length > 0 && !activeMemberIds.has(party.leader_user_id)) {
+      const newLeaderId = members[0].user_id;
+      db.prepare("UPDATE guild_parties SET leader_user_id = ? WHERE party_id = ?")
+        .run(newLeaderId, party.party_id);
+      updates.push("leader:reassigned_to_active_member");
+      party = { ...party, leader_user_id: newLeaderId };
+    }
+
+    return {
+      partyId: party.party_id,
+      serverId: party.server_id,
+      repaired: updates.length > 0,
+      changes: updates,
+      statusBefore,
+      statusAfter: party.status,
+      leaderBefore,
+      leaderAfter: party.leader_user_id,
+      activeMemberCount: members.length
+    };
+  })();
+
+  return repairResult;
+}
+
+/**
  * Get user's active party
  */
 export function getUserActiveParty(db, userId, serverId = null) {

--- a/src/game/storeCoinPacks.js
+++ b/src/game/storeCoinPacks.js
@@ -1,0 +1,130 @@
+export const STORE_COIN_PACKS = Object.freeze({
+  coin_pack_099: Object.freeze({
+    id: "coin_pack_099",
+    priceUsd: 0.99,
+    priceLabel: "$0.99",
+    coins: 10_000
+  }),
+  coin_pack_199: Object.freeze({
+    id: "coin_pack_199",
+    priceUsd: 1.99,
+    priceLabel: "$1.99",
+    coins: 25_000
+  }),
+  coin_pack_499: Object.freeze({
+    id: "coin_pack_499",
+    priceUsd: 4.99,
+    priceLabel: "$4.99",
+    coins: 100_000
+  })
+});
+
+const DEFAULT_COIN_PACK_SKU_MAP = Object.freeze({
+  // Chef's Coin Crate - 10,000c
+  "1511191985644507336": "coin_pack_099",
+  // Brothkeeper's Savings - 25,000c
+  "1511192707119321109": "coin_pack_199",
+  // Greedy Noodle Goblin Hoard - 100,000c
+  "1511192852288376884": "coin_pack_499"
+});
+
+const VALID_COIN_PACK_IDS = new Set(Object.keys(STORE_COIN_PACKS));
+
+function parseCoinPackMap(rawValue) {
+  const raw = String(rawValue || "").trim();
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([externalId, coinPackId]) => [String(externalId), String(coinPackId).trim().toLowerCase()])
+        .filter(([, coinPackId]) => VALID_COIN_PACK_IDS.has(coinPackId))
+    );
+  } catch {
+    const pairs = raw.split(",").map((entry) => entry.trim()).filter(Boolean);
+    const mapped = {};
+    for (const pair of pairs) {
+      const [externalId, coinPackIdRaw] = pair.split(":").map((part) => String(part || "").trim());
+      const coinPackId = coinPackIdRaw.toLowerCase();
+      if (!externalId || !VALID_COIN_PACK_IDS.has(coinPackId)) continue;
+      mapped[externalId] = coinPackId;
+    }
+    return mapped;
+  }
+}
+
+const ENV_COIN_PACK_SKU_MAP = parseCoinPackMap(process.env.NOODLE_COIN_PACK_SKU_MAP);
+const ENV_COIN_PACK_PRODUCT_MAP = parseCoinPackMap(process.env.NOODLE_COIN_PACK_PRODUCT_MAP);
+
+export function getStoreCoinPack(coinPackId) {
+  if (!coinPackId) return null;
+  const packId = String(coinPackId).trim().toLowerCase();
+  return STORE_COIN_PACKS[packId] ?? null;
+}
+
+export function resolveStoreCoinPackIdFromSku(skuId) {
+  if (!skuId) return null;
+  const id = String(skuId);
+  return ENV_COIN_PACK_SKU_MAP[id] ?? DEFAULT_COIN_PACK_SKU_MAP[id] ?? null;
+}
+
+export function resolveStoreCoinPackIdFromProduct(productId) {
+  if (!productId) return null;
+  return ENV_COIN_PACK_PRODUCT_MAP[String(productId)] ?? null;
+}
+
+export function resolveStoreCoinPackIdFromMetadata(metadata = {}) {
+  const directCandidates = [
+    metadata?.coin_pack_id,
+    metadata?.coin_pack,
+    metadata?.coin_pack_key,
+    metadata?.pack_id
+  ];
+  for (const candidate of directCandidates) {
+    const pack = getStoreCoinPack(candidate);
+    if (pack) return pack.id;
+  }
+
+  const mappedCandidates = [
+    metadata?.product_id,
+    metadata?.spec_id,
+    metadata?.sku_id,
+    metadata?.sku,
+    metadata?.item_id
+  ];
+  for (const candidate of mappedCandidates) {
+    const mapped = resolveStoreCoinPackIdFromProduct(candidate);
+    if (mapped) return mapped;
+  }
+
+  return null;
+}
+
+export function grantStoreCoinPack({ player, coinPackId } = {}) {
+  if (!player || typeof player !== "object") {
+    return { ok: false, reason: "Missing player." };
+  }
+
+  const pack = getStoreCoinPack(coinPackId);
+  if (!pack) {
+    return { ok: false, reason: "Coin pack not found." };
+  }
+
+  const coinsToGrant = Math.max(0, Math.floor(Number(pack.coins || 0) || 0));
+  if (coinsToGrant <= 0) {
+    return { ok: false, reason: "Coin pack is invalid." };
+  }
+
+  player.coins = (Number(player.coins) || 0) + coinsToGrant;
+  if (!player.lifetime || typeof player.lifetime !== "object") player.lifetime = {};
+  player.lifetime.coins_earned = (Number(player.lifetime.coins_earned) || 0) + coinsToGrant;
+
+  return {
+    ok: true,
+    coinPackId: pack.id,
+    coinsGranted: coinsToGrant,
+    pack
+  };
+}

--- a/src/game/storeCoinPacks.js
+++ b/src/game/storeCoinPacks.js
@@ -87,11 +87,18 @@ export function resolveStoreCoinPackIdFromMetadata(metadata = {}) {
     if (pack) return pack.id;
   }
 
+  const skuCandidates = [
+    metadata?.sku_id,
+    metadata?.sku
+  ];
+  for (const candidate of skuCandidates) {
+    const mapped = resolveStoreCoinPackIdFromSku(candidate);
+    if (mapped) return mapped;
+  }
+
   const mappedCandidates = [
     metadata?.product_id,
     metadata?.spec_id,
-    metadata?.sku_id,
-    metadata?.sku,
     metadata?.item_id
   ];
   for (const candidate of mappedCandidates) {

--- a/src/game/storeCoinPacks.js
+++ b/src/game/storeCoinPacks.js
@@ -80,7 +80,10 @@ export function resolveStoreCoinPackIdFromMetadata(metadata = {}) {
     metadata?.coin_pack_id,
     metadata?.coin_pack,
     metadata?.coin_pack_key,
-    metadata?.pack_id
+    metadata?.pack_id,
+    metadata?.product_id,
+    metadata?.spec_id,
+    metadata?.item_id
   ];
   for (const candidate of directCandidates) {
     const pack = getStoreCoinPack(candidate);

--- a/src/game/subscriptions.js
+++ b/src/game/subscriptions.js
@@ -3,11 +3,13 @@ export const SUBSCRIPTION_PERKS = Object.freeze({
   TAKEOUT_COUNTER: "takeout_counter"
 });
 
-export const SUBSCRIPTION_MONTHLY_COIN_GRANT = 25_000;
+export const SUBSCRIPTION_MONTHLY_COIN_GRANT = 50_000;
 export const ORDER_ACCEPT_CAP_BASE = 5;
 export const ORDER_ACCEPT_CAP_HOUSE_247 = 500;
+export const HOUSE_247_VOTE_DURATION_MS = 12 * 60 * 60 * 1000;
 
 const KNOWN_PERKS = new Set(Object.values(SUBSCRIPTION_PERKS));
+const PAID_SUBSCRIPTION_PERKS = new Set([SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]);
 
 function defaultPerkState() {
   return {
@@ -42,7 +44,7 @@ function parseSkuMap(rawValue) {
     return Object.fromEntries(
       Object.entries(parsed)
         .map(([sku, perk]) => [String(sku), String(perk).trim().toLowerCase()])
-        .filter(([, perk]) => KNOWN_PERKS.has(perk))
+        .filter(([, perk]) => PAID_SUBSCRIPTION_PERKS.has(perk))
     );
   } catch {
     const pairs = raw.split(",").map((entry) => entry.trim()).filter(Boolean);
@@ -51,7 +53,7 @@ function parseSkuMap(rawValue) {
       const [sku, perk] = pair.split(":").map((part) => String(part || "").trim());
       if (!sku || !perk) continue;
       const perkId = perk.toLowerCase();
-      if (!KNOWN_PERKS.has(perkId)) continue;
+      if (!PAID_SUBSCRIPTION_PERKS.has(perkId)) continue;
       mapped[sku] = perkId;
     }
     return mapped;
@@ -63,6 +65,50 @@ const ENV_SKU_MAP = parseSkuMap(process.env.NOODLE_SUBSCRIPTION_SKU_MAP);
 export function resolveSubscriptionPerkId(skuId) {
   if (!skuId) return null;
   return ENV_SKU_MAP[String(skuId)] ?? null;
+}
+
+function ensureVoteRewardState(player) {
+  if (!player || typeof player !== "object") return null;
+  if (!player.vote_rewards || typeof player.vote_rewards !== "object" || Array.isArray(player.vote_rewards)) {
+    player.vote_rewards = {
+      pending_claims: 0,
+      last_vote_at: null,
+      last_claim_at: null,
+      last_webhook_at: null,
+      sources: {},
+      house_247_expires_at: null
+    };
+  }
+  return player.vote_rewards;
+}
+
+export function getHouse247VoteExpiry(player) {
+  const voteRewards = ensureVoteRewardState(player);
+  const expiresAt = Number(voteRewards?.house_247_expires_at || 0);
+  return Number.isFinite(expiresAt) && expiresAt > 0 ? Math.floor(expiresAt) : null;
+}
+
+export function hasHouse247VoteAccess(player, now = Date.now()) {
+  const expiresAt = getHouse247VoteExpiry(player);
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0) return false;
+  return Number(now) < expiresAt;
+}
+
+export function grantHouse247VoteAccess(player, {
+  now = Date.now(),
+  durationMs = HOUSE_247_VOTE_DURATION_MS
+} = {}) {
+  const voteRewards = ensureVoteRewardState(player);
+  const duration = Math.max(0, Math.floor(Number(durationMs) || 0));
+  if (duration <= 0) return getHouse247VoteExpiry(player);
+
+  const currentExpiry = Number(voteRewards?.house_247_expires_at || 0);
+  const startAt = Number.isFinite(currentExpiry) && currentExpiry > Number(now)
+    ? currentExpiry
+    : Number(now);
+  const nextExpiry = Math.floor(startAt + duration);
+  voteRewards.house_247_expires_at = nextExpiry;
+  return nextExpiry;
 }
 
 function normalizeTimestamp(value) {
@@ -142,11 +188,11 @@ export function hasActivePerk(player, perkId, now = Date.now()) {
 }
 
 export function hasUnlimitedMarketStock(player, now = Date.now()) {
-  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now);
+  return hasHouse247VoteAccess(player, now);
 }
 
 export function getOrderAcceptCap(player, now = Date.now()) {
-  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now)
+  return hasHouse247VoteAccess(player, now)
     ? ORDER_ACCEPT_CAP_HOUSE_247
     : ORDER_ACCEPT_CAP_BASE;
 }

--- a/src/game/subscriptions.js
+++ b/src/game/subscriptions.js
@@ -183,9 +183,13 @@ export function hasActivePerk(player, perkId, now = Date.now()) {
   const perkState = subscriptions.perks[perkKey];
   if (!perkState?.active) return false;
 
+  const nowTs = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  const periodStartAt = normalizeTimestamp(perkState.period_start_at);
+  if (Number.isFinite(periodStartAt) && nowTs < periodStartAt) return false;
+
   const periodEndAt = normalizeTimestamp(perkState.period_end_at);
   if (!Number.isFinite(periodEndAt)) return true;
-  return now < periodEndAt;
+  return nowTs < periodEndAt;
 }
 
 export function hasUnlimitedMarketStock(player, now = Date.now()) {
@@ -283,9 +287,20 @@ export function applyMonthlySubscriptionCoinGrant(player, {
     return { ok: false, reason: "invalid_grant_amount", granted: false, amount: 0 };
   }
 
+  const billingPeriodKey = resolveSubscriptionBillingPeriodKey({ periodStartAt, periodEndAt, now });
+
+  if (!hasActivePerk(player, perkKey, now)) {
+    return {
+      ok: true,
+      granted: false,
+      amount: 0,
+      perkId: perkKey,
+      billingPeriodKey
+    };
+  }
+
   const subscriptions = ensureSubscriptionState(player);
   const perkState = subscriptions.perks[perkKey];
-  const billingPeriodKey = resolveSubscriptionBillingPeriodKey({ periodStartAt, periodEndAt, now });
 
   if (String(perkState.last_coin_grant_period || "") === billingPeriodKey) {
     return {

--- a/src/game/subscriptions.js
+++ b/src/game/subscriptions.js
@@ -10,6 +10,7 @@ export const HOUSE_247_VOTE_DURATION_MS = 12 * 60 * 60 * 1000;
 
 const KNOWN_PERKS = new Set(Object.values(SUBSCRIPTION_PERKS));
 const PAID_SUBSCRIPTION_PERKS = new Set([SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]);
+const MONTHLY_COIN_GRANT_PERKS = new Set([SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]);
 
 function defaultPerkState() {
   return {
@@ -265,6 +266,16 @@ export function applyMonthlySubscriptionCoinGrant(player, {
   const perkKey = String(perkId || "").trim().toLowerCase();
   if (!KNOWN_PERKS.has(perkKey)) {
     return { ok: false, reason: "unknown_perk", granted: false, amount: 0 };
+  }
+
+  if (!MONTHLY_COIN_GRANT_PERKS.has(perkKey)) {
+    return {
+      ok: true,
+      granted: false,
+      amount: 0,
+      perkId: perkKey,
+      billingPeriodKey: resolveSubscriptionBillingPeriodKey({ periodStartAt, periodEndAt, now })
+    };
   }
 
   const grantAmount = Math.max(0, Math.floor(Number(coins) || 0));

--- a/src/game/subscriptions.js
+++ b/src/game/subscriptions.js
@@ -188,11 +188,12 @@ export function hasActivePerk(player, perkId, now = Date.now()) {
 }
 
 export function hasUnlimitedMarketStock(player, now = Date.now()) {
-  return hasHouse247VoteAccess(player, now);
+  return hasHouse247VoteAccess(player, now)
+    || hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now);
 }
 
 export function getOrderAcceptCap(player, now = Date.now()) {
-  return hasHouse247VoteAccess(player, now)
+  return hasUnlimitedMarketStock(player, now)
     ? ORDER_ACCEPT_CAP_HOUSE_247
     : ORDER_ACCEPT_CAP_BASE;
 }

--- a/src/game/subscriptions.js
+++ b/src/game/subscriptions.js
@@ -1,0 +1,257 @@
+export const SUBSCRIPTION_PERKS = Object.freeze({
+  HOUSE_247: "house_247",
+  TAKEOUT_COUNTER: "takeout_counter"
+});
+
+export const SUBSCRIPTION_MONTHLY_COIN_GRANT = 25_000;
+export const ORDER_ACCEPT_CAP_BASE = 5;
+export const ORDER_ACCEPT_CAP_HOUSE_247 = 500;
+
+const KNOWN_PERKS = new Set(Object.values(SUBSCRIPTION_PERKS));
+
+function defaultPerkState() {
+  return {
+    active: false,
+    entitlement_id: null,
+    period_start_at: null,
+    period_end_at: null,
+    last_coin_grant_period: null,
+    last_coin_grant_at: null,
+    last_event_type: null,
+    last_event_at: null,
+    updated_at: null
+  };
+}
+
+export function createDefaultSubscriptionState() {
+  return {
+    perks: {
+      [SUBSCRIPTION_PERKS.HOUSE_247]: defaultPerkState(),
+      [SUBSCRIPTION_PERKS.TAKEOUT_COUNTER]: defaultPerkState()
+    }
+  };
+}
+
+function parseSkuMap(rawValue) {
+  const raw = String(rawValue || "").trim();
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([sku, perk]) => [String(sku), String(perk).trim().toLowerCase()])
+        .filter(([, perk]) => KNOWN_PERKS.has(perk))
+    );
+  } catch {
+    const pairs = raw.split(",").map((entry) => entry.trim()).filter(Boolean);
+    const mapped = {};
+    for (const pair of pairs) {
+      const [sku, perk] = pair.split(":").map((part) => String(part || "").trim());
+      if (!sku || !perk) continue;
+      const perkId = perk.toLowerCase();
+      if (!KNOWN_PERKS.has(perkId)) continue;
+      mapped[sku] = perkId;
+    }
+    return mapped;
+  }
+}
+
+const ENV_SKU_MAP = parseSkuMap(process.env.NOODLE_SUBSCRIPTION_SKU_MAP);
+
+export function resolveSubscriptionPerkId(skuId) {
+  if (!skuId) return null;
+  return ENV_SKU_MAP[String(skuId)] ?? null;
+}
+
+function normalizeTimestamp(value) {
+  if (value == null || value === "") return null;
+
+  const asNumber = Number(value);
+  if (Number.isFinite(asNumber)) {
+    // Treat small numeric values as epoch seconds.
+    if (asNumber > 0 && asNumber < 1_000_000_000_000) {
+      return Math.floor(asNumber * 1000);
+    }
+    return Math.floor(asNumber);
+  }
+
+  const asDate = Date.parse(String(value));
+  if (!Number.isFinite(asDate)) return null;
+  return Math.floor(asDate);
+}
+
+function normalizePeriodMarker(value) {
+  const ts = normalizeTimestamp(value);
+  return Number.isFinite(ts) ? String(ts) : null;
+}
+
+export function resolveSubscriptionBillingPeriodKey({ periodStartAt = null, periodEndAt = null, now = Date.now() } = {}) {
+  const startMarker = normalizePeriodMarker(periodStartAt);
+  if (startMarker) return `start:${startMarker}`;
+
+  const endMarker = normalizePeriodMarker(periodEndAt);
+  if (endMarker) return `end:${endMarker}`;
+
+  const date = new Date(Number.isFinite(Number(now)) ? Number(now) : Date.now());
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `month:${y}-${m}`;
+}
+
+export function ensureSubscriptionState(player) {
+  if (!player || typeof player !== "object") return createDefaultSubscriptionState();
+
+  if (!player.subscriptions || typeof player.subscriptions !== "object" || Array.isArray(player.subscriptions)) {
+    player.subscriptions = createDefaultSubscriptionState();
+    return player.subscriptions;
+  }
+
+  if (!player.subscriptions.perks || typeof player.subscriptions.perks !== "object" || Array.isArray(player.subscriptions.perks)) {
+    player.subscriptions.perks = {};
+  }
+
+  for (const perkId of KNOWN_PERKS) {
+    const existing = player.subscriptions.perks[perkId];
+    if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+      player.subscriptions.perks[perkId] = defaultPerkState();
+      continue;
+    }
+
+    player.subscriptions.perks[perkId] = {
+      ...defaultPerkState(),
+      ...existing
+    };
+  }
+
+  return player.subscriptions;
+}
+
+export function hasActivePerk(player, perkId, now = Date.now()) {
+  const perkKey = String(perkId || "").trim().toLowerCase();
+  if (!KNOWN_PERKS.has(perkKey)) return false;
+
+  const subscriptions = ensureSubscriptionState(player);
+  const perkState = subscriptions.perks[perkKey];
+  if (!perkState?.active) return false;
+
+  const periodEndAt = normalizeTimestamp(perkState.period_end_at);
+  if (!Number.isFinite(periodEndAt)) return true;
+  return now < periodEndAt;
+}
+
+export function hasUnlimitedMarketStock(player, now = Date.now()) {
+  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now);
+}
+
+export function getOrderAcceptCap(player, now = Date.now()) {
+  return hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now)
+    ? ORDER_ACCEPT_CAP_HOUSE_247
+    : ORDER_ACCEPT_CAP_BASE;
+}
+
+export function applySubscriptionEntitlementEvent(player, {
+  perkId,
+  eventType,
+  entitlementId = null,
+  periodStartAt = null,
+  periodEndAt = null,
+  now = Date.now()
+} = {}) {
+  const perkKey = String(perkId || "").trim().toLowerCase();
+  if (!KNOWN_PERKS.has(perkKey)) {
+    return { ok: false, reason: "unknown_perk", changed: false };
+  }
+
+  const type = String(eventType || "").trim().toUpperCase();
+  if (!type) {
+    return { ok: false, reason: "missing_event_type", changed: false };
+  }
+
+  const subscriptions = ensureSubscriptionState(player);
+  const perkState = subscriptions.perks[perkKey];
+  const before = JSON.stringify(perkState);
+
+  const normalizedStartAt = normalizeTimestamp(periodStartAt);
+  const normalizedEndAt = normalizeTimestamp(periodEndAt);
+
+  if (type === "ENTITLEMENT_CREATE" || type === "ENTITLEMENT_UPDATE") {
+    perkState.active = true;
+    if (entitlementId) perkState.entitlement_id = String(entitlementId);
+    if (Number.isFinite(normalizedStartAt)) perkState.period_start_at = normalizedStartAt;
+    if (Number.isFinite(normalizedEndAt)) perkState.period_end_at = normalizedEndAt;
+  } else if (type === "ENTITLEMENT_DELETE") {
+    perkState.active = false;
+    if (Number.isFinite(normalizedEndAt)) {
+      perkState.period_end_at = normalizedEndAt;
+    } else {
+      perkState.period_end_at = now;
+    }
+  } else {
+    return { ok: false, reason: "unsupported_event_type", changed: false };
+  }
+
+  perkState.last_event_type = type;
+  perkState.last_event_at = now;
+  perkState.updated_at = now;
+
+  const changed = before !== JSON.stringify(perkState);
+
+  return {
+    ok: true,
+    changed,
+    perkId: perkKey,
+    eventType: type,
+    active: hasActivePerk(player, perkKey, now),
+    state: { ...perkState }
+  };
+}
+
+export function applyMonthlySubscriptionCoinGrant(player, {
+  perkId,
+  periodStartAt = null,
+  periodEndAt = null,
+  coins = SUBSCRIPTION_MONTHLY_COIN_GRANT,
+  now = Date.now()
+} = {}) {
+  const perkKey = String(perkId || "").trim().toLowerCase();
+  if (!KNOWN_PERKS.has(perkKey)) {
+    return { ok: false, reason: "unknown_perk", granted: false, amount: 0 };
+  }
+
+  const grantAmount = Math.max(0, Math.floor(Number(coins) || 0));
+  if (grantAmount <= 0) {
+    return { ok: false, reason: "invalid_grant_amount", granted: false, amount: 0 };
+  }
+
+  const subscriptions = ensureSubscriptionState(player);
+  const perkState = subscriptions.perks[perkKey];
+  const billingPeriodKey = resolveSubscriptionBillingPeriodKey({ periodStartAt, periodEndAt, now });
+
+  if (String(perkState.last_coin_grant_period || "") === billingPeriodKey) {
+    return {
+      ok: true,
+      granted: false,
+      amount: 0,
+      perkId: perkKey,
+      billingPeriodKey
+    };
+  }
+
+  player.coins = (Number(player.coins) || 0) + grantAmount;
+  if (!player.lifetime || typeof player.lifetime !== "object") player.lifetime = {};
+  player.lifetime.coins_earned = (Number(player.lifetime.coins_earned) || 0) + grantAmount;
+
+  perkState.last_coin_grant_period = billingPeriodKey;
+  perkState.last_coin_grant_at = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  perkState.updated_at = perkState.last_coin_grant_at;
+
+  return {
+    ok: true,
+    granted: true,
+    amount: grantAmount,
+    perkId: perkKey,
+    billingPeriodKey
+  };
+}

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -187,6 +187,16 @@ function resolveSnapshotOrderTotal({
   return Math.max(TAKEOUT_SNAPSHOT_MIN_ORDERS, Math.min(TAKEOUT_SNAPSHOT_MAX_ORDERS, boardTotal));
 }
 
+function getRequiredTakeoutIngredients(recipe) {
+  const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+  return ingredients.filter((ing) => {
+    if (ing?.optional) return false;
+    const itemId = String(ing?.item_id || "").trim();
+    const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+    return Boolean(itemId) && qty > 0;
+  });
+}
+
 export function computeTakeoutRequiredIngredients(snapshot = [], recipes = {}) {
   const totals = {};
 
@@ -194,7 +204,7 @@ export function computeTakeoutRequiredIngredients(snapshot = [], recipes = {}) {
     const recipeId = String(row?.recipe_id || "").trim();
     if (!recipeId) continue;
     const recipe = recipes?.[recipeId];
-    const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+    const ingredients = getRequiredTakeoutIngredients(recipe);
     const orderCount = Math.max(
       0,
       Math.floor(Number(row?.total_orders ?? row?.visible_order_count ?? 0) || 0)
@@ -241,7 +251,7 @@ function resolveTakeoutOrderCoinValue(recipeId, {
   items = {}
 } = {}) {
   const recipe = recipes?.[recipeId];
-  const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+  const ingredients = getRequiredTakeoutIngredients(recipe);
   let ingredientCost = 0;
   for (const ing of ingredients) {
     const itemId = String(ing?.item_id || "").trim();
@@ -262,6 +272,7 @@ function consumeCoveredIngredients(coveredIngredients, recipeIngredients, orderC
 
   const required = [];
   for (const ing of recipeIngredients || []) {
+    if (ing?.optional) continue;
     const itemId = String(ing?.item_id || "").trim();
     const qtyPerOrder = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
     if (!itemId || qtyPerOrder <= 0) continue;

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -337,11 +337,13 @@ export function processTakeoutCatchup(player, {
 
       const hourly = Array.isArray(row?.hourly_order_counts) ? row.hourly_order_counts : [];
       const orderCount = Math.max(0, Math.floor(Number(hourly[hour] || 0) || 0));
-      if (orderCount <= 0) continue;
+      const visibleRemaining = Math.max(0, Math.floor(Number(row?.visible_order_count || 0) || 0));
+      const orderCountToProcess = Math.min(orderCount, visibleRemaining);
+      if (orderCountToProcess <= 0) continue;
 
       const recipe = recipes?.[recipeId];
       const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
-      const served = consumeCoveredIngredients(coveredIngredients, ingredients, orderCount);
+      const served = consumeCoveredIngredients(coveredIngredients, ingredients, orderCountToProcess);
       if (served <= 0) continue;
 
       const perOrderCoins = resolveTakeoutOrderCoinValue(recipeId, { recipes, marketPrices, items });

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -102,12 +102,13 @@ export function normalizeTakeoutMenuSelection({ selectedRecipeIds = [], learnedR
   return deduped;
 }
 
-function buildShiftSnapshot(menuRecipeIds = []) {
+function buildShiftSnapshot(menuRecipeIds = [], hours = TAKEOUT_SHIFT_DURATION_HOURS) {
+  const totalHours = Math.max(1, Math.floor(Number(hours) || TAKEOUT_SHIFT_DURATION_HOURS));
   return menuRecipeIds.map((recipeId) => ({
     recipe_id: recipeId,
     visible_order_count: 0,
     total_orders: 0,
-    hourly_order_counts: Array.from({ length: TAKEOUT_SHIFT_DURATION_HOURS }, () => 0)
+    hourly_order_counts: Array.from({ length: totalHours }, () => 0)
   }));
 }
 
@@ -133,10 +134,10 @@ export function buildTakeoutShiftSnapshot(menuRecipeIds = [], {
   hours = TAKEOUT_SHIFT_DURATION_HOURS,
   totalOrders = TAKEOUT_SNAPSHOT_MIN_ORDERS
 } = {}) {
-  const out = buildShiftSnapshot(menuRecipeIds);
+  const totalHours = Math.max(1, Math.floor(Number(hours) || TAKEOUT_SHIFT_DURATION_HOURS));
+  const out = buildShiftSnapshot(menuRecipeIds, totalHours);
   if (!out.length) return out;
 
-  const totalHours = Math.max(1, Math.floor(Number(hours) || TAKEOUT_SHIFT_DURATION_HOURS));
   const menuSize = out.length;
   const parsedTotalOrders = Number(totalOrders);
   const orderTotal = Number.isFinite(parsedTotalOrders) && parsedTotalOrders > 0

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -347,6 +347,10 @@ export function processTakeoutCatchup(player, {
       const perOrderCoins = resolveTakeoutOrderCoinValue(recipeId, { recipes, marketPrices, items });
       earned += perOrderCoins * served;
 
+      // Keep snapshot demand in sync with idle catch-up so served orders are not re-servable.
+      const remainingVisible = Math.max(0, Math.floor(Number(row?.visible_order_count || 0) || 0) - served);
+      row.visible_order_count = remainingVisible;
+
       if (!player.lifetime || typeof player.lifetime !== "object") player.lifetime = {};
       player.lifetime.bowls_served_total = (Number(player.lifetime.bowls_served_total) || 0) + served;
       player.lifetime.orders_served = (Number(player.lifetime.orders_served) || 0) + served;
@@ -482,6 +486,7 @@ export function startTakeoutShiftWithCoverage(player, {
     return {
       ok: false,
       reason: "insufficient_coins",
+      snapshotOrderTotal,
       operatingCost,
       requiredIngredients,
       snapshot

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -1,0 +1,548 @@
+import { nowTs } from "../util/time.js";
+
+export const TAKEOUT_SHIFT_DURATION_HOURS = 12;
+export const TAKEOUT_SHIFT_DURATION_MS = TAKEOUT_SHIFT_DURATION_HOURS * 60 * 60 * 1000;
+export const TAKEOUT_MENU_MIN_RECIPES = 5;
+export const TAKEOUT_MENU_MAX_RECIPES = 10;
+export const TAKEOUT_SNAPSHOT_MIN_ORDERS = 100;
+export const TAKEOUT_SNAPSHOT_MAX_ORDERS = 500;
+export const TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS = 1000;
+export const TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS = 2000;
+const TAKEOUT_HOUR_MS = 60 * 60 * 1000;
+
+const TIER_PAYOUT_MULTIPLIERS = Object.freeze({
+  common: 1.3,
+  uncommon: 1.5,
+  rare: 1.75,
+  epic: 2.1,
+  legendary: 2.5,
+  seasonal: 1.6
+});
+
+function defaultShiftState() {
+  return {
+    status: "inactive",
+    started_at: null,
+    ends_at: null,
+    last_processed_hour_index: 0,
+    last_tick_at: null,
+    operating_cost_paid_marker: null,
+    operating_cost: 0,
+    required_ingredients: {},
+    covered_ingredients: {},
+    idle_order_board_snapshot: []
+  };
+}
+
+export function createDefaultTakeoutState() {
+  return {
+    menu_recipe_ids: [],
+    shift: defaultShiftState(),
+    earned_unclaimed_coins: 0,
+    updated_at: null
+  };
+}
+
+export function ensureTakeoutState(player) {
+  if (!player || typeof player !== "object") return createDefaultTakeoutState();
+
+  if (!player.takeout || typeof player.takeout !== "object" || Array.isArray(player.takeout)) {
+    player.takeout = createDefaultTakeoutState();
+    return player.takeout;
+  }
+
+  const takeout = player.takeout;
+  if (!Array.isArray(takeout.menu_recipe_ids)) takeout.menu_recipe_ids = [];
+  if (!Number.isFinite(Number(takeout.earned_unclaimed_coins))) takeout.earned_unclaimed_coins = 0;
+  takeout.earned_unclaimed_coins = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins) || 0));
+
+  if (!takeout.shift || typeof takeout.shift !== "object" || Array.isArray(takeout.shift)) {
+    takeout.shift = defaultShiftState();
+  } else {
+    takeout.shift = {
+      ...defaultShiftState(),
+      ...takeout.shift
+    };
+  }
+
+  if (!Array.isArray(takeout.shift.idle_order_board_snapshot)) {
+    takeout.shift.idle_order_board_snapshot = [];
+  }
+
+  return takeout;
+}
+
+export function getTakeoutMenuLimits(learnedRecipeCount) {
+  const learned = Math.max(0, Math.floor(Number(learnedRecipeCount) || 0));
+  const maxAllowed = Math.min(TAKEOUT_MENU_MAX_RECIPES, learned);
+  const minRequired = learned > 0 ? Math.min(TAKEOUT_MENU_MIN_RECIPES, maxAllowed) : 0;
+  return { learned, minRequired, maxAllowed };
+}
+
+export function normalizeTakeoutMenuSelection({ selectedRecipeIds = [], learnedRecipeIds = [] } = {}) {
+  const learnedSet = new Set((learnedRecipeIds || []).map((id) => String(id || "").trim()).filter(Boolean));
+  const deduped = [];
+  const seen = new Set();
+
+  for (const rawId of selectedRecipeIds || []) {
+    const recipeId = String(rawId || "").trim();
+    if (!recipeId || seen.has(recipeId) || !learnedSet.has(recipeId)) continue;
+    seen.add(recipeId);
+    deduped.push(recipeId);
+    if (deduped.length >= TAKEOUT_MENU_MAX_RECIPES) break;
+  }
+
+  return deduped;
+}
+
+function buildShiftSnapshot(menuRecipeIds = []) {
+  return menuRecipeIds.map((recipeId) => ({
+    recipe_id: recipeId,
+    visible_order_count: 0,
+    total_orders: 0,
+    hourly_order_counts: Array.from({ length: TAKEOUT_SHIFT_DURATION_HOURS }, () => 0)
+  }));
+}
+
+function toIntSeed(value) {
+  const n = Math.floor(Number(value) || 0);
+  if (!Number.isFinite(n)) return 0;
+  return n;
+}
+
+function deriveShiftSeed(parts = []) {
+  // FNV-1a style integer mixing gives stable pseudo-randomness per shift seed.
+  let hash = 2166136261;
+  for (const part of parts) {
+    const n = toIntSeed(part);
+    hash ^= n;
+    hash = Math.imul(hash, 16777619);
+    hash >>>= 0;
+  }
+  return hash >>> 0;
+}
+
+export function buildTakeoutShiftSnapshot(menuRecipeIds = [], {
+  hours = TAKEOUT_SHIFT_DURATION_HOURS,
+  totalOrders = TAKEOUT_SNAPSHOT_MIN_ORDERS
+} = {}) {
+  const out = buildShiftSnapshot(menuRecipeIds);
+  if (!out.length) return out;
+
+  const totalHours = Math.max(1, Math.floor(Number(hours) || TAKEOUT_SHIFT_DURATION_HOURS));
+  const menuSize = out.length;
+  const parsedTotalOrders = Number(totalOrders);
+  const orderTotal = Number.isFinite(parsedTotalOrders) && parsedTotalOrders > 0
+    ? Math.floor(parsedTotalOrders)
+    : TAKEOUT_SNAPSHOT_MIN_ORDERS;
+  if (orderTotal <= 0) return out;
+
+  const hourlyCounts = Array.from({ length: totalHours }, () => Math.floor(orderTotal / totalHours));
+  let remainder = orderTotal % totalHours;
+  for (let hour = 0; hour < totalHours && remainder > 0; hour += 1) {
+    hourlyCounts[hour] += 1;
+    remainder -= 1;
+  }
+
+  let rotation = 0;
+  for (let hour = 0; hour < totalHours; hour += 1) {
+    const ordersThisHour = hourlyCounts[hour] ?? 0;
+    for (let j = 0; j < ordersThisHour; j += 1) {
+      const idx = (rotation + j) % menuSize;
+      const row = out[idx];
+      row.hourly_order_counts[hour] = (row.hourly_order_counts[hour] ?? 0) + 1;
+      row.total_orders += 1;
+      row.visible_order_count = row.total_orders;
+    }
+    rotation = (rotation + ordersThisHour) % menuSize;
+  }
+
+  return out;
+}
+
+function resolveSnapshotOrderTotal({
+  boardOrderTotal = null,
+  unlimitedOrders = false,
+  shiftSeed = 0,
+  menuRecipeCount = 0
+} = {}) {
+  if (unlimitedOrders) {
+    const minOrders = TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS;
+    const maxOrders = TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS;
+    const span = Math.max(1, maxOrders - minOrders + 1);
+    const seed = deriveShiftSeed([shiftSeed, boardOrderTotal, menuRecipeCount]);
+    return minOrders + (seed % span);
+  }
+
+  const boardTotal = Math.floor(Number(boardOrderTotal) || 0);
+  if (!Number.isFinite(boardTotal) || boardTotal <= 0) return TAKEOUT_SNAPSHOT_MIN_ORDERS;
+  return Math.max(TAKEOUT_SNAPSHOT_MIN_ORDERS, Math.min(TAKEOUT_SNAPSHOT_MAX_ORDERS, boardTotal));
+}
+
+export function computeTakeoutRequiredIngredients(snapshot = [], recipes = {}) {
+  const totals = {};
+
+  for (const row of snapshot || []) {
+    const recipeId = String(row?.recipe_id || "").trim();
+    if (!recipeId) continue;
+    const recipe = recipes?.[recipeId];
+    const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+    const orderCount = Math.max(
+      0,
+      Math.floor(Number(row?.total_orders ?? row?.visible_order_count ?? 0) || 0)
+    );
+    if (orderCount <= 0) continue;
+
+    for (const ing of ingredients) {
+      const itemId = String(ing?.item_id || "").trim();
+      const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+      if (!itemId || qty <= 0) continue;
+      totals[itemId] = (totals[itemId] ?? 0) + (qty * orderCount);
+    }
+  }
+
+  return totals;
+}
+
+export function computeTakeoutOperatingCost(requiredIngredients = {}, { marketPrices = {}, items = {} } = {}) {
+  let total = 0;
+  for (const [itemId, qtyRaw] of Object.entries(requiredIngredients || {})) {
+    const qty = Math.max(0, Math.floor(Number(qtyRaw || 0) || 0));
+    if (qty <= 0) continue;
+    const marketPrice = Number(marketPrices?.[itemId]);
+    const basePrice = Number(items?.[itemId]?.base_price);
+    const unitPrice = Number.isFinite(marketPrice) && marketPrice > 0
+      ? marketPrice
+      : (Number.isFinite(basePrice) && basePrice > 0 ? basePrice : 0);
+    total += unitPrice * qty;
+  }
+  return Math.max(0, Math.floor(total));
+}
+
+function resolveIngredientUnitPrice(itemId, { marketPrices = {}, items = {} } = {}) {
+  const marketPrice = Number(marketPrices?.[itemId]);
+  const basePrice = Number(items?.[itemId]?.base_price);
+  if (Number.isFinite(marketPrice) && marketPrice > 0) return marketPrice;
+  if (Number.isFinite(basePrice) && basePrice > 0) return basePrice;
+  return 0;
+}
+
+function resolveTakeoutOrderCoinValue(recipeId, {
+  recipes = {},
+  marketPrices = {},
+  items = {}
+} = {}) {
+  const recipe = recipes?.[recipeId];
+  const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+  let ingredientCost = 0;
+  for (const ing of ingredients) {
+    const itemId = String(ing?.item_id || "").trim();
+    const qty = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+    if (!itemId || qty <= 0) continue;
+    ingredientCost += resolveIngredientUnitPrice(itemId, { marketPrices, items }) * qty;
+  }
+
+  const tierKey = String(recipe?.tier || "common").trim().toLowerCase();
+  const mult = Number(TIER_PAYOUT_MULTIPLIERS[tierKey] ?? TIER_PAYOUT_MULTIPLIERS.common);
+  const payout = Math.round(ingredientCost * mult);
+  return Math.max(1, Number.isFinite(payout) ? payout : 1);
+}
+
+function consumeCoveredIngredients(coveredIngredients, recipeIngredients, orderCount) {
+  const qtyToServe = Math.max(0, Math.floor(Number(orderCount || 0) || 0));
+  if (qtyToServe <= 0) return 0;
+
+  const required = [];
+  for (const ing of recipeIngredients || []) {
+    const itemId = String(ing?.item_id || "").trim();
+    const qtyPerOrder = Math.max(0, Math.floor(Number(ing?.qty || 0) || 0));
+    if (!itemId || qtyPerOrder <= 0) continue;
+    required.push({ itemId, qtyPerOrder });
+  }
+  if (!required.length) return qtyToServe;
+
+  let maxServable = qtyToServe;
+  for (const req of required) {
+    const available = Math.max(0, Math.floor(Number(coveredIngredients?.[req.itemId] || 0) || 0));
+    const possible = Math.floor(available / req.qtyPerOrder);
+    if (possible < maxServable) maxServable = possible;
+  }
+
+  if (maxServable <= 0) return 0;
+  for (const req of required) {
+    const needed = req.qtyPerOrder * maxServable;
+    coveredIngredients[req.itemId] = Math.max(
+      0,
+      Math.floor(Number(coveredIngredients?.[req.itemId] || 0) || 0) - needed
+    );
+  }
+
+  return maxServable;
+}
+
+export function processTakeoutCatchup(player, {
+  now = nowTs(),
+  recipes = {},
+  marketPrices = {},
+  items = {}
+} = {}) {
+  const takeout = ensureTakeoutState(player);
+  const shift = takeout.shift;
+  if (shift.status !== "active") {
+    return { ok: true, processedHours: 0, earned: 0, completed: false, totalProcessedHours: 0 };
+  }
+
+  const startedAt = Number(shift.started_at || 0);
+  const endsAt = Number(shift.ends_at || 0);
+  if (!Number.isFinite(startedAt) || startedAt < 0 || !Number.isFinite(endsAt) || endsAt <= startedAt) {
+    shift.status = "inactive";
+    shift.last_tick_at = now;
+    takeout.updated_at = now;
+    return { ok: true, processedHours: 0, earned: 0, completed: true, totalProcessedHours: 0 };
+  }
+
+  const effectiveNow = Math.min(now, endsAt);
+  const elapsedWholeHours = Math.max(0, Math.floor((effectiveNow - startedAt) / TAKEOUT_HOUR_MS));
+  const maxProcessableHours = Math.min(TAKEOUT_SHIFT_DURATION_HOURS, elapsedWholeHours);
+  const prevProcessedHours = Math.max(0, Math.floor(Number(shift.last_processed_hour_index || 0) || 0));
+  if (prevProcessedHours >= maxProcessableHours) {
+    const completed = maxProcessableHours >= TAKEOUT_SHIFT_DURATION_HOURS || now >= endsAt;
+    if (completed) shift.status = "inactive";
+    shift.last_tick_at = now;
+    takeout.updated_at = now;
+    return { ok: true, processedHours: 0, earned: 0, completed, totalProcessedHours: maxProcessableHours };
+  }
+
+  const coveredIngredients = shift.covered_ingredients && typeof shift.covered_ingredients === "object"
+    ? shift.covered_ingredients
+    : {};
+  shift.covered_ingredients = coveredIngredients;
+
+  const snapshot = Array.isArray(shift.idle_order_board_snapshot)
+    ? shift.idle_order_board_snapshot
+    : [];
+  let earned = 0;
+
+  for (let hour = prevProcessedHours; hour < maxProcessableHours; hour += 1) {
+    for (const row of snapshot) {
+      const recipeId = String(row?.recipe_id || "").trim();
+      if (!recipeId) continue;
+
+      const hourly = Array.isArray(row?.hourly_order_counts) ? row.hourly_order_counts : [];
+      const orderCount = Math.max(0, Math.floor(Number(hourly[hour] || 0) || 0));
+      if (orderCount <= 0) continue;
+
+      const recipe = recipes?.[recipeId];
+      const ingredients = Array.isArray(recipe?.ingredients) ? recipe.ingredients : [];
+      const served = consumeCoveredIngredients(coveredIngredients, ingredients, orderCount);
+      if (served <= 0) continue;
+
+      const perOrderCoins = resolveTakeoutOrderCoinValue(recipeId, { recipes, marketPrices, items });
+      earned += perOrderCoins * served;
+    }
+  }
+
+  const earnedSafe = Math.max(0, Math.floor(Number(earned || 0) || 0));
+  takeout.earned_unclaimed_coins = Math.max(
+    0,
+    Math.floor(Number(takeout.earned_unclaimed_coins || 0) || 0) + earnedSafe
+  );
+  shift.last_processed_hour_index = maxProcessableHours;
+  shift.last_tick_at = now;
+
+  const completed = maxProcessableHours >= TAKEOUT_SHIFT_DURATION_HOURS || now >= endsAt;
+  if (completed) shift.status = "inactive";
+
+  takeout.updated_at = now;
+
+  return {
+    ok: true,
+    processedHours: Math.max(0, maxProcessableHours - prevProcessedHours),
+    earned: earnedSafe,
+    completed,
+    totalProcessedHours: maxProcessableHours
+  };
+}
+
+export function isTakeoutShiftActive(player, now = nowTs()) {
+  const takeout = ensureTakeoutState(player);
+  if (takeout.shift.status !== "active") return false;
+
+  const endsAt = Number(takeout.shift.ends_at || 0);
+  if (!Number.isFinite(endsAt) || endsAt <= 0) return false;
+  return now < endsAt;
+}
+
+export function finishTakeoutShiftIfEnded(player, now = nowTs()) {
+  const takeout = ensureTakeoutState(player);
+  const shift = takeout.shift;
+  if (shift.status !== "active") return false;
+
+  const endsAt = Number(shift.ends_at || 0);
+  if (!Number.isFinite(endsAt) || endsAt <= 0 || now < endsAt) return false;
+
+  shift.status = "inactive";
+  shift.last_tick_at = now;
+  takeout.updated_at = now;
+  return true;
+}
+
+export function openTakeoutShift(player, {
+  now = nowTs(),
+  snapshot = null,
+  snapshotOrderTotal = null,
+  requiredIngredients = null,
+  coveredIngredients = null,
+  operatingCost = null,
+  operatingCostMarker = null
+} = {}) {
+  const takeout = ensureTakeoutState(player);
+
+  // End stale active shifts first so players can immediately start a new 12h run.
+  finishTakeoutShiftIfEnded(player, now);
+
+  if (isTakeoutShiftActive(player, now)) {
+    return { ok: false, reason: "shift_active" };
+  }
+
+  const startedAt = now;
+  const endsAt = startedAt + TAKEOUT_SHIFT_DURATION_MS;
+  const normalizedSnapshot = Array.isArray(snapshot)
+    ? snapshot
+    : buildTakeoutShiftSnapshot(takeout.menu_recipe_ids, { totalOrders: snapshotOrderTotal });
+  const normalizedRequiredIngredients = requiredIngredients && typeof requiredIngredients === "object"
+    ? { ...requiredIngredients }
+    : {};
+  const normalizedCoveredIngredients = coveredIngredients && typeof coveredIngredients === "object"
+    ? { ...coveredIngredients }
+    : { ...normalizedRequiredIngredients };
+
+  takeout.shift = {
+    status: "active",
+    started_at: startedAt,
+    ends_at: endsAt,
+    last_processed_hour_index: 0,
+    last_tick_at: startedAt,
+    operating_cost_paid_marker: operatingCostMarker ?? null,
+    operating_cost: Math.max(0, Math.floor(Number(operatingCost || 0) || 0)),
+    required_ingredients: normalizedRequiredIngredients,
+    covered_ingredients: normalizedCoveredIngredients,
+    idle_order_board_snapshot: normalizedSnapshot
+  };
+  takeout.updated_at = now;
+
+  return {
+    ok: true,
+    startedAt,
+    endsAt
+  };
+}
+
+export function startTakeoutShiftWithCoverage(player, {
+  now = nowTs(),
+  boardOrderTotal = null,
+  unlimitedOrders = false,
+  recipes = {},
+  marketPrices = {},
+  items = {}
+} = {}) {
+  const takeout = ensureTakeoutState(player);
+  const menuRecipeIds = Array.isArray(takeout.menu_recipe_ids) ? [...takeout.menu_recipe_ids] : [];
+
+  if (menuRecipeIds.length <= 0) {
+    return { ok: false, reason: "menu_not_set" };
+  }
+
+  const snapshotOrderTotal = resolveSnapshotOrderTotal({
+    boardOrderTotal,
+    unlimitedOrders,
+    shiftSeed: now,
+    menuRecipeCount: menuRecipeIds.length
+  });
+  const snapshot = buildTakeoutShiftSnapshot(menuRecipeIds, { totalOrders: snapshotOrderTotal });
+  const requiredIngredients = computeTakeoutRequiredIngredients(snapshot, recipes);
+  const operatingCost = computeTakeoutOperatingCost(requiredIngredients, { marketPrices, items });
+  const playerCoins = Math.max(0, Math.floor(Number(player?.coins || 0) || 0));
+
+  if (playerCoins < operatingCost) {
+    return {
+      ok: false,
+      reason: "insufficient_coins",
+      operatingCost,
+      requiredIngredients,
+      snapshot
+    };
+  }
+
+  player.coins = playerCoins - operatingCost;
+
+  const openResult = openTakeoutShift(player, {
+    now,
+    snapshot,
+    snapshotOrderTotal,
+    requiredIngredients,
+    coveredIngredients: requiredIngredients,
+    operatingCost,
+    operatingCostMarker: `takeout_shift:${now}`
+  });
+  if (!openResult.ok) {
+    player.coins = playerCoins;
+    return {
+      ...openResult,
+      snapshotOrderTotal,
+      operatingCost,
+      requiredIngredients,
+      snapshot
+    };
+  }
+
+  return {
+    ok: true,
+    startedAt: openResult.startedAt,
+    endsAt: openResult.endsAt,
+    snapshotOrderTotal,
+    operatingCost,
+    requiredIngredients,
+    snapshot
+  };
+}
+
+export function setTakeoutMenu(player, { menuRecipeIds = [], learnedRecipeIds = [], now = nowTs() } = {}) {
+  const takeout = ensureTakeoutState(player);
+  const normalizedMenu = normalizeTakeoutMenuSelection({ selectedRecipeIds: menuRecipeIds, learnedRecipeIds });
+
+  const limits = getTakeoutMenuLimits(learnedRecipeIds.length);
+  if (limits.learned <= 0) {
+    return { ok: false, reason: "no_learned_recipes", limits, menuRecipeIds: [] };
+  }
+
+  if (normalizedMenu.length < limits.minRequired) {
+    return { ok: false, reason: "menu_too_small", limits, menuRecipeIds: normalizedMenu };
+  }
+
+  if (normalizedMenu.length > limits.maxAllowed) {
+    return { ok: false, reason: "menu_too_large", limits, menuRecipeIds: normalizedMenu };
+  }
+
+  takeout.menu_recipe_ids = normalizedMenu;
+  takeout.updated_at = now;
+
+  return { ok: true, limits, menuRecipeIds: [...normalizedMenu] };
+}
+
+export function claimTakeoutEarnings(player, { now = nowTs() } = {}) {
+  const takeout = ensureTakeoutState(player);
+  const amount = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins) || 0));
+  if (amount <= 0) {
+    return { ok: false, reason: "nothing_to_claim", amount: 0 };
+  }
+
+  player.coins = (Number(player.coins) || 0) + amount;
+  if (!player.lifetime || typeof player.lifetime !== "object") player.lifetime = {};
+  player.lifetime.coins_earned = (Number(player.lifetime.coins_earned) || 0) + amount;
+
+  takeout.earned_unclaimed_coins = 0;
+  takeout.updated_at = now;
+
+  return { ok: true, amount };
+}

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -39,6 +39,7 @@ export function createDefaultTakeoutState() {
     menu_recipe_ids: [],
     shift: defaultShiftState(),
     earned_unclaimed_coins: 0,
+    first_shift_started_at: null,
     updated_at: null
   };
 }
@@ -55,6 +56,12 @@ export function ensureTakeoutState(player) {
   if (!Array.isArray(takeout.menu_recipe_ids)) takeout.menu_recipe_ids = [];
   if (!Number.isFinite(Number(takeout.earned_unclaimed_coins))) takeout.earned_unclaimed_coins = 0;
   takeout.earned_unclaimed_coins = Math.max(0, Math.floor(Number(takeout.earned_unclaimed_coins) || 0));
+  {
+    const firstShiftStartedAt = Number(takeout.first_shift_started_at || 0);
+    takeout.first_shift_started_at = Number.isFinite(firstShiftStartedAt) && firstShiftStartedAt > 0
+      ? firstShiftStartedAt
+      : null;
+  }
 
   if (!takeout.shift || typeof takeout.shift !== "object" || Array.isArray(takeout.shift)) {
     takeout.shift = defaultShiftState();
@@ -433,6 +440,9 @@ export function openTakeoutShift(player, {
     covered_ingredients: normalizedCoveredIngredients,
     idle_order_board_snapshot: normalizedSnapshot
   };
+  if (!Number.isFinite(Number(takeout.first_shift_started_at || 0)) || Number(takeout.first_shift_started_at || 0) <= 0) {
+    takeout.first_shift_started_at = startedAt;
+  }
   takeout.updated_at = now;
 
   return {

--- a/src/game/takeout.js
+++ b/src/game/takeout.js
@@ -339,6 +339,10 @@ export function processTakeoutCatchup(player, {
 
       const perOrderCoins = resolveTakeoutOrderCoinValue(recipeId, { recipes, marketPrices, items });
       earned += perOrderCoins * served;
+
+      if (!player.lifetime || typeof player.lifetime !== "object") player.lifetime = {};
+      player.lifetime.bowls_served_total = (Number(player.lifetime.bowls_served_total) || 0) + served;
+      player.lifetime.orders_served = (Number(player.lifetime.orders_served) || 0) + served;
     }
   }
 

--- a/src/game/voteRewards.js
+++ b/src/game/voteRewards.js
@@ -1,5 +1,10 @@
 import { nowTs } from "../util/time.js";
 import { applySxpLevelUp } from "./serve.js";
+import {
+  grantHouse247VoteAccess,
+  getHouse247VoteExpiry,
+  HOUSE_247_VOTE_DURATION_MS
+} from "./subscriptions.js";
 
 export const TOPGG_BOT_URL = "https://top.gg/bot/1460058511802105976/vote";
 
@@ -61,11 +66,10 @@ export const VOTE_PLATFORM_PAGES = [
   {
     source: VOTE_SOURCES.BOTLIST_ME,
     label: "BotList.me",
-    voteUrl: null,
-    isVoteLive: false,
+    voteUrl: "https://botlist.me/bots/1460058511802105976/vote",
+    isVoteLive: true,
     supportsVoteRewards: true,
     supportsServerCount: true,
-    notes: "*Bot page pending*"
   },
   {
     source: VOTE_SOURCES.DISCORDBOTSGG,
@@ -198,7 +202,8 @@ export function registerVoteFromSource(player, source = VOTE_SOURCES.TOPGG, now 
       duplicate: true,
       lifetimeLimited: false,
       shouldPersistDuplicate,
-      pendingClaims: state.pending_claims
+      pendingClaims: state.pending_claims,
+      house247ExpiresAt: getHouse247VoteExpiry(player)
     };
   }
 
@@ -209,6 +214,10 @@ export function registerVoteFromSource(player, source = VOTE_SOURCES.TOPGG, now 
   sourceState.last_vote_at = now;
   sourceState.last_webhook_at = now;
   sourceState.votes_total = Math.max(0, Number(sourceState.votes_total || 0)) + 1;
+  const house247ExpiresAt = grantHouse247VoteAccess(player, {
+    now,
+    durationMs: HOUSE_247_VOTE_DURATION_MS
+  });
 
   return {
     ok: true,
@@ -216,7 +225,8 @@ export function registerVoteFromSource(player, source = VOTE_SOURCES.TOPGG, now 
     duplicate: false,
     lifetimeLimited: false,
     shouldPersistDuplicate: true,
-    pendingClaims: state.pending_claims
+    pendingClaims: state.pending_claims,
+    house247ExpiresAt
   };
 }
 
@@ -280,6 +290,7 @@ export function getVoteRewardStatus(player) {
     pendingClaims: Math.max(0, Number(state.pending_claims || 0)),
     lastVoteAt: state.last_vote_at,
     lastClaimAt: state.last_claim_at,
+    house247ExpiresAt: getHouse247VoteExpiry(player),
     reward: { ...DEFAULT_VOTE_REWARD }
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2943,11 +2943,22 @@ import { theme } from "./ui/theme.js";
           periodEndAt,
           now: Date.now()
         });
+        const rawPeriodStart = Number.isFinite(Number(periodStartAt)) && Number(periodStartAt) > 0
+          ? Math.floor(Number(periodStartAt))
+          : "-";
+        const rawPeriodEnd = Number.isFinite(Number(periodEndAt)) && Number(periodEndAt) > 0
+          ? Math.floor(Number(periodEndAt))
+          : "-";
+        const payloadFingerprint = crypto
+          .createHash("sha256")
+          .update(rawBody || "")
+          .digest("hex")
+          .slice(0, 16);
         const subscriptionIdempotencyKey = (() => {
-          // Discord can reuse entitlement IDs across renewals; always scope by billing period.
+          // Deduplicate exact retries, while allowing distinct updates in the same billing period.
           return entitlementId
-            ? `discord_subscription:${eventType}:${entitlementId}:${billingPeriodKey}`
-            : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
+            ? `discord_subscription:${eventType}:${entitlementId}:${rawPeriodStart}:${rawPeriodEnd}:${payloadFingerprint}`
+            : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}:${payloadFingerprint}`;
         })();
 
         const cached = getIdempotentResult(db, subscriptionIdempotencyKey);

--- a/src/index.js
+++ b/src/index.js
@@ -2940,14 +2940,9 @@ import { theme } from "./ui/theme.js";
           now: Date.now()
         });
         const subscriptionIdempotencyKey = (() => {
-          // Discord can reuse entitlement IDs across renewals; include billing period on updates.
-          if (eventType === "ENTITLEMENT_UPDATE") {
-            return entitlementId
-              ? `discord_subscription:${eventType}:${entitlementId}:${billingPeriodKey}`
-              : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
-          }
+          // Discord can reuse entitlement IDs across renewals; always scope by billing period.
           return entitlementId
-            ? `discord_subscription:${eventType}:${entitlementId}`
+            ? `discord_subscription:${eventType}:${entitlementId}:${billingPeriodKey}`
             : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
         })();
 

--- a/src/index.js
+++ b/src/index.js
@@ -2972,12 +2972,6 @@ import { theme } from "./ui/theme.js";
           periodEndAt,
           now: nowMs
         });
-        const rawPeriodStart = Number.isFinite(Number(periodStartAt)) && Number(periodStartAt) > 0
-          ? Math.floor(Number(periodStartAt))
-          : "-";
-        const rawPeriodEnd = Number.isFinite(Number(periodEndAt)) && Number(periodEndAt) > 0
-          ? Math.floor(Number(periodEndAt))
-          : "-";
         const payloadFingerprint = crypto
           .createHash("sha256")
           .update(rawBody || "")
@@ -2986,7 +2980,7 @@ import { theme } from "./ui/theme.js";
         const subscriptionIdempotencyKey = (() => {
           // Deduplicate exact retries, while allowing distinct updates in the same billing period.
           return entitlementId
-            ? `discord_subscription:${eventType}:${entitlementId}:${rawPeriodStart}:${rawPeriodEnd}:${payloadFingerprint}`
+            ? `discord_subscription:${eventType}:${entitlementId}:${billingPeriodKey}:${payloadFingerprint}`
             : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}:${payloadFingerprint}`;
         })();
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,8 +62,15 @@ import { theme } from "./ui/theme.js";
   const { getCustomEmojiEntries } = await import("./ui/icons.js");
   const { grantStoreBundle, resolveStoreBundleSpecId } = await import("./game/storeBundles.js");
   const {
+    grantStoreCoinPack,
+    getStoreCoinPack,
+    resolveStoreCoinPackIdFromMetadata,
+    resolveStoreCoinPackIdFromSku
+  } = await import("./game/storeCoinPacks.js");
+  const {
     applySubscriptionEntitlementEvent,
     applyMonthlySubscriptionCoinGrant,
+    SUBSCRIPTION_PERKS,
     hasActivePerk,
     resolveSubscriptionBillingPeriodKey,
     resolveSubscriptionPerkId
@@ -2684,15 +2691,16 @@ import { theme } from "./ui/theme.js";
         const metadata = session?.metadata ?? {};
         const discordId = metadata?.discord_id || session?.client_reference_id || null;
         const specId = metadata?.spec_id || null;
+        const coinPackId = resolveStoreCoinPackIdFromMetadata(metadata);
 
         webhookInfo(
           "Stripe: Checkout completed",
-          JSON.stringify({ sessionId, discordId, specId })
+          JSON.stringify({ sessionId, discordId, specId, coinPackId })
         );
 
-        if (!discordId || !specId) {
+        if (!discordId || (!specId && !coinPackId)) {
           res.writeHead(202, { "content-type": "text/plain" });
-          res.end("missing discord id or spec id");
+          res.end("missing discord id or purchasable id");
           return;
         }
 
@@ -2717,16 +2725,20 @@ import { theme } from "./ui/theme.js";
         let player = getPlayer(db, serverId, discordId);
         if (!player) player = newPlayerProfile(discordId);
 
-        const result = grantStoreBundle({
-          player,
-          specId,
-          specializationsContent,
-          decorSetsContent,
-          coins: 10000
-        });
+        const purchaseId = coinPackId || specId;
+        const purchaseKind = coinPackId ? "coin_pack" : "specialization";
+        const result = coinPackId
+          ? grantStoreCoinPack({ player, coinPackId })
+          : grantStoreBundle({
+              player,
+              specId,
+              specializationsContent,
+              decorSetsContent,
+              coins: 10000
+            });
         webhookInfo(
           "Stripe: Grant result",
-          JSON.stringify({ ok: result.ok, reason: result.reason, specId, serverId, discordId })
+          JSON.stringify({ ok: result.ok, reason: result.reason, purchaseKind, purchaseId, serverId, discordId })
         );
 
         if (result.ok) {
@@ -2737,12 +2749,18 @@ import { theme } from "./ui/theme.js";
               userId: discordId,
               action: "stripe_checkout",
               ttlSeconds: 60 * 60 * 24 * 30,
-              result: { ok: true, specId }
+              result: { ok: true, purchaseKind, purchaseId }
             });
           }
 
-          const spec = getSpecializationById(specializationsContent, specId);
-          const specName = spec?.name ?? specId;
+          const purchaseName = (() => {
+            if (coinPackId) {
+              const pack = getStoreCoinPack(coinPackId);
+              return pack ? `${pack.priceLabel} Coin Pack` : coinPackId;
+            }
+            const spec = getSpecializationById(specializationsContent, specId);
+            return spec?.name ?? specId;
+          })();
           const stripeExternalEventId = sessionId
             ? `stripe:${sessionId}`
             : `stripe:raw:${crypto.createHash("sha256").update(rawBody).digest("hex")}`;
@@ -2751,19 +2769,19 @@ import { theme } from "./ui/theme.js";
             externalEventId: stripeExternalEventId,
             userId: discordId,
             serverId,
-            specId,
+            specId: purchaseId,
             status: "granted",
             purchasedAt: Date.now()
           });
-          const purchaseCount = getAllTimeSpecializationPurchaseCount(db, specId);
+          const purchaseCount = getAllTimeSpecializationPurchaseCount(db, purchaseId);
           await sendDevAlert({
             title: "Stripe Store Purchase Alert!",
             description:
               `User: <@${discordId}> (${discordId})\n` +
-              `Specialization: ${specName} (${specId})\n` +
+              `Purchase: ${purchaseName} (${purchaseId})\n` +
               `Server: ${serverId}\n` +
               `Session: ${sessionId ?? "unknown"}`,
-            footerText: `Specialization Purchases: ${purchaseCount.toLocaleString()}`,
+            footerText: `Purchase Count: ${purchaseCount.toLocaleString()}`,
             color: theme.colors.success
           });
         }
@@ -2930,6 +2948,7 @@ import { theme } from "./ui/theme.js";
       } = extractEntitlementPayload(payload);
       const specId = resolveStoreBundleSpecId(skuId);
       const perkId = resolveSubscriptionPerkId(skuId);
+      const coinPackId = resolveStoreCoinPackIdFromSku(skuId);
 
       if (!userId) {
         res.writeHead(202, { "content-type": "text/plain" });
@@ -2937,17 +2956,18 @@ import { theme } from "./ui/theme.js";
         return;
       }
 
-      if (!specId && !perkId) {
+      if (!specId && !perkId && !coinPackId) {
         res.writeHead(202, { "content-type": "text/plain" });
         res.end("unsupported sku");
         return;
       }
 
       if (perkId) {
+        const nowMs = Date.now();
         const billingPeriodKey = resolveSubscriptionBillingPeriodKey({
           periodStartAt,
           periodEndAt,
-          now: Date.now()
+          now: nowMs
         });
         const rawPeriodStart = Number.isFinite(Number(periodStartAt)) && Number(periodStartAt) > 0
           ? Math.floor(Number(periodStartAt))
@@ -2984,6 +3004,7 @@ import { theme } from "./ui/theme.js";
 
         let subscriptionPlayer = getPlayer(db, subscriptionServerId, userId);
         if (!subscriptionPlayer) subscriptionPlayer = newPlayerProfile(userId);
+        const wasActiveBefore = hasActivePerk(subscriptionPlayer, perkId, nowMs);
 
         const lifecycleResult = applySubscriptionEntitlementEvent(subscriptionPlayer, {
           perkId,
@@ -2991,7 +3012,7 @@ import { theme } from "./ui/theme.js";
           entitlementId,
           periodStartAt,
           periodEndAt,
-          now: Date.now()
+          now: nowMs
         });
 
         let monthlyGrantResult = { ok: true, granted: false, amount: 0, billingPeriodKey: null };
@@ -3000,9 +3021,19 @@ import { theme } from "./ui/theme.js";
             perkId,
             periodStartAt,
             periodEndAt,
-            now: Date.now()
+            now: nowMs
           });
         }
+
+        const isActiveAfter = hasActivePerk(subscriptionPlayer, perkId, nowMs);
+        const takeoutStarted = perkId === SUBSCRIPTION_PERKS.TAKEOUT_COUNTER
+          && lifecycleResult.ok
+          && !wasActiveBefore
+          && isActiveAfter;
+        const takeoutEnded = perkId === SUBSCRIPTION_PERKS.TAKEOUT_COUNTER
+          && lifecycleResult.ok
+          && wasActiveBefore
+          && !isActiveAfter;
 
         if (lifecycleResult.ok || monthlyGrantResult.granted) {
           upsertPlayer(db, subscriptionServerId, userId, subscriptionPlayer, null, subscriptionPlayer.schema_version);
@@ -3028,12 +3059,40 @@ import { theme } from "./ui/theme.js";
           serverId: subscriptionServerId,
           perkId,
           eventType,
-          active: hasActivePerk(subscriptionPlayer, perkId),
+          active: isActiveAfter,
           lifecycleOk: Boolean(lifecycleResult.ok),
           lifecycleReason: lifecycleResult.reason ?? null,
           monthlyCoinsGranted: monthlyGrantResult.granted ? monthlyGrantResult.amount : 0,
           billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
         });
+
+        if (takeoutStarted) {
+          await sendDevAlert({
+            title: "Take Out Subscription Started",
+            description:
+              `User: <@${userId}> (${userId})\n`
+              + `Perk: Take Out Counter (${perkId})\n`
+              + `Event: ${eventType}\n`
+              + `Server: ${subscriptionServerId}\n`
+              + `Monthly Coins Granted: ${monthlyGrantResult.granted ? monthlyGrantResult.amount : 0}c`,
+            footerText: `Entitlement: ${entitlementId || "unknown"}`,
+            color: theme.colors.success
+          });
+        }
+
+        if (takeoutEnded) {
+          await sendDevAlert({
+            title: "Take Out Subscription Ended",
+            description:
+              `User: <@${userId}> (${userId})\n`
+              + `Perk: Take Out Counter (${perkId})\n`
+              + `Event: ${eventType}\n`
+              + `Server: ${subscriptionServerId}\n`
+              + `Monthly Coins Granted: ${monthlyGrantResult.granted ? monthlyGrantResult.amount : 0}c`,
+            footerText: `Entitlement: ${entitlementId || "unknown"}`,
+            color: theme.colors.warning
+          });
+        }
 
         putIdempotentResult(db, {
           key: subscriptionIdempotencyKey,
@@ -3084,16 +3143,20 @@ import { theme } from "./ui/theme.js";
       let player = getPlayer(db, serverId, userId);
       if (!player) player = newPlayerProfile(userId);
 
-      const result = grantStoreBundle({
-        player,
-        specId,
-        specializationsContent,
-        decorSetsContent,
-        coins: 10000
-      });
+      const purchaseId = coinPackId || specId;
+      const purchaseKind = coinPackId ? "coin_pack" : "specialization";
+      const result = coinPackId
+        ? grantStoreCoinPack({ player, coinPackId })
+        : grantStoreBundle({
+            player,
+            specId,
+            specializationsContent,
+            decorSetsContent,
+            coins: 10000
+          });
       webhookInfo(
         "Discord: Grant result",
-        JSON.stringify({ ok: result.ok, reason: result.reason, specId, serverId, userId })
+        JSON.stringify({ ok: result.ok, reason: result.reason, purchaseKind, purchaseId, serverId, userId })
       );
 
       if (result.ok) {
@@ -3104,12 +3167,18 @@ import { theme } from "./ui/theme.js";
             userId,
             action: "discord_entitlement",
             ttlSeconds: 60 * 60 * 24 * 30,
-            result: { ok: true, specId }
+            result: { ok: true, purchaseKind, purchaseId }
           });
         }
 
-        const spec = getSpecializationById(specializationsContent, specId);
-        const specName = spec?.name ?? specId;
+        const purchaseName = (() => {
+          if (coinPackId) {
+            const pack = getStoreCoinPack(coinPackId);
+            return pack ? `${pack.priceLabel} Coin Pack` : coinPackId;
+          }
+          const spec = getSpecializationById(specializationsContent, specId);
+          return spec?.name ?? specId;
+        })();
         const discordExternalEventId = entitlementId
           ? `discord:${entitlementId}`
           : `discord:raw:${crypto.createHash("sha256").update(rawBody).digest("hex")}`;
@@ -3118,18 +3187,18 @@ import { theme } from "./ui/theme.js";
           externalEventId: discordExternalEventId,
           userId,
           serverId,
-          specId,
+          specId: purchaseId,
           status: "granted",
           purchasedAt: Date.now()
         });
-        const purchaseCount = getAllTimeSpecializationPurchaseCount(db, specId);
+        const purchaseCount = getAllTimeSpecializationPurchaseCount(db, purchaseId);
         await sendDevAlert({
           title: "Discord Store Purchase Alert!",
           description:
             `User: <@${userId}> (${userId})\n` +
-            `Specialization: ${specName} (${specId})\n` +
+            `Purchase: ${purchaseName} (${purchaseId})\n` +
             `Server: ${serverId}`,
-          footerText: `Specialization Purchases: ${purchaseCount.toLocaleString()}`,
+          footerText: `Purchase Count: ${purchaseCount.toLocaleString()}`,
           color: theme.colors.success
         });
       }

--- a/src/index.js
+++ b/src/index.js
@@ -3063,34 +3063,6 @@ import { theme } from "./ui/theme.js";
           billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
         });
 
-        if (takeoutStarted) {
-          await sendDevAlert({
-            title: "Take Out Subscription Started",
-            description:
-              `User: <@${userId}> (${userId})\n`
-              + `Perk: Take Out Counter (${perkId})\n`
-              + `Event: ${eventType}\n`
-              + `Server: ${subscriptionServerId}\n`
-              + `Monthly Coins Granted: ${monthlyGrantResult.granted ? monthlyGrantResult.amount : 0}c`,
-            footerText: `Entitlement: ${entitlementId || "unknown"}`,
-            color: theme.colors.success
-          });
-        }
-
-        if (takeoutEnded) {
-          await sendDevAlert({
-            title: "Take Out Subscription Ended",
-            description:
-              `User: <@${userId}> (${userId})\n`
-              + `Perk: Take Out Counter (${perkId})\n`
-              + `Event: ${eventType}\n`
-              + `Server: ${subscriptionServerId}\n`
-              + `Monthly Coins Granted: ${monthlyGrantResult.granted ? monthlyGrantResult.amount : 0}c`,
-            footerText: `Entitlement: ${entitlementId || "unknown"}`,
-            color: theme.colors.warning
-          });
-        }
-
         putIdempotentResult(db, {
           key: subscriptionIdempotencyKey,
           userId,
@@ -3105,6 +3077,38 @@ import { theme } from "./ui/theme.js";
             billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
           }
         });
+
+        if (takeoutStarted) {
+          await sendDevAlert({
+            title: "Take Out Subscription Started",
+            description:
+              `User: <@${userId}> (${userId})\n`
+              + `Perk: Take Out Counter (${perkId})\n`
+              + `Event: ${eventType}\n`
+              + `Server: ${subscriptionServerId}\n`
+              + `Monthly Coins Granted: ${monthlyGrantResult.granted ? monthlyGrantResult.amount : 0}c`,
+            footerText: `Entitlement: ${entitlementId || "unknown"}`,
+            color: theme.colors.success
+          }).catch((error) => {
+            webhookWarn("Discord: subscription start alert failed", error?.stack ?? String(error));
+          });
+        }
+
+        if (takeoutEnded) {
+          await sendDevAlert({
+            title: "Take Out Subscription Ended",
+            description:
+              `User: <@${userId}> (${userId})\n`
+              + `Perk: Take Out Counter (${perkId})\n`
+              + `Event: ${eventType}\n`
+              + `Server: ${subscriptionServerId}\n`
+              + `Monthly Coins Granted: ${monthlyGrantResult.granted ? monthlyGrantResult.amount : 0}c`,
+            footerText: `Entitlement: ${entitlementId || "unknown"}`,
+            color: theme.colors.warning
+          }).catch((error) => {
+            webhookWarn("Discord: subscription end alert failed", error?.stack ?? String(error));
+          });
+        }
 
         res.writeHead(200, { "content-type": "text/plain" });
         res.end(lifecycleResult.ok ? "ok" : "ignored");

--- a/src/index.js
+++ b/src/index.js
@@ -3372,6 +3372,7 @@ import { theme } from "./ui/theme.js";
       if (isNoodle || isNoodleDev || isNoodleSocial || isNoodleStaff || isNoodleUpgrades) {
         // Check if this button/select will show a modal
           const willShowModal = cid?.includes("pick:cook_select:") ||
+              cid?.includes("pick:takeout_cook_select:") ||
               cid?.includes("pick:forage_item_select:") ||
               cid?.includes("pick:fishing_item_select:") ||
               cid?.includes("action:party_create") ||

--- a/src/index.js
+++ b/src/index.js
@@ -2931,9 +2931,15 @@ import { theme } from "./ui/theme.js";
       const specId = resolveStoreBundleSpecId(skuId);
       const perkId = resolveSubscriptionPerkId(skuId);
 
-      if (!userId || (!specId && !perkId)) {
+      if (!userId) {
         res.writeHead(202, { "content-type": "text/plain" });
-        res.end("missing sku or user");
+        res.end("missing user");
+        return;
+      }
+
+      if (!specId && !perkId) {
+        res.writeHead(202, { "content-type": "text/plain" });
+        res.end("unsupported sku");
         return;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,13 @@ import { theme } from "./ui/theme.js";
   const { getKitchenUnlockState, KITCHEN_BROTH_RECIPES } = await import("./game/kitchen.js");
   const { getCustomEmojiEntries } = await import("./ui/icons.js");
   const { grantStoreBundle, resolveStoreBundleSpecId } = await import("./game/storeBundles.js");
+  const {
+    applySubscriptionEntitlementEvent,
+    applyMonthlySubscriptionCoinGrant,
+    hasActivePerk,
+    resolveSubscriptionBillingPeriodKey,
+    resolveSubscriptionPerkId
+  } = await import("./game/subscriptions.js");
   const { ensureSpecializationState, getSpecializationById } = await import("./game/specialization.js");
   const { getAvailableRecipes } = await import("./game/resilience.js");
   const {
@@ -1229,7 +1236,23 @@ import { theme } from "./ui/theme.js";
       skuId: data?.sku_id ?? data?.skuId ?? payload?.sku_id ?? payload?.skuId ?? null,
       userId: data?.user_id ?? data?.userId ?? payload?.user_id ?? payload?.userId ?? null,
       guildId: data?.guild_id ?? data?.guildId ?? payload?.guild_id ?? payload?.guildId ?? null,
-      entitlementId: data?.id ?? data?.entitlement_id ?? payload?.entitlement_id ?? payload?.id ?? null
+      entitlementId: data?.id ?? data?.entitlement_id ?? payload?.entitlement_id ?? payload?.id ?? null,
+      periodStartAt:
+        data?.starts_at
+        ?? data?.start_at
+        ?? data?.period_start
+        ?? data?.current_period_start
+        ?? payload?.starts_at
+        ?? payload?.period_start
+        ?? null,
+      periodEndAt:
+        data?.ends_at
+        ?? data?.end_at
+        ?? data?.period_end
+        ?? data?.current_period_end
+        ?? payload?.ends_at
+        ?? payload?.period_end
+        ?? null
     };
   }
 
@@ -2892,17 +2915,133 @@ import { theme } from "./ui/theme.js";
         return;
       }
 
-      const { eventType, skuId, userId, guildId, entitlementId } = extractEntitlementPayload(payload);
-      if (eventType !== "ENTITLEMENT_CREATE") {
-        res.writeHead(200, { "content-type": "text/plain" });
-        res.end("ignored");
+      const {
+        eventType,
+        skuId,
+        userId,
+        guildId,
+        entitlementId,
+        periodStartAt,
+        periodEndAt
+      } = extractEntitlementPayload(payload);
+      const specId = resolveStoreBundleSpecId(skuId);
+      const perkId = resolveSubscriptionPerkId(skuId);
+
+      if (!userId || (!specId && !perkId)) {
+        res.writeHead(202, { "content-type": "text/plain" });
+        res.end("missing sku or user");
         return;
       }
 
-      const specId = resolveStoreBundleSpecId(skuId);
-      if (!specId || !userId) {
-        res.writeHead(202, { "content-type": "text/plain" });
-        res.end("missing sku or user");
+      if (perkId) {
+        const billingPeriodKey = resolveSubscriptionBillingPeriodKey({
+          periodStartAt,
+          periodEndAt,
+          now: Date.now()
+        });
+        const subscriptionIdempotencyKey = (() => {
+          // Discord can reuse entitlement IDs across renewals; include billing period on updates.
+          if (eventType === "ENTITLEMENT_UPDATE") {
+            return entitlementId
+              ? `discord_subscription:${eventType}:${entitlementId}:${billingPeriodKey}`
+              : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
+          }
+          return entitlementId
+            ? `discord_subscription:${eventType}:${entitlementId}`
+            : `discord_subscription:${eventType}:${userId}:${perkId}:${skuId}:${billingPeriodKey}`;
+        })();
+
+        const cached = getIdempotentResult(db, subscriptionIdempotencyKey);
+        if (cached) {
+          res.writeHead(200, { "content-type": "text/plain" });
+          res.end("ok");
+          return;
+        }
+
+        const subscriptionServerId = guildId || getLatestServerIdForUser(db, userId);
+        if (!subscriptionServerId) {
+          webhookWarn("Discord: Missing server for subscription user", userId);
+          res.writeHead(202, { "content-type": "text/plain" });
+          res.end("missing server");
+          return;
+        }
+
+        let subscriptionPlayer = getPlayer(db, subscriptionServerId, userId);
+        if (!subscriptionPlayer) subscriptionPlayer = newPlayerProfile(userId);
+
+        const lifecycleResult = applySubscriptionEntitlementEvent(subscriptionPlayer, {
+          perkId,
+          eventType,
+          entitlementId,
+          periodStartAt,
+          periodEndAt,
+          now: Date.now()
+        });
+
+        let monthlyGrantResult = { ok: true, granted: false, amount: 0, billingPeriodKey: null };
+        if (lifecycleResult.ok && (eventType === "ENTITLEMENT_CREATE" || eventType === "ENTITLEMENT_UPDATE")) {
+          monthlyGrantResult = applyMonthlySubscriptionCoinGrant(subscriptionPlayer, {
+            perkId,
+            periodStartAt,
+            periodEndAt,
+            now: Date.now()
+          });
+        }
+
+        if (lifecycleResult.ok || monthlyGrantResult.granted) {
+          upsertPlayer(db, subscriptionServerId, userId, subscriptionPlayer, null, subscriptionPlayer.schema_version);
+        }
+
+        webhookInfo(
+          "Discord: Subscription entitlement result",
+          JSON.stringify({
+            ok: lifecycleResult.ok,
+            reason: lifecycleResult.reason ?? null,
+            eventType,
+            perkId,
+            userId,
+            serverId: subscriptionServerId,
+            active: hasActivePerk(subscriptionPlayer, perkId),
+            monthlyCoinsGranted: monthlyGrantResult.granted ? monthlyGrantResult.amount : 0,
+            billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
+          })
+        );
+
+        emitTelemetry("subscription_state_change", {
+          userId,
+          serverId: subscriptionServerId,
+          perkId,
+          eventType,
+          active: hasActivePerk(subscriptionPlayer, perkId),
+          lifecycleOk: Boolean(lifecycleResult.ok),
+          lifecycleReason: lifecycleResult.reason ?? null,
+          monthlyCoinsGranted: monthlyGrantResult.granted ? monthlyGrantResult.amount : 0,
+          billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
+        });
+
+        putIdempotentResult(db, {
+          key: subscriptionIdempotencyKey,
+          userId,
+          action: "discord_subscription_entitlement",
+          ttlSeconds: 60 * 60 * 24 * 30,
+          result: {
+            ok: Boolean(lifecycleResult.ok),
+            perkId,
+            eventType,
+            active: hasActivePerk(subscriptionPlayer, perkId),
+            monthlyCoinsGranted: monthlyGrantResult.granted ? monthlyGrantResult.amount : 0,
+            billingPeriodKey: monthlyGrantResult.billingPeriodKey ?? null
+          }
+        });
+
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end(lifecycleResult.ok ? "ok" : "ignored");
+        return;
+      }
+
+      if (eventType !== "ENTITLEMENT_CREATE") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("ignored");
         return;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ import { theme } from "./ui/theme.js";
     getLatestServerIdForUser,
     recordRecentSocialInteraction,
     recordStorePurchaseEvent,
-    getAllTimeSpecializationPurchaseCount
+    getAllTimeStorePurchaseCount
   } = await import("./db/index.js");
   const { checkRateLimit } = await import("./infra/rateLimit.js");
   const { emitTelemetry } = await import("./infra/telemetry.js");
@@ -833,11 +833,11 @@ import { theme } from "./ui/theme.js";
     if (!db) return;
 
     const baselineRows = [
-      { source: "bootstrap", externalEventId: "baseline-astral-caravan-1", userId: "legacy-seed", serverId: null, specId: "astral_caravan" },
-      { source: "bootstrap", externalEventId: "baseline-astral-caravan-2", userId: "legacy-seed", serverId: null, specId: "astral_caravan" },
-      { source: "bootstrap", externalEventId: "baseline-sakura-sweetheart-1", userId: "legacy-seed", serverId: null, specId: "sakura_sweetheart_noodle_atelier" },
-      { source: "bootstrap", externalEventId: "baseline-bloomwarden-garden-1", userId: "legacy-seed", serverId: null, specId: "bloomwarden_garden_hall" },
-      { source: "bootstrap", externalEventId: "baseline-elderwood-hearth-1", userId: "legacy-seed", serverId: null, specId: "elderwood_hearth" }
+      { source: "bootstrap", externalEventId: "baseline-astral-caravan-1", userId: "legacy-seed", serverId: null, purchaseId: "astral_caravan" },
+      { source: "bootstrap", externalEventId: "baseline-astral-caravan-2", userId: "legacy-seed", serverId: null, purchaseId: "astral_caravan" },
+      { source: "bootstrap", externalEventId: "baseline-sakura-sweetheart-1", userId: "legacy-seed", serverId: null, purchaseId: "sakura_sweetheart_noodle_atelier" },
+      { source: "bootstrap", externalEventId: "baseline-bloomwarden-garden-1", userId: "legacy-seed", serverId: null, purchaseId: "bloomwarden_garden_hall" },
+      { source: "bootstrap", externalEventId: "baseline-elderwood-hearth-1", userId: "legacy-seed", serverId: null, purchaseId: "elderwood_hearth" }
     ];
 
     let inserted = 0;
@@ -2772,11 +2772,11 @@ import { theme } from "./ui/theme.js";
             externalEventId: stripeExternalEventId,
             userId: discordId,
             serverId,
-            specId: purchaseId,
+            purchaseId,
             status: "granted",
             purchasedAt: Date.now()
           });
-          const purchaseCount = getAllTimeSpecializationPurchaseCount(db, purchaseId);
+          const purchaseCount = getAllTimeStorePurchaseCount(db, purchaseId);
           await sendDevAlert({
             title: "Stripe Store Purchase Alert!",
             description:
@@ -3190,11 +3190,11 @@ import { theme } from "./ui/theme.js";
           externalEventId: discordExternalEventId,
           userId,
           serverId,
-          specId: purchaseId,
+          purchaseId,
           status: "granted",
           purchasedAt: Date.now()
         });
-        const purchaseCount = getAllTimeSpecializationPurchaseCount(db, purchaseId);
+        const purchaseCount = getAllTimeStorePurchaseCount(db, purchaseId);
         await sendDevAlert({
           title: "Discord Store Purchase Alert!",
           description:

--- a/src/index.js
+++ b/src/index.js
@@ -1243,7 +1243,9 @@ import { theme } from "./ui/theme.js";
         ?? data?.period_start
         ?? data?.current_period_start
         ?? payload?.starts_at
+        ?? payload?.start_at
         ?? payload?.period_start
+        ?? payload?.current_period_start
         ?? null,
       periodEndAt:
         data?.ends_at
@@ -1251,7 +1253,9 @@ import { theme } from "./ui/theme.js";
         ?? data?.period_end
         ?? data?.current_period_end
         ?? payload?.ends_at
+        ?? payload?.end_at
         ?? payload?.period_end
+        ?? payload?.current_period_end
         ?? null
     };
   }

--- a/test/cook-picker-routing.test.js
+++ b/test/cook-picker-routing.test.js
@@ -62,3 +62,16 @@ test("Cook select handlers exist for both normal and takeout routes", () => {
     "Missing takeout cook select handler"
   );
 });
+
+test("Takeout serve does not consume main order board slots", () => {
+  const body = sliceBetween(
+    noodleSource,
+    "if (sub === \"takeout_serve\") {",
+    "if (sub === \"takeout_claim\") {"
+  );
+  assert.doesNotMatch(
+    body,
+    /markOrderConsumed\(/,
+    "Takeout serve should not mark main order board slots as consumed"
+  );
+});

--- a/test/cook-picker-routing.test.js
+++ b/test/cook-picker-routing.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const noodlePath = path.resolve(process.cwd(), "src/commands/noodle.js");
+const noodleSource = fs.readFileSync(noodlePath, "utf8");
+
+function sliceBetween(source, startToken, endToken) {
+  const startIdx = source.indexOf(startToken);
+  assert.notEqual(startIdx, -1, `Missing token: ${startToken}`);
+  const endIdx = source.indexOf(endToken, startIdx + startToken.length);
+  assert.notEqual(endIdx, -1, `Missing token: ${endToken}`);
+  return source.slice(startIdx, endIdx);
+}
+
+test("Cook picker uses normal cook select custom id", () => {
+  const body = sliceBetween(
+    noodleSource,
+    "function buildCookPickerPayload(",
+    "function getTakeoutRecipeNeedRows("
+  );
+  assert.match(
+    body,
+    /setCustomId\(`noodle:pick:cook_select:\$\{userId\}:\$\{safePage\}:\$\{Date\.now\(\)\.toString\(36\)\}`\)/,
+    "Normal cook picker should emit noodle:pick:cook_select"
+  );
+  assert.doesNotMatch(
+    body,
+    /setCustomId\(`noodle:pick:takeout_cook_select:/,
+    "Normal cook picker should not emit takeout cook custom id"
+  );
+});
+
+test("Takeout cook picker uses takeout cook select custom id", () => {
+  const body = sliceBetween(
+    noodleSource,
+    "function buildTakeoutCookPickerPayload(",
+    "function buildTakeoutServePickerPayload("
+  );
+  assert.match(
+    body,
+    /setCustomId\(`noodle:pick:takeout_cook_select:\$\{userId\}:\$\{safePage\}:\$\{Date\.now\(\)\.toString\(36\)\}`\)/,
+    "Takeout cook picker should emit noodle:pick:takeout_cook_select"
+  );
+  assert.doesNotMatch(
+    body,
+    /setCustomId\(`noodle:pick:cook_select:/,
+    "Takeout cook picker should not emit normal cook custom id"
+  );
+});
+
+test("Cook select handlers exist for both normal and takeout routes", () => {
+  assert.match(
+    noodleSource,
+    /if \(cid\.startsWith\("noodle:pick:cook_select:"\)\)/,
+    "Missing normal cook select handler"
+  );
+  assert.match(
+    noodleSource,
+    /if \(cid\.startsWith\("noodle:pick:takeout_cook_select:"\)\)/,
+    "Missing takeout cook select handler"
+  );
+});

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -10,6 +10,7 @@ import {
 } from "../src/game/discovery.js";
 import {
   CLUE_DUPLICATE_COINS,
+  DISCOVERY_PITY_NO_DROP_SERVES,
   DISCOVERY_TIER_UNLOCK_LEVEL,
   DISCOVERY_TIER_UNLOCK_REP,
   SCROLL_DUPLICATE_COINS
@@ -120,6 +121,86 @@ test("Discovery: getDiscoverableRecipes - respects tier gating", () => {
   assert.ok(recipeIds.includes("fancy_ramen"), "Should include rare recipe");
   assert.ok(!recipeIds.includes("epic_ramen"), "Should not include epic recipe");
   assert.ok(!recipeIds.includes("seasonal_ramen"), "Should not include seasonal recipe");
+});
+
+test("Discovery: getDiscoverableRecipes includes normal + current event recipes", () => {
+  const contentWithEvents = {
+    recipes: {
+      normal_recipe: {
+        recipe_id: "normal_recipe",
+        name: "Normal Recipe",
+        tier: "common",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      current_event_recipe: {
+        recipe_id: "current_event_recipe",
+        name: "Current Event Recipe",
+        tier: "common",
+        event_id: "event_summer",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      other_event_recipe: {
+        recipe_id: "other_event_recipe",
+        name: "Other Event Recipe",
+        tier: "common",
+        event_id: "event_winter",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      }
+    },
+    items: mockContent.items
+  };
+
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: [],
+    clues_owned: {},
+    scrolls_owned: {}
+  };
+
+  const discoverable = getDiscoverableRecipes(player, contentWithEvents, {
+    activeEventId: "event_summer"
+  }).map((r) => r.recipe_id);
+
+  assert.ok(discoverable.includes("normal_recipe"), "Expected normal recipe to remain discoverable");
+  assert.ok(discoverable.includes("current_event_recipe"), "Expected current event recipe to be discoverable");
+  assert.ok(!discoverable.includes("other_event_recipe"), "Expected non-active event recipe to be excluded");
+});
+
+test("Discovery: getDiscoverableRecipes excludes event recipes without active event", () => {
+  const contentWithEvent = {
+    recipes: {
+      normal_recipe: {
+        recipe_id: "normal_recipe",
+        name: "Normal Recipe",
+        tier: "common",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      event_recipe: {
+        recipe_id: "event_recipe",
+        name: "Event Recipe",
+        tier: "common",
+        event_id: "event_summer",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      }
+    },
+    items: mockContent.items
+  };
+
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: [],
+    clues_owned: {},
+    scrolls_owned: {}
+  };
+
+  const discoverable = getDiscoverableRecipes(player, contentWithEvent, {
+    activeEventId: null
+  }).map((r) => r.recipe_id);
+
+  assert.ok(discoverable.includes("normal_recipe"));
+  assert.ok(!discoverable.includes("event_recipe"));
 });
 
 test("Discovery: applyDiscovery - new clue is added", () => {
@@ -572,4 +653,142 @@ test("Discovery: serve scroll roll can produce duplicate even when undiscovered 
   const result = applyDiscovery(player, discoveries[0], content, () => 0.9);
   assert.equal(result.isDuplicate, true);
   assert.equal(result.reward, `+${SCROLL_DUPLICATE_COINS}c (duplicate scroll)`);
+});
+
+test("Discovery: rollRecipeDiscovery can drop clue for current event recipe", () => {
+  const contentWithCurrentEventOnly = {
+    recipes: {
+      known_normal: {
+        recipe_id: "known_normal",
+        name: "Known Normal",
+        tier: "common",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      event_recipe: {
+        recipe_id: "event_recipe",
+        name: "Event Recipe",
+        tier: "common",
+        event_id: "event_summer",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      }
+    },
+    items: mockContent.items
+  };
+
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: ["known_normal"],
+    clues_owned: {},
+    scrolls_owned: {}
+  };
+
+  const seq = [0, 0, 0.5, 0, 0.999];
+  const rng = () => (seq.length ? seq.shift() : 0);
+  const discoveries = rollRecipeDiscovery({
+    player,
+    content: contentWithCurrentEventOnly,
+    npcArchetype: null,
+    tier: "common",
+    rng,
+    activeEventId: "event_summer"
+  });
+
+  assert.equal(discoveries.length, 1);
+  assert.equal(discoveries[0].type, "clue");
+  assert.equal(discoveries[0].recipeId, "event_recipe");
+});
+
+test("Discovery: rollRecipeDiscovery can drop scroll for current event recipe", () => {
+  const contentWithCurrentEventOnly = {
+    recipes: {
+      known_normal: {
+        recipe_id: "known_normal",
+        name: "Known Normal",
+        tier: "common",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      },
+      event_recipe: {
+        recipe_id: "event_recipe",
+        name: "Event Recipe",
+        tier: "common",
+        event_id: "event_summer",
+        ingredients: [{ item_id: "soy_broth", qty: 1 }]
+      }
+    },
+    items: mockContent.items
+  };
+
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: ["known_normal"],
+    clues_owned: {},
+    scrolls_owned: {}
+  };
+
+  const seq = [0, 0.999, 0, 0];
+  const rng = () => (seq.length ? seq.shift() : 0);
+  const discoveries = rollRecipeDiscovery({
+    player,
+    content: contentWithCurrentEventOnly,
+    npcArchetype: null,
+    tier: "common",
+    rng,
+    activeEventId: "event_summer"
+  });
+
+  assert.equal(discoveries.length, 1);
+  assert.equal(discoveries[0].type, "scroll");
+  assert.equal(discoveries[0].recipeId, "event_recipe");
+});
+
+test("Discovery: pity clue grants after long no-drop streak", () => {
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: [],
+    clues_owned: {},
+    scrolls_owned: {}
+  };
+
+  let discoveries = [];
+  for (let i = 0; i < DISCOVERY_PITY_NO_DROP_SERVES; i++) {
+    discoveries = rollRecipeDiscovery({
+      player,
+      content: mockContent,
+      npcArchetype: null,
+      tier: "common",
+      rng: () => 0.999
+    });
+  }
+
+  assert.equal(discoveries.length, 1);
+  assert.equal(discoveries[0].type, "clue");
+  assert.equal(Boolean(discoveries[0].pityGranted), true);
+  assert.equal(player.discovery?.no_drop_serve_streak ?? 0, 0);
+});
+
+test("Discovery: no-drop streak increments before pity threshold", () => {
+  const player = {
+    shop_level: 99,
+    rep: 999,
+    known_recipes: [],
+    clues_owned: {},
+    scrolls_owned: {}
+  };
+
+  const attempts = Math.max(1, DISCOVERY_PITY_NO_DROP_SERVES - 1);
+  for (let i = 0; i < attempts; i++) {
+    const discoveries = rollRecipeDiscovery({
+      player,
+      content: mockContent,
+      npcArchetype: null,
+      tier: "common",
+      rng: () => 0.999
+    });
+    assert.equal(discoveries.length, 0);
+  }
+
+  assert.equal(player.discovery?.no_drop_serve_streak ?? 0, attempts);
 });

--- a/test/social.test.js
+++ b/test/social.test.js
@@ -27,6 +27,7 @@ import {
   inviteUserToParty,
   leaveParty,
   getParty,
+  repairPartyRecord,
   getUserActiveParty,
   transferTip,
   getUserTipStats,
@@ -235,6 +236,54 @@ test("Party: getUserActiveParty can be scoped by server", dbTestOpts, () => {
 
   const invited = inviteUserToParty(db, "server2", server2Party.partyId, "user2");
   assert.equal(invited.partyId, server2Party.partyId);
+
+  db.close();
+});
+
+test("Party: repair reassigns leader when leader is not active member", dbTestOpts, () => {
+  const db = setupTestDb();
+  const { partyId } = createParty(db, "server1", "leader1", "Test Party");
+  joinParty(db, "server1", partyId, "user2");
+
+  // Create an inconsistent party: active party but inactive leader membership row.
+  db.prepare("UPDATE party_members SET left_at = ? WHERE party_id = ? AND user_id = ?")
+    .run(nowTs(), partyId, "leader1");
+
+  const repaired = repairPartyRecord(db, partyId, "server1");
+  const party = getParty(db, partyId);
+
+  assert.equal(repaired.repaired, true);
+  assert.ok(repaired.changes.includes("leader:reassigned_to_active_member"));
+  assert.equal(party.leader_user_id, "user2");
+  assert.equal(party.status, "active");
+
+  db.close();
+});
+
+test("Party: repair aligns party status with member rows", dbTestOpts, () => {
+  const db = setupTestDb();
+
+  // Active party with no active members should become disbanded.
+  const p1 = createParty(db, "server1", "leaderA", "Active No Members");
+  db.prepare("UPDATE party_members SET left_at = ? WHERE party_id = ?")
+    .run(nowTs(), p1.partyId);
+  const repaired1 = repairPartyRecord(db, p1.partyId, "server1");
+  const party1 = getParty(db, p1.partyId);
+
+  assert.equal(repaired1.repaired, true);
+  assert.equal(party1.status, "disbanded");
+  assert.ok(party1.disbanded_at);
+
+  // Disbanded party with active members should become active.
+  const p2 = createParty(db, "server1", "leaderB", "Disbanded With Members");
+  db.prepare("UPDATE guild_parties SET status = 'disbanded', disbanded_at = ? WHERE party_id = ?")
+    .run(nowTs(), p2.partyId);
+  const repaired2 = repairPartyRecord(db, p2.partyId, "server1");
+  const party2 = getParty(db, p2.partyId);
+
+  assert.equal(repaired2.repaired, true);
+  assert.equal(party2.status, "active");
+  assert.equal(party2.disbanded_at, null);
 
   db.close();
 });

--- a/test/storeCoinPacks.test.js
+++ b/test/storeCoinPacks.test.js
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   getStoreCoinPack,
   resolveStoreCoinPackIdFromSku,
+  resolveStoreCoinPackIdFromMetadata,
   grantStoreCoinPack
 } from "../src/game/storeCoinPacks.js";
 
@@ -39,4 +40,15 @@ test("Store coin packs: default Discord SKU mapping resolves all configured pack
   assert.equal(resolveStoreCoinPackIdFromSku("1511191985644507336"), "coin_pack_099");
   assert.equal(resolveStoreCoinPackIdFromSku("1511192707119321109"), "coin_pack_199");
   assert.equal(resolveStoreCoinPackIdFromSku("1511192852288376884"), "coin_pack_499");
+});
+
+test("Store coin packs: metadata sku_id resolves through SKU mapping", () => {
+  assert.equal(
+    resolveStoreCoinPackIdFromMetadata({ sku_id: "1511191985644507336" }),
+    "coin_pack_099"
+  );
+  assert.equal(
+    resolveStoreCoinPackIdFromMetadata({ sku: "1511192707119321109" }),
+    "coin_pack_199"
+  );
 });

--- a/test/storeCoinPacks.test.js
+++ b/test/storeCoinPacks.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getStoreCoinPack,
+  resolveStoreCoinPackIdFromSku,
+  grantStoreCoinPack
+} from "../src/game/storeCoinPacks.js";
+
+test("Store coin packs: catalog exposes expected packs", () => {
+  const small = getStoreCoinPack("coin_pack_099");
+  const medium = getStoreCoinPack("coin_pack_199");
+  const large = getStoreCoinPack("coin_pack_499");
+
+  assert.equal(small?.coins, 10_000);
+  assert.equal(medium?.coins, 25_000);
+  assert.equal(large?.coins, 100_000);
+});
+
+test("Store coin packs: grant credits coins and lifetime earnings", () => {
+  const player = { coins: 500, lifetime: { coins_earned: 1_500 } };
+  const result = grantStoreCoinPack({ player, coinPackId: "coin_pack_199" });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.coinsGranted, 25_000);
+  assert.equal(player.coins, 25_500);
+  assert.equal(player.lifetime.coins_earned, 26_500);
+});
+
+test("Store coin packs: unknown pack returns an error", () => {
+  const player = { coins: 0, lifetime: { coins_earned: 0 } };
+  const result = grantStoreCoinPack({ player, coinPackId: "missing_pack" });
+
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /not found/i);
+});
+
+test("Store coin packs: default Discord SKU mapping resolves all configured packs", () => {
+  assert.equal(resolveStoreCoinPackIdFromSku("1511191985644507336"), "coin_pack_099");
+  assert.equal(resolveStoreCoinPackIdFromSku("1511192707119321109"), "coin_pack_199");
+  assert.equal(resolveStoreCoinPackIdFromSku("1511192852288376884"), "coin_pack_499");
+});

--- a/test/storeCoinPacks.test.js
+++ b/test/storeCoinPacks.test.js
@@ -52,3 +52,10 @@ test("Store coin packs: metadata sku_id resolves through SKU mapping", () => {
     "coin_pack_199"
   );
 });
+
+test("Store coin packs: metadata spec_id supports direct coin pack ids", () => {
+  assert.equal(
+    resolveStoreCoinPackIdFromMetadata({ spec_id: "coin_pack_199" }),
+    "coin_pack_199"
+  );
+});

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -131,7 +131,7 @@ test("Subscriptions: monthly coin grant is idempotent per billing period", () =>
   assert.equal(player.coins, 100 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
 });
 
-test("Subscriptions: both perks grant monthly coins independently", () => {
+test("Subscriptions: 24/7 House does not grant monthly coins", () => {
   const player = { coins: 0, lifetime: { coins_earned: 0 } };
   const periodStart = 1_700_000_000_000;
 
@@ -140,16 +140,29 @@ test("Subscriptions: both perks grant monthly coins independently", () => {
     periodStartAt: periodStart,
     now: periodStart + 1000
   });
+
+  assert.equal(houseGrant.ok, true);
+  assert.equal(houseGrant.granted, false);
+  assert.equal(houseGrant.amount, 0);
+  assert.equal(player.coins, 0);
+  assert.equal(player.lifetime.coins_earned, 0);
+});
+
+test("Subscriptions: Take Out Counter still grants monthly coins", () => {
+  const player = { coins: 0, lifetime: { coins_earned: 0 } };
+  const periodStart = 1_700_000_000_000;
+
   const takeoutGrant = applyMonthlySubscriptionCoinGrant(player, {
     perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
     periodStartAt: periodStart,
     now: periodStart + 1000
   });
 
-  assert.equal(houseGrant.granted, true);
+  assert.equal(takeoutGrant.ok, true);
   assert.equal(takeoutGrant.granted, true);
-  assert.equal(player.coins, SUBSCRIPTION_MONTHLY_COIN_GRANT * 2);
-  assert.equal(player.lifetime.coins_earned, SUBSCRIPTION_MONTHLY_COIN_GRANT * 2);
+  assert.equal(takeoutGrant.amount, SUBSCRIPTION_MONTHLY_COIN_GRANT);
+  assert.equal(player.coins, SUBSCRIPTION_MONTHLY_COIN_GRANT);
+  assert.equal(player.lifetime.coins_earned, SUBSCRIPTION_MONTHLY_COIN_GRANT);
 });
 
 test("Subscriptions: vote-granted 24/7 House increases active order cap", () => {

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -176,7 +176,7 @@ test("Subscriptions: vote-granted 24/7 House grants unlimited market stock behav
   assert.equal(hasUnlimitedMarketStock(player, now + HOUSE_247_VOTE_DURATION_MS + 1), false);
 });
 
-test("Subscriptions: entitlement-only 24/7 perk no longer unlocks market stock", () => {
+test("Subscriptions: entitlement 24/7 perk unlocks market stock and order cap", () => {
   const player = {};
   const now = 1_700_000_000_000;
 
@@ -188,5 +188,6 @@ test("Subscriptions: entitlement-only 24/7 perk no longer unlocks market stock",
   });
 
   assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now + 1), true);
-  assert.equal(hasUnlimitedMarketStock(player, now + 1), false);
+  assert.equal(hasUnlimitedMarketStock(player, now + 1), true);
+  assert.equal(getOrderAcceptCap(player, now + 1), ORDER_ACCEPT_CAP_HOUSE_247);
 });

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -1,0 +1,184 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ORDER_ACCEPT_CAP_BASE,
+  ORDER_ACCEPT_CAP_HOUSE_247,
+  SUBSCRIPTION_PERKS,
+  SUBSCRIPTION_MONTHLY_COIN_GRANT,
+  applySubscriptionEntitlementEvent,
+  applyMonthlySubscriptionCoinGrant,
+  createDefaultSubscriptionState,
+  ensureSubscriptionState,
+  getOrderAcceptCap,
+  hasUnlimitedMarketStock,
+  hasActivePerk
+} from "../src/game/subscriptions.js";
+
+test("Subscriptions: default state contains both perks", () => {
+  const state = createDefaultSubscriptionState();
+  assert.equal(state.perks[SUBSCRIPTION_PERKS.HOUSE_247].active, false);
+  assert.equal(state.perks[SUBSCRIPTION_PERKS.TAKEOUT_COUNTER].active, false);
+});
+
+test("Subscriptions: ensureSubscriptionState repairs malformed player state", () => {
+  const player = { subscriptions: { perks: { house_247: { active: true } } } };
+  ensureSubscriptionState(player);
+
+  assert.equal(typeof player.subscriptions.perks[SUBSCRIPTION_PERKS.HOUSE_247], "object");
+  assert.equal(typeof player.subscriptions.perks[SUBSCRIPTION_PERKS.TAKEOUT_COUNTER], "object");
+});
+
+test("Subscriptions: entitlement create activates perk and respects period end", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+  const later = now + (30 * 24 * 60 * 60 * 1000);
+
+  const result = applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_1",
+    periodStartAt: now,
+    periodEndAt: later,
+    now
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.active, true);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now + 1000), true);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, later + 1), false);
+});
+
+test("Subscriptions: entitlement update refreshes period timestamps", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_2",
+    periodStartAt: now,
+    periodEndAt: now + 1000,
+    now
+  });
+
+  const updated = applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_UPDATE",
+    entitlementId: "ent_2",
+    periodStartAt: now + 1000,
+    periodEndAt: now + 2000,
+    now: now + 1000
+  });
+
+  assert.equal(updated.ok, true);
+  assert.equal(updated.state.period_end_at, now + 2000);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.TAKEOUT_COUNTER, now + 1500), true);
+});
+
+test("Subscriptions: entitlement delete deactivates perk", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_3",
+    periodEndAt: now + 10_000,
+    now
+  });
+
+  const deleted = applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_DELETE",
+    entitlementId: "ent_3",
+    now: now + 2_000
+  });
+
+  assert.equal(deleted.ok, true);
+  assert.equal(deleted.active, false);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now + 2_001), false);
+});
+
+test("Subscriptions: monthly coin grant is idempotent per billing period", () => {
+  const player = { coins: 100, lifetime: { coins_earned: 50 } };
+  const periodStart = 1_700_000_000_000;
+  const periodEnd = periodStart + (30 * 24 * 60 * 60 * 1000);
+
+  const first = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    periodStartAt: periodStart,
+    periodEndAt: periodEnd,
+    now: periodStart + 1000
+  });
+  assert.equal(first.ok, true);
+  assert.equal(first.granted, true);
+  assert.equal(first.amount, SUBSCRIPTION_MONTHLY_COIN_GRANT);
+  assert.equal(player.coins, 100 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
+  assert.equal(player.lifetime.coins_earned, 50 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
+
+  const second = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    periodStartAt: periodStart,
+    periodEndAt: periodEnd,
+    now: periodStart + 2000
+  });
+  assert.equal(second.ok, true);
+  assert.equal(second.granted, false);
+  assert.equal(second.amount, 0);
+  assert.equal(player.coins, 100 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
+});
+
+test("Subscriptions: both perks grant monthly coins independently", () => {
+  const player = { coins: 0, lifetime: { coins_earned: 0 } };
+  const periodStart = 1_700_000_000_000;
+
+  const houseGrant = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    periodStartAt: periodStart,
+    now: periodStart + 1000
+  });
+  const takeoutGrant = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    periodStartAt: periodStart,
+    now: periodStart + 1000
+  });
+
+  assert.equal(houseGrant.granted, true);
+  assert.equal(takeoutGrant.granted, true);
+  assert.equal(player.coins, SUBSCRIPTION_MONTHLY_COIN_GRANT * 2);
+  assert.equal(player.lifetime.coins_earned, SUBSCRIPTION_MONTHLY_COIN_GRANT * 2);
+});
+
+test("Subscriptions: 24/7 House increases active order cap", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  assert.equal(getOrderAcceptCap(player, now), ORDER_ACCEPT_CAP_BASE);
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    periodEndAt: now + 1000,
+    now
+  });
+
+  assert.equal(getOrderAcceptCap(player, now + 1), ORDER_ACCEPT_CAP_HOUSE_247);
+});
+
+test("Subscriptions: 24/7 House grants unlimited market stock behavior", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
+  assert.equal(hasUnlimitedMarketStock(player, now), false);
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    periodEndAt: now + 1000,
+    now
+  });
+
+  assert.equal(hasUnlimitedMarketStock(player, now + 1), true);
+  assert.equal(hasUnlimitedMarketStock(player, now + 1001), false);
+});

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -6,10 +6,12 @@ import {
   ORDER_ACCEPT_CAP_HOUSE_247,
   SUBSCRIPTION_PERKS,
   SUBSCRIPTION_MONTHLY_COIN_GRANT,
+  HOUSE_247_VOTE_DURATION_MS,
   applySubscriptionEntitlementEvent,
   applyMonthlySubscriptionCoinGrant,
   createDefaultSubscriptionState,
   ensureSubscriptionState,
+  grantHouse247VoteAccess,
   getOrderAcceptCap,
   hasUnlimitedMarketStock,
   hasActivePerk
@@ -106,7 +108,7 @@ test("Subscriptions: monthly coin grant is idempotent per billing period", () =>
   const periodEnd = periodStart + (30 * 24 * 60 * 60 * 1000);
 
   const first = applyMonthlySubscriptionCoinGrant(player, {
-    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
     periodStartAt: periodStart,
     periodEndAt: periodEnd,
     now: periodStart + 1000
@@ -118,7 +120,7 @@ test("Subscriptions: monthly coin grant is idempotent per billing period", () =>
   assert.equal(player.lifetime.coins_earned, 50 + SUBSCRIPTION_MONTHLY_COIN_GRANT);
 
   const second = applyMonthlySubscriptionCoinGrant(player, {
-    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
     periodStartAt: periodStart,
     periodEndAt: periodEnd,
     now: periodStart + 2000
@@ -150,35 +152,41 @@ test("Subscriptions: both perks grant monthly coins independently", () => {
   assert.equal(player.lifetime.coins_earned, SUBSCRIPTION_MONTHLY_COIN_GRANT * 2);
 });
 
-test("Subscriptions: 24/7 House increases active order cap", () => {
+test("Subscriptions: vote-granted 24/7 House increases active order cap", () => {
   const player = {};
   const now = 1_700_000_000_000;
 
   assert.equal(getOrderAcceptCap(player, now), ORDER_ACCEPT_CAP_BASE);
 
-  applySubscriptionEntitlementEvent(player, {
-    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
-    eventType: "ENTITLEMENT_CREATE",
-    periodEndAt: now + 1000,
-    now
-  });
+  grantHouse247VoteAccess(player, { now });
 
   assert.equal(getOrderAcceptCap(player, now + 1), ORDER_ACCEPT_CAP_HOUSE_247);
+  assert.equal(getOrderAcceptCap(player, now + HOUSE_247_VOTE_DURATION_MS + 1), ORDER_ACCEPT_CAP_BASE);
 });
 
-test("Subscriptions: 24/7 House grants unlimited market stock behavior", () => {
+test("Subscriptions: vote-granted 24/7 House grants unlimited market stock behavior", () => {
   const player = {};
   const now = 1_700_000_000_000;
 
   assert.equal(hasUnlimitedMarketStock(player, now), false);
 
+  grantHouse247VoteAccess(player, { now });
+
+  assert.equal(hasUnlimitedMarketStock(player, now + 1), true);
+  assert.equal(hasUnlimitedMarketStock(player, now + HOUSE_247_VOTE_DURATION_MS + 1), false);
+});
+
+test("Subscriptions: entitlement-only 24/7 perk no longer unlocks market stock", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+
   applySubscriptionEntitlementEvent(player, {
     perkId: SUBSCRIPTION_PERKS.HOUSE_247,
     eventType: "ENTITLEMENT_CREATE",
-    periodEndAt: now + 1000,
+    periodEndAt: now + HOUSE_247_VOTE_DURATION_MS,
     now
   });
 
-  assert.equal(hasUnlimitedMarketStock(player, now + 1), true);
-  assert.equal(hasUnlimitedMarketStock(player, now + 1001), false);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now + 1), true);
+  assert.equal(hasUnlimitedMarketStock(player, now + 1), false);
 });

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -51,6 +51,28 @@ test("Subscriptions: entitlement create activates perk and respects period end",
   assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, later + 1), false);
 });
 
+test("Subscriptions: entitlement with future period start is not active until start", () => {
+  const player = {};
+  const now = 1_700_000_000_000;
+  const startsAt = now + 60_000;
+  const endsAt = now + 120_000;
+
+  const result = applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.HOUSE_247,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_future",
+    periodStartAt: startsAt,
+    periodEndAt: endsAt,
+    now
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.active, false);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, now + 1_000), false);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, startsAt + 1), true);
+  assert.equal(hasActivePerk(player, SUBSCRIPTION_PERKS.HOUSE_247, endsAt + 1), false);
+});
+
 test("Subscriptions: entitlement update refreshes period timestamps", () => {
   const player = {};
   const now = 1_700_000_000_000;
@@ -107,6 +129,15 @@ test("Subscriptions: monthly coin grant is idempotent per billing period", () =>
   const periodStart = 1_700_000_000_000;
   const periodEnd = periodStart + (30 * 24 * 60 * 60 * 1000);
 
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_takeout_idempotent",
+    periodStartAt: periodStart,
+    periodEndAt: periodEnd,
+    now: periodStart
+  });
+
   const first = applyMonthlySubscriptionCoinGrant(player, {
     perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
     periodStartAt: periodStart,
@@ -151,10 +182,21 @@ test("Subscriptions: 24/7 House does not grant monthly coins", () => {
 test("Subscriptions: Take Out Counter still grants monthly coins", () => {
   const player = { coins: 0, lifetime: { coins_earned: 0 } };
   const periodStart = 1_700_000_000_000;
+  const periodEnd = periodStart + (30 * 24 * 60 * 60 * 1000);
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_takeout_grant",
+    periodStartAt: periodStart,
+    periodEndAt: periodEnd,
+    now: periodStart
+  });
 
   const takeoutGrant = applyMonthlySubscriptionCoinGrant(player, {
     perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
     periodStartAt: periodStart,
+    periodEndAt: periodEnd,
     now: periodStart + 1000
   });
 
@@ -163,6 +205,64 @@ test("Subscriptions: Take Out Counter still grants monthly coins", () => {
   assert.equal(takeoutGrant.amount, SUBSCRIPTION_MONTHLY_COIN_GRANT);
   assert.equal(player.coins, SUBSCRIPTION_MONTHLY_COIN_GRANT);
   assert.equal(player.lifetime.coins_earned, SUBSCRIPTION_MONTHLY_COIN_GRANT);
+});
+
+test("Subscriptions: monthly grant is skipped before period start", () => {
+  const player = { coins: 0, lifetime: { coins_earned: 0 } };
+  const now = 1_700_000_000_000;
+  const startsAt = now + 60_000;
+  const endsAt = now + (30 * 24 * 60 * 60 * 1000);
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_takeout_future",
+    periodStartAt: startsAt,
+    periodEndAt: endsAt,
+    now
+  });
+
+  const grant = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    periodStartAt: startsAt,
+    periodEndAt: endsAt,
+    now: now + 1_000
+  });
+
+  assert.equal(grant.ok, true);
+  assert.equal(grant.granted, false);
+  assert.equal(grant.amount, 0);
+  assert.equal(player.coins, 0);
+  assert.equal(player.lifetime.coins_earned, 0);
+});
+
+test("Subscriptions: monthly grant is skipped after period end", () => {
+  const player = { coins: 0, lifetime: { coins_earned: 0 } };
+  const now = 1_700_000_000_000;
+  const startsAt = now - (30 * 24 * 60 * 60 * 1000);
+  const endsAt = now - 1_000;
+
+  applySubscriptionEntitlementEvent(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    eventType: "ENTITLEMENT_CREATE",
+    entitlementId: "ent_takeout_expired",
+    periodStartAt: startsAt,
+    periodEndAt: endsAt,
+    now
+  });
+
+  const grant = applyMonthlySubscriptionCoinGrant(player, {
+    perkId: SUBSCRIPTION_PERKS.TAKEOUT_COUNTER,
+    periodStartAt: startsAt,
+    periodEndAt: endsAt,
+    now
+  });
+
+  assert.equal(grant.ok, true);
+  assert.equal(grant.granted, false);
+  assert.equal(grant.amount, 0);
+  assert.equal(player.coins, 0);
+  assert.equal(player.lifetime.coins_earned, 0);
 });
 
 test("Subscriptions: vote-granted 24/7 House increases active order cap", () => {

--- a/test/takeout.test.js
+++ b/test/takeout.test.js
@@ -245,6 +245,21 @@ test("Takeout: snapshot distribution is deterministic and sums to board total", 
   assert.ok(Math.max(...hourlyTotals) - Math.min(...hourlyTotals) <= 1);
 });
 
+test("Takeout: snapshot honors custom hour count without sparse arrays", () => {
+  const snapshot = buildTakeoutShiftSnapshot(["r1", "r2"], { hours: 6, totalOrders: 60 });
+  assert.equal(snapshot.length, 2);
+
+  for (const row of snapshot) {
+    assert.equal(row.hourly_order_counts.length, 6);
+    assert.ok(row.hourly_order_counts.every((v) => Number.isFinite(v)));
+  }
+
+  const hourlyTotals = Array.from({ length: 6 }, (_, hour) =>
+    snapshot.reduce((sum, row) => sum + (row.hourly_order_counts[hour] ?? 0), 0)
+  );
+  assert.equal(hourlyTotals.reduce((sum, count) => sum + count, 0), 60);
+});
+
 test("Takeout: non-24/7 users snapshot board-total-at-open", () => {
   const player = { coins: 50_000, takeout: createDefaultTakeoutState() };
   player.takeout.menu_recipe_ids = ["r1", "r2"];

--- a/test/takeout.test.js
+++ b/test/takeout.test.js
@@ -1,0 +1,431 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  TAKEOUT_SHIFT_DURATION_MS,
+  TAKEOUT_SNAPSHOT_MAX_ORDERS,
+  TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS,
+  TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS,
+  createDefaultTakeoutState,
+  ensureTakeoutState,
+  getTakeoutMenuLimits,
+  setTakeoutMenu,
+  openTakeoutShift,
+  isTakeoutShiftActive,
+  finishTakeoutShiftIfEnded,
+  claimTakeoutEarnings,
+  buildTakeoutShiftSnapshot,
+  computeTakeoutRequiredIngredients,
+  computeTakeoutOperatingCost,
+  startTakeoutShiftWithCoverage,
+  processTakeoutCatchup
+} from "../src/game/takeout.js";
+
+test("Takeout: default state shape", () => {
+  const state = createDefaultTakeoutState();
+  assert.deepEqual(state.menu_recipe_ids, []);
+  assert.equal(state.shift.status, "inactive");
+  assert.equal(state.earned_unclaimed_coins, 0);
+});
+
+test("Takeout: menu limits allow fewer than 5 when learned recipes are below 5", () => {
+  const limits = getTakeoutMenuLimits(3);
+  assert.equal(limits.minRequired, 3);
+  assert.equal(limits.maxAllowed, 3);
+});
+
+test("Takeout: set menu enforces min/max and learned recipe membership", () => {
+  const player = {};
+  ensureTakeoutState(player);
+
+  const tooSmall = setTakeoutMenu(player, {
+    menuRecipeIds: ["r1"],
+    learnedRecipeIds: ["r1", "r2", "r3", "r4", "r5", "r6"]
+  });
+  assert.equal(tooSmall.ok, false);
+  assert.equal(tooSmall.reason, "menu_too_small");
+
+  const ok = setTakeoutMenu(player, {
+    menuRecipeIds: ["r1", "r2", "r3", "r4", "r5", "invalid"],
+    learnedRecipeIds: ["r1", "r2", "r3", "r4", "r5", "r6"]
+  });
+  assert.equal(ok.ok, true);
+  assert.deepEqual(player.takeout.menu_recipe_ids, ["r1", "r2", "r3", "r4", "r5"]);
+});
+
+test("Takeout: finished shift can immediately be reopened for another 12h", () => {
+  const player = {
+    takeout: {
+      menu_recipe_ids: ["r1", "r2", "r3", "r4", "r5"],
+      shift: {
+        status: "active",
+        started_at: 100,
+        ends_at: 200,
+        last_processed_hour_index: 12,
+        last_tick_at: 200,
+        operating_cost_paid_marker: null,
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: 200
+    }
+  };
+
+  const endedNow = 300;
+  const ended = finishTakeoutShiftIfEnded(player, endedNow);
+  assert.equal(ended, true);
+  assert.equal(player.takeout.shift.status, "inactive");
+
+  const reopened = openTakeoutShift(player, { now: endedNow });
+  assert.equal(reopened.ok, true);
+  assert.equal(player.takeout.shift.status, "active");
+  assert.equal(player.takeout.shift.started_at, endedNow);
+  assert.equal(player.takeout.shift.ends_at, endedNow + TAKEOUT_SHIFT_DURATION_MS);
+  assert.equal(isTakeoutShiftActive(player, endedNow + 1), true);
+});
+
+test("Takeout: claim earnings moves coins and is idempotent when empty", () => {
+  const player = {
+    coins: 10,
+    lifetime: { coins_earned: 5 },
+    takeout: {
+      menu_recipe_ids: [],
+      shift: {
+        status: "inactive",
+        started_at: null,
+        ends_at: null,
+        last_processed_hour_index: 0,
+        last_tick_at: null,
+        operating_cost_paid_marker: null,
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 250,
+      updated_at: null
+    }
+  };
+
+  const first = claimTakeoutEarnings(player);
+  assert.equal(first.ok, true);
+  assert.equal(first.amount, 250);
+  assert.equal(player.coins, 260);
+  assert.equal(player.lifetime.coins_earned, 255);
+  assert.equal(player.takeout.earned_unclaimed_coins, 0);
+
+  const second = claimTakeoutEarnings(player);
+  assert.equal(second.ok, false);
+  assert.equal(second.reason, "nothing_to_claim");
+});
+
+test("Takeout: fixed operating cost computed from 12h snapshot ingredient totals", () => {
+  const snapshot = [
+    { recipe_id: "r1", total_orders: 2, visible_order_count: 2, hourly_order_counts: [1, 1] },
+    { recipe_id: "r2", total_orders: 1, visible_order_count: 1, hourly_order_counts: [1] }
+  ];
+  const recipes = {
+    r1: { ingredients: [{ item_id: "i1", qty: 2 }, { item_id: "i2", qty: 1 }] },
+    r2: { ingredients: [{ item_id: "i1", qty: 1 }] }
+  };
+  const required = computeTakeoutRequiredIngredients(snapshot, recipes);
+  assert.deepEqual(required, { i1: 5, i2: 2 });
+
+  const cost = computeTakeoutOperatingCost(required, {
+    marketPrices: { i1: 3, i2: 4 },
+    items: {}
+  });
+  assert.equal(cost, 23);
+});
+
+test("Takeout: shift cannot start when player cannot afford fixed operating cost", () => {
+  const player = {
+    coins: 5,
+    takeout: {
+      menu_recipe_ids: ["r1"],
+      shift: {
+        status: "inactive",
+        started_at: null,
+        ends_at: null,
+        last_processed_hour_index: 0,
+        last_tick_at: null,
+        operating_cost_paid_marker: null,
+        operating_cost: 0,
+        required_ingredients: {},
+        covered_ingredients: {},
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: null
+    }
+  };
+
+  const result = startTakeoutShiftWithCoverage(player, {
+    now: 1000,
+    recipes: {
+      r1: { ingredients: [{ item_id: "i1", qty: 2 }] }
+    },
+    marketPrices: { i1: 2 },
+    items: {}
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "insufficient_coins");
+  assert.equal(player.takeout.shift.status, "inactive");
+  assert.equal(player.coins, 5);
+});
+
+test("Takeout: covered idle ingredient pool is isolated from pantry usage", () => {
+  const player = {
+    coins: 50_000,
+    inv_ingredients: { i1: 1, i2: 0 },
+    takeout: {
+      menu_recipe_ids: ["r1"],
+      shift: {
+        status: "inactive",
+        started_at: null,
+        ends_at: null,
+        last_processed_hour_index: 0,
+        last_tick_at: null,
+        operating_cost_paid_marker: null,
+        operating_cost: 0,
+        required_ingredients: {},
+        covered_ingredients: {},
+        idle_order_board_snapshot: []
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: null
+    }
+  };
+
+  const result = startTakeoutShiftWithCoverage(player, {
+    now: 2000,
+    recipes: {
+      r1: { ingredients: [{ item_id: "i1", qty: 2 }, { item_id: "i2", qty: 1 }] }
+    },
+    marketPrices: { i1: 3, i2: 4 },
+    items: {}
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(player.takeout.shift.status, "active");
+  assert.equal(player.takeout.shift.operating_cost, result.operatingCost);
+  assert.equal(player.takeout.shift.operating_cost_paid_marker, "takeout_shift:2000");
+  assert.ok(Object.keys(player.takeout.shift.covered_ingredients).length > 0);
+  assert.deepEqual(player.inv_ingredients, { i1: 1, i2: 0 });
+
+  const firstCovered = player.takeout.shift.covered_ingredients;
+  player.inv_ingredients.i1 = 0;
+  assert.deepEqual(player.takeout.shift.covered_ingredients, firstCovered);
+});
+
+test("Takeout: generated shift snapshot spans 12 hours with recipe demand", () => {
+  const snapshot = buildTakeoutShiftSnapshot(["r1", "r2", "r3"], { totalOrders: 120 });
+  assert.equal(snapshot.length, 3);
+  const total = snapshot.reduce((sum, row) => sum + row.total_orders, 0);
+  assert.equal(total, 120);
+  for (const row of snapshot) {
+    assert.equal(row.hourly_order_counts.length, 12);
+    assert.ok(row.total_orders > 0);
+    assert.equal(row.visible_order_count, row.total_orders);
+  }
+});
+
+test("Takeout: snapshot distribution is deterministic and sums to board total", () => {
+  const snapshot = buildTakeoutShiftSnapshot(["r1", "r2", "r3", "r4"], { totalOrders: 137 });
+  const total = snapshot.reduce((sum, row) => sum + row.total_orders, 0);
+  assert.equal(total, 137);
+
+  const hourlyTotals = Array.from({ length: 12 }, (_, hour) =>
+    snapshot.reduce((sum, row) => sum + (row.hourly_order_counts[hour] ?? 0), 0)
+  );
+  assert.equal(hourlyTotals.reduce((sum, count) => sum + count, 0), 137);
+  assert.ok(Math.max(...hourlyTotals) - Math.min(...hourlyTotals) <= 1);
+});
+
+test("Takeout: non-24/7 users snapshot board-total-at-open", () => {
+  const player = { coins: 50_000, takeout: createDefaultTakeoutState() };
+  player.takeout.menu_recipe_ids = ["r1", "r2"];
+
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    boardOrderTotal: 140,
+    unlimitedOrders: false,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+    },
+    marketPrices: { i1: 1 },
+    items: { i1: { base_price: 1 } }
+  });
+
+  assert.equal(open.ok, true);
+  assert.equal(open.snapshotOrderTotal, 140);
+  const total = player.takeout.shift.idle_order_board_snapshot
+    .reduce((sum, row) => sum + (row.total_orders || 0), 0);
+  assert.equal(total, 140);
+});
+
+test("Takeout: 24/7 users use unlimited snapshot total", () => {
+  const player = { coins: 100_000, takeout: createDefaultTakeoutState() };
+  player.takeout.menu_recipe_ids = ["r1", "r2"];
+
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    boardOrderTotal: 140,
+    unlimitedOrders: true,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+    },
+    marketPrices: { i1: 1 },
+    items: { i1: { base_price: 1 } }
+  });
+
+  assert.equal(open.ok, true);
+  assert.ok(open.snapshotOrderTotal > TAKEOUT_SNAPSHOT_MAX_ORDERS);
+  assert.ok(open.snapshotOrderTotal >= TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS);
+  assert.ok(open.snapshotOrderTotal <= TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS);
+  const total = player.takeout.shift.idle_order_board_snapshot
+    .reduce((sum, row) => sum + (row.total_orders || 0), 0);
+  assert.equal(total, open.snapshotOrderTotal);
+});
+
+test("Takeout: unlimited snapshot is deterministic per shift seed and can vary across shifts", () => {
+  const openAt = (now) => {
+    const player = { coins: 100_000, takeout: createDefaultTakeoutState() };
+    player.takeout.menu_recipe_ids = ["r1", "r2", "r3"];
+    const open = startTakeoutShiftWithCoverage(player, {
+      now,
+      boardOrderTotal: 200,
+      unlimitedOrders: true,
+      recipes: {
+        r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+        r2: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+        r3: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+      },
+      marketPrices: { i1: 1 },
+      items: { i1: { base_price: 1 } }
+    });
+    assert.equal(open.ok, true);
+    return open.snapshotOrderTotal;
+  };
+
+  const sameA = openAt(123_000);
+  const sameB = openAt(123_000);
+  const different = openAt(124_000);
+
+  assert.equal(sameA, sameB);
+  assert.ok(sameA >= TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS);
+  assert.ok(sameA <= TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS);
+  assert.ok(different >= TAKEOUT_SNAPSHOT_UNLIMITED_MIN_ORDERS);
+  assert.ok(different <= TAKEOUT_SNAPSHOT_UNLIMITED_MAX_ORDERS);
+  assert.notEqual(different, sameA);
+});
+
+test("Takeout: catch-up processes whole hours only and caps at 12", () => {
+  const player = {
+    coins: 1_000,
+    takeout: createDefaultTakeoutState()
+  };
+  player.takeout.menu_recipe_ids = ["r1"];
+
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(open.ok, true);
+
+  const halfHour = processTakeoutCatchup(player, {
+    now: 30 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(halfHour.processedHours, 0);
+
+  const after13h = processTakeoutCatchup(player, {
+    now: 13 * 60 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(after13h.totalProcessedHours, 12);
+  assert.equal(player.takeout.shift.last_processed_hour_index, 12);
+  assert.equal(player.takeout.shift.status, "inactive");
+});
+
+test("Takeout: catch-up is deterministic for same snapshot and elapsed time", () => {
+  const buildPlayer = () => {
+    const p = { coins: 1_000, takeout: createDefaultTakeoutState() };
+    p.takeout.menu_recipe_ids = ["r1", "r2"];
+    const open = startTakeoutShiftWithCoverage(p, {
+      now: 0,
+      recipes: {
+        r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+        r2: { tier: "rare", ingredients: [{ item_id: "i2", qty: 1 }] }
+      },
+      marketPrices: { i1: 5, i2: 9 },
+      items: { i1: { base_price: 5 }, i2: { base_price: 9 } }
+    });
+    assert.equal(open.ok, true);
+    return p;
+  };
+
+  const p1 = buildPlayer();
+  const p2 = buildPlayer();
+
+  const r1 = processTakeoutCatchup(p1, {
+    now: 5 * 60 * 60 * 1000,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "rare", ingredients: [{ item_id: "i2", qty: 1 }] }
+    },
+    marketPrices: { i1: 5, i2: 9 },
+    items: { i1: { base_price: 5 }, i2: { base_price: 9 } }
+  });
+  const r2 = processTakeoutCatchup(p2, {
+    now: 5 * 60 * 60 * 1000,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] },
+      r2: { tier: "rare", ingredients: [{ item_id: "i2", qty: 1 }] }
+    },
+    marketPrices: { i1: 5, i2: 9 },
+    items: { i1: { base_price: 5 }, i2: { base_price: 9 } }
+  });
+
+  assert.equal(r1.earned, r2.earned);
+  assert.equal(p1.takeout.earned_unclaimed_coins, p2.takeout.earned_unclaimed_coins);
+  assert.equal(p1.takeout.shift.last_processed_hour_index, p2.takeout.shift.last_processed_hour_index);
+});
+
+test("Takeout: catch-up does not double-process repeated calls", () => {
+  const player = { coins: 1_000, takeout: createDefaultTakeoutState() };
+  player.takeout.menu_recipe_ids = ["r1"];
+  const open = startTakeoutShiftWithCoverage(player, {
+    now: 0,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  assert.equal(open.ok, true);
+
+  const first = processTakeoutCatchup(player, {
+    now: 3 * 60 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  const before = player.takeout.earned_unclaimed_coins;
+
+  const second = processTakeoutCatchup(player, {
+    now: 3 * 60 * 60 * 1000,
+    recipes: { r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] } },
+    marketPrices: { i1: 5 },
+    items: { i1: { base_price: 5 } }
+  });
+  const after = player.takeout.earned_unclaimed_coins;
+
+  assert.ok(first.processedHours > 0);
+  assert.equal(second.processedHours, 0);
+  assert.equal(after, before);
+});

--- a/test/takeout.test.js
+++ b/test/takeout.test.js
@@ -481,3 +481,50 @@ test("Takeout: catch-up decrements visible snapshot demand for served orders", (
   assert.equal(player.takeout.shift.idle_order_board_snapshot[0].visible_order_count, 0);
   assert.equal(player.lifetime.orders_served, 4);
 });
+
+test("Takeout: catch-up respects manual serve reductions in visible order count", () => {
+  const player = {
+    takeout: {
+      menu_recipe_ids: ["r1"],
+      shift: {
+        status: "active",
+        started_at: 0,
+        ends_at: TAKEOUT_SHIFT_DURATION_MS,
+        last_processed_hour_index: 0,
+        last_tick_at: 0,
+        operating_cost_paid_marker: "takeout_shift:0",
+        operating_cost: 0,
+        required_ingredients: { i1: 4 },
+        covered_ingredients: { i1: 4 },
+        idle_order_board_snapshot: [
+          {
+            recipe_id: "r1",
+            visible_order_count: 1,
+            total_orders: 4,
+            hourly_order_counts: [2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+          }
+        ]
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: 0
+    },
+    lifetime: {
+      bowls_served_total: 0,
+      orders_served: 0
+    }
+  };
+
+  const result = processTakeoutCatchup(player, {
+    now: 2 * 60 * 60 * 1000,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+    },
+    marketPrices: { i1: 1 },
+    items: { i1: { base_price: 1 } }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.processedHours, 2);
+  assert.equal(player.takeout.shift.idle_order_board_snapshot[0].visible_order_count, 0);
+  assert.equal(player.lifetime.orders_served, 1);
+});

--- a/test/takeout.test.js
+++ b/test/takeout.test.js
@@ -168,6 +168,11 @@ test("Takeout: shift cannot start when player cannot afford fixed operating cost
 
   assert.equal(result.ok, false);
   assert.equal(result.reason, "insufficient_coins");
+  assert.ok(result.snapshotOrderTotal > 0);
+  assert.equal(
+    result.snapshot.reduce((sum, row) => sum + Math.max(0, Math.floor(Number(row?.total_orders || 0) || 0)), 0),
+    result.snapshotOrderTotal
+  );
   assert.equal(player.takeout.shift.status, "inactive");
   assert.equal(player.coins, 5);
 });
@@ -428,4 +433,51 @@ test("Takeout: catch-up does not double-process repeated calls", () => {
   assert.ok(first.processedHours > 0);
   assert.equal(second.processedHours, 0);
   assert.equal(after, before);
+});
+
+test("Takeout: catch-up decrements visible snapshot demand for served orders", () => {
+  const player = {
+    takeout: {
+      menu_recipe_ids: ["r1"],
+      shift: {
+        status: "active",
+        started_at: 0,
+        ends_at: TAKEOUT_SHIFT_DURATION_MS,
+        last_processed_hour_index: 0,
+        last_tick_at: 0,
+        operating_cost_paid_marker: "takeout_shift:0",
+        operating_cost: 0,
+        required_ingredients: { i1: 4 },
+        covered_ingredients: { i1: 4 },
+        idle_order_board_snapshot: [
+          {
+            recipe_id: "r1",
+            visible_order_count: 4,
+            total_orders: 4,
+            hourly_order_counts: [2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+          }
+        ]
+      },
+      earned_unclaimed_coins: 0,
+      updated_at: 0
+    },
+    lifetime: {
+      bowls_served_total: 0,
+      orders_served: 0
+    }
+  };
+
+  const result = processTakeoutCatchup(player, {
+    now: 2 * 60 * 60 * 1000,
+    recipes: {
+      r1: { tier: "common", ingredients: [{ item_id: "i1", qty: 1 }] }
+    },
+    marketPrices: { i1: 1 },
+    items: { i1: { base_price: 1 } }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.processedHours, 2);
+  assert.equal(player.takeout.shift.idle_order_board_snapshot[0].visible_order_count, 0);
+  assert.equal(player.lifetime.orders_served, 4);
 });

--- a/test/voteRewards.test.js
+++ b/test/voteRewards.test.js
@@ -9,6 +9,7 @@ import {
   registerVoteFromSource,
   VOTE_SOURCES
 } from "../src/game/voteRewards.js";
+import { HOUSE_247_VOTE_DURATION_MS } from "../src/game/subscriptions.js";
 
 function mockPlayer() {
   return {
@@ -216,5 +217,33 @@ test("Vote rewards: status lines follow display ordering and limit", () => {
   const limitedLines = getVotePlatformStatusLines(player, { limit: 1 });
   assert.equal(limitedLines.length, 1);
   assert.match(limitedLines[0], /Rank\.top/i);
+});
+
+test("Vote rewards: each vote adds 12h of 24/7 House and stacks from current expiry", () => {
+  const now = 4_000_000;
+  const player = mockPlayer();
+
+  const first = registerVoteFromSource(player, VOTE_SOURCES.TOPGG, now);
+  assert.equal(first.duplicate, false);
+  assert.equal(first.house247ExpiresAt, now + HOUSE_247_VOTE_DURATION_MS);
+
+  const second = registerVoteFromSource(player, VOTE_SOURCES.DISCORDBOTLIST, now + 1_000);
+  assert.equal(second.duplicate, false);
+  assert.equal(second.house247ExpiresAt, now + HOUSE_247_VOTE_DURATION_MS * 2);
+
+  const status = getVoteRewardStatus(player);
+  assert.equal(status.house247ExpiresAt, now + HOUSE_247_VOTE_DURATION_MS * 2);
+});
+
+test("Vote rewards: duplicate retries do not extend 24/7 House timer", () => {
+  const now = 5_000_000;
+  const player = mockPlayer();
+
+  const first = registerVoteFromSource(player, VOTE_SOURCES.TOPGG, now);
+  const duplicate = registerVoteFromSource(player, VOTE_SOURCES.TOPGG, now + 60_000);
+
+  assert.equal(first.duplicate, false);
+  assert.equal(duplicate.duplicate, true);
+  assert.equal(duplicate.house247ExpiresAt, first.house247ExpiresAt);
 });
 


### PR DESCRIPTION
## Summary
- Complete monetization and perk rollout for takeout + coin packs with Discord-only SKU support.
- Add lifecycle alerts for coin package purchases and takeout subscription start/end.
- Replace dev subscription toggles with giveaway winner grants for perks, coin packs, and arbitrary direct coin amounts.
- Unify storefront/profile messaging and icons for perk visibility and improve takeout value copy.
- Add discovery no-drop pity clue behavior and supporting automated coverage.

## Target Branch (Required)
- [ ] Target is develop (feature/integration testing)
- [x] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (`cleanstart` / `syncmain`).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [ ] I rebased this branch on latest origin/develop.
- [ ] This PR is intended for integration/QA testing, not direct production release.
- [ ] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [x] I rebased this branch on latest origin/main.
- [x] This change is release-ready and already validated at appropriate level.
- [x] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [x] Lint/type checks pass (if applicable).

Commands run:
```bash
npm run review:all
node --check src/commands/noodle.js src/commands/noodleDev.js
```

Short results:
- `npm run review:all` passed (`eslint`, `node --test`, and pre-review guard all green).
- `node --check` passed for updated command files.

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

Risk notes:
- Primary risk is regression in monetization/perk gating text and entitlement routing.
- Mitigated by targeted unit coverage for subscriptions, vote rewards, coin packs, social, and discovery.

## Reviewer Notes
- Areas to focus on:
  - Entitlement lifecycle transitions and idempotency in webhook handling.
  - `/noodle-dev giveaway_winner` reward type validation and coin grant branch.
  - UI copy consistency for takeout/store/profile paths.
- Known limitations:
  - Discord SKU-only mode currently assumes configured SKU IDs are source of truth.
- Follow-up work (if any):
  - None required for this rollout.

---

### Review Gate
Do not request review until all required checkboxes are complete.
If any box is intentionally unchecked, explain why in this PR description.
