### PR TITLE
fix(noodle): unify serve unlock messaging and dev refresh behavior

### DIFF
--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -2169,12 +2169,25 @@ function extractOrderIndexFromId(orderId) {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
-function resolveConsumedOrderIndex(fullOrderId, acceptedOrder, resolvedOrder) {
-  const acceptedIndex = Number(acceptedOrder?.order_index);
-  if (Number.isFinite(acceptedIndex) && acceptedIndex >= 0) return acceptedIndex;
+function parseNonNegativeOrderIndex(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  }
+  return null;
+}
 
-  const resolvedIndex = Number(resolvedOrder?.order_index);
-  if (Number.isFinite(resolvedIndex) && resolvedIndex >= 0) return resolvedIndex;
+function resolveConsumedOrderIndex(fullOrderId, acceptedOrder, resolvedOrder) {
+  const acceptedIndex = parseNonNegativeOrderIndex(acceptedOrder?.order_index);
+  if (acceptedIndex !== null) return acceptedIndex;
+
+  const resolvedIndex = parseNonNegativeOrderIndex(resolvedOrder?.order_index);
+  if (resolvedIndex !== null) return resolvedIndex;
 
   return extractOrderIndexFromId(fullOrderId);
 }
@@ -11006,21 +11019,21 @@ ${lines.join("\n")}`;
       const consumedBeforeMark = Array.isArray(p.orders_consumed_indices)
         ? p.orders_consumed_indices
         : [];
-      const consumedAlreadyContainedBefore = Number.isFinite(Number(consumedOrderIndex))
-        ? consumedBeforeMark.includes(Number(consumedOrderIndex))
+      const consumedAlreadyContainedBefore = Number.isFinite(consumedOrderIndex)
+        ? consumedBeforeMark.includes(consumedOrderIndex)
         : false;
       delete acceptedMap[fullOrderId];
       markOrderConsumed(p, consumedOrderIndex);
       const consumedAfterMark = Array.isArray(p.orders_consumed_indices)
         ? p.orders_consumed_indices
         : [];
-      const consumedContainsAfter = Number.isFinite(Number(consumedOrderIndex))
-        ? consumedAfterMark.includes(Number(consumedOrderIndex))
+      const consumedContainsAfter = Number.isFinite(consumedOrderIndex)
+        ? consumedAfterMark.includes(consumedOrderIndex)
         : false;
       serveCommitResults.push({
         fullOrderId,
         served: true,
-        consumedIndexUsed: Number.isFinite(Number(consumedOrderIndex)) ? Number(consumedOrderIndex) : null,
+        consumedIndexUsed: Number.isFinite(consumedOrderIndex) ? consumedOrderIndex : null,
         markOrderConsumedCalled: true,
         consumedAlreadyContainedBefore,
         consumedContainsAfter

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -2161,6 +2161,24 @@ const s = String(orderId)
 return s.slice(-6).toUpperCase();
 }
 
+function extractOrderIndexFromId(orderId) {
+  if (!orderId) return null;
+  const match = String(orderId).match(/-o(\d+)-/i);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function resolveConsumedOrderIndex(fullOrderId, acceptedOrder, resolvedOrder) {
+  const acceptedIndex = Number(acceptedOrder?.order_index);
+  if (Number.isFinite(acceptedIndex) && acceptedIndex >= 0) return acceptedIndex;
+
+  const resolvedIndex = Number(resolvedOrder?.order_index);
+  if (Number.isFinite(resolvedIndex) && resolvedIndex >= 0) return resolvedIndex;
+
+  return extractOrderIndexFromId(fullOrderId);
+}
+
 function formatBonusValue(key, value) {
   if (typeof value === "boolean") return value ? "Yes" : "No";
   if (typeof value === "number") {
@@ -5834,7 +5852,12 @@ if (inDevPath && sub === "dashboard") {
       .setCustomId(`noodle-dev:dashboard:nav:${userId}:0:${nextServerPage}`)
       .setLabel("Next")
       .setStyle(ButtonStyle.Secondary)
-      .setDisabled(page !== 0 || totalServerPages <= 1)
+      .setDisabled(page !== 0 || totalServerPages <= 1),
+    new ButtonBuilder()
+      .setCustomId(`noodle-dev:dashboard:refresh:${userId}:${page}:${clampedServerPage}`)
+      .setLabel("Refresh")
+      .setEmoji(getButtonEmoji("refresh"))
+      .setStyle(ButtonStyle.Secondary)
   );
 
   return commit({
@@ -7440,6 +7463,8 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       let seasonalServedCoins = 0;
       let leveledUp = false;
       const discoveryMessages = [];
+      const bowlLedgerCompletedBefore = new Set(p?.collections?.progress?.bowl_ledger?.completed_entries ?? []);
+      const completedCollectionsBefore = new Set(p?.collections?.completed ?? []);
       const recipe = content.recipes?.[selectedRecipeId] ?? null;
       const combinedEffects = calculateCombinedEffects(p, upgradesContent, staffContent, calculateStaffEffects);
       const activeEventEffects = getActiveEventEffects(eventsContent, s);
@@ -7487,6 +7512,16 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         p.lifetime.bowls_served_total = (p.lifetime.bowls_served_total ?? 0) + 1;
         p.lifetime.coins_earned = (p.lifetime.coins_earned ?? 0) + rewards.coins;
         leveledUp = applySxpLevelUp(p) || leveledUp;
+
+        const levelBeforeCollection = Number(p.shop_level || 1);
+        applyCollectionProgressOnServe(p, collectionsContent, content, {
+          npcArchetype: null,
+          recipeId: selectedRecipeId,
+          quality: bowlQuality
+        });
+        if (Number(p.shop_level || 1) > levelBeforeCollection) {
+          leveledUp = true;
+        }
 
         totalCoins += rewards.coins;
         totalRep += rewards.rep;
@@ -7536,12 +7571,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         `${getIcon("coins")} +${totalCoins}c · ${getIcon("rep")} +${totalRep} rep · ${getIcon("sxp")} +${totalSxp} sxp`,
         `${getIcon("orders")} Remaining counter orders for this recipe: **${remainingForRecipe}**`
       ];
-      if (leveledUp) {
-        serveSummary.push(`${getIcon("status_complete")} Level up! You are now **Lv.${Math.max(1, Number(p.shop_level || 1))}**.`);
-      }
-      if (discoveryMessages.length > 0) {
-        serveSummary.push(discoveryMessages.slice(0, 4).join("\n"));
-      }
 
       if (servedCount > 0) {
         applyQuestProgress(
@@ -7564,11 +7593,62 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
             now
           );
         }
+
+        const newlyUnlockedBadgeIds = unlockBadges(p, badgesContent);
+        for (const badgeId of newlyUnlockedBadgeIds) {
+          const badge = getBadgeById(badgesContent, badgeId);
+          const icon = resolveIcon(badge?.icon, getIcon("badges"));
+          const badgeName = badge?.name ?? badgeId;
+          serveSummary.push(`${icon} **Badge unlocked:** ${badgeName}`);
+        }
+
+        const bowlLedgerCompletedAfter = new Set(p?.collections?.progress?.bowl_ledger?.completed_entries ?? []);
+        const newlyCompletedBowls = [...bowlLedgerCompletedAfter]
+          .filter((entry) => !bowlLedgerCompletedBefore.has(entry))
+          .map((entry) => Number(entry))
+          .filter((value) => Number.isFinite(value))
+          .sort((a, b) => a - b);
+        for (const threshold of newlyCompletedBowls) {
+          serveSummary.push(`${getIcon("serve")} **Bowl milestone reached:** ${threshold.toLocaleString()} bowls served.`);
+        }
+
+        const collectionNameById = new Map((collectionsContent?.collections ?? [])
+          .filter((entry) => entry?.collection_id)
+          .map((entry) => [entry.collection_id, entry.name ?? entry.collection_id]));
+        const newlyCompletedCollectionIds = (p?.collections?.completed ?? [])
+          .filter((collectionId) => !completedCollectionsBefore.has(collectionId));
+        for (const collectionId of newlyCompletedCollectionIds) {
+          const collectionName = collectionNameById.get(collectionId) ?? collectionId;
+          serveSummary.push(`${getIcon("collections")} **Collection completed:** ${collectionName}`);
+        }
+
+        const specState = ensureSpecializationState(p);
+        const bowlsServedAfter = p.lifetime.bowls_served_total;
+        const newlyUnlockedSpecs = (specializationsContent?.specializations ?? []).filter((spec) => {
+          if (!spec?.spec_id) return false;
+          const req = spec?.requirements?.bowls_served_total;
+          if (!req || bowlsServedAfter < req) return false;
+          return !specState.unlocked_spec_ids.includes(spec.spec_id);
+        });
+        if (newlyUnlockedSpecs.length) {
+          for (const spec of newlyUnlockedSpecs) {
+            specState.unlocked_spec_ids.push(spec.spec_id);
+            const icon = resolveIcon(spec.icon, getIcon("sparkle"));
+            serveSummary.push(`${icon} **Specialization unlocked:** ${spec.name}`);
+          }
+        }
+      }
+
+      if (leveledUp) {
+        serveSummary.push(`${getIcon("level_up")} Level up! You're now **Level ${Math.max(1, Number(p.shop_level || 1))}**.`);
+      }
+      if (discoveryMessages.length > 0) {
+        serveSummary.push(discoveryMessages.slice(0, 4).join("\n"));
       }
 
       const confirmationEmbed = buildMenuEmbed({
         title: `${getIcon("serve")} Counter Serve`,
-        description: serveSummary.join("\n\n"),
+        description: serveSummary.join("\n"),
         user: interaction.member ?? interaction.user,
         color: theme.colors.success
       });
@@ -7921,10 +8001,18 @@ if (sub === "status") {
     });
   }
   const statusEmbed = buildDevStatusEmbed();
+  const refreshRow = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`noodle-dev:status:refresh:${userId}`)
+      .setLabel("Refresh")
+      .setEmoji(getButtonEmoji("refresh"))
+      .setStyle(ButtonStyle.Secondary)
+  );
 
   return commit({
     content: " ",
     embeds: [statusEmbed],
+    components: [refreshRow],
     ephemeral: false
   });
 }
@@ -10335,6 +10423,7 @@ ${lines.join("\n")}`;
     const results = [];
     const unlockedRecipeNames = [];
     const readyBowlsByRecipe = new Map();
+    const acceptedCommitted = [];
     const acceptedOrdersNow = [];
     let acceptedNow = 0;
 
@@ -10388,6 +10477,10 @@ ${lines.join("\n")}`;
           base_speed_window_seconds: baseSpeedWindowSeconds
         }
       };
+      acceptedCommitted.push({
+        orderId: order.order_id,
+        orderIndex: Number.isFinite(Number(order.order_index)) ? Number(order.order_index) : null
+      });
 
       const rName = content.recipes[order.recipe_id]?.name ?? "a dish";
       const timeNote = expiresAt
@@ -10633,6 +10726,17 @@ ${lines.join("\n")}`;
       user: interaction.member ?? interaction.user
     });
     const hasAcceptedOrders = Object.keys(p.orders?.accepted ?? {}).length > 0;
+    emitTelemetry("order_accept_commit", {
+      requestId: interaction.id,
+      serverId,
+      userId,
+      ordersDay: p.orders_day ?? dayKeyUTC(),
+      house247Active: hasHouse247Perk(p),
+      orderAcceptCap: cap,
+      acceptedCountBefore: acceptedCount,
+      acceptedCountAfter: hasAcceptedOrders ? Object.keys(p.orders?.accepted ?? {}).length : 0,
+      accepted: acceptedCommitted
+    });
     const showTutorialBuyRowAfterAccept = resolveTutorialGateValue({
       player: p,
       gate: "showTutorialBuyRowAfterAccept",
@@ -10729,6 +10833,53 @@ ${lines.join("\n")}`;
     }
 
     const acceptedMap = p.orders?.accepted ?? {};
+    const consumedBeforeServe = Array.isArray(p.orders_consumed_indices)
+      ? p.orders_consumed_indices.length
+      : 0;
+    const serveAttemptResolved = [];
+
+    for (const tok of tokens) {
+      const matchedEntry = Object.entries(acceptedMap).find(([fullId]) => {
+        const full = String(fullId).toUpperCase();
+        const short = shortOrderId(fullId);
+        return full === tok || short === tok;
+      });
+      if (!matchedEntry) continue;
+
+      const [fullOrderId, acceptedEntry] = matchedEntry;
+      const resolvedOrder = acceptedEntry?.order ?? findOrderByToken({
+        playerState: p,
+        settings: set,
+        content,
+        activeSeason: s.season,
+        serverId,
+        userId,
+        activeEventId,
+        token: fullOrderId
+      });
+      const acceptedSnapshotIndex = Number(acceptedEntry?.order?.order_index);
+      const resolvedOrderIndex = Number(resolvedOrder?.order_index);
+      serveAttemptResolved.push({
+        token: tok,
+        fullOrderId,
+        acceptedSnapshotHasIndex: Number.isFinite(acceptedSnapshotIndex) && acceptedSnapshotIndex >= 0,
+        acceptedSnapshotIndex: Number.isFinite(acceptedSnapshotIndex) && acceptedSnapshotIndex >= 0 ? acceptedSnapshotIndex : null,
+        resolvedOrderIndex: Number.isFinite(resolvedOrderIndex) && resolvedOrderIndex >= 0 ? resolvedOrderIndex : null,
+        fallbackIndexFromOrderId: extractOrderIndexFromId(fullOrderId)
+      });
+    }
+
+    emitTelemetry("order_serve_attempt", {
+      requestId: interaction.id,
+      serverId,
+      userId,
+      ordersDay: p.orders_day ?? dayKeyUTC(),
+      house247Active: hasHouse247Perk(p),
+      tokens,
+      resolved: serveAttemptResolved,
+      consumedCountBefore: consumedBeforeServe
+    });
+
     // Ensure core stats and lifetime tracking exist
     p.coins = Number.isFinite(p.coins) ? p.coins : 0;
     p.rep = Number.isFinite(p.rep) ? p.rep : 0;
@@ -10759,6 +10910,9 @@ ${lines.join("\n")}`;
     let leveledUp = false;
     let recipeUnlocked = false;
     const unlockedRecipeNames = [];
+    const bowlLedgerCompletedBefore = new Set(p?.collections?.progress?.bowl_ledger?.completed_entries ?? []);
+    const completedCollectionsBefore = new Set(p?.collections?.completed ?? []);
+    const serveCommitResults = [];
 
     for (const tok of tokens) {
       const matchEntry = Object.entries(acceptedMap).find(([fullId]) => {
@@ -10848,8 +11002,29 @@ ${lines.join("\n")}`;
       bowl.qty -= 1;
       if (bowl.qty <= 0) delete p.inv_bowls[selectedEntry?.key ?? order.recipe_id];
 
+      const consumedOrderIndex = resolveConsumedOrderIndex(fullOrderId, accepted.order, order);
+      const consumedBeforeMark = Array.isArray(p.orders_consumed_indices)
+        ? new Set(p.orders_consumed_indices)
+        : new Set();
+      const consumedAlreadyContainedBefore = Number.isFinite(Number(consumedOrderIndex))
+        ? consumedBeforeMark.has(Number(consumedOrderIndex))
+        : false;
       delete acceptedMap[fullOrderId];
-      markOrderConsumed(p, order.order_index);
+      markOrderConsumed(p, consumedOrderIndex);
+      const consumedAfterMark = Array.isArray(p.orders_consumed_indices)
+        ? new Set(p.orders_consumed_indices)
+        : new Set();
+      const consumedContainsAfter = Number.isFinite(Number(consumedOrderIndex))
+        ? consumedAfterMark.has(Number(consumedOrderIndex))
+        : false;
+      serveCommitResults.push({
+        fullOrderId,
+        served: true,
+        consumedIndexUsed: Number.isFinite(Number(consumedOrderIndex)) ? Number(consumedOrderIndex) : null,
+        markOrderConsumedCalled: true,
+        consumedAlreadyContainedBefore,
+        consumedContainsAfter
+      });
 
       p.coins += rewards.coins;
       p.rep += rewards.rep;
@@ -11075,13 +11250,53 @@ ${lines.join("\n")}`;
           now
         );
       }
-      unlockBadges(p, badgesContent);
+
+      const newlyUnlockedBadgeIds = unlockBadges(p, badgesContent);
+      for (const badgeId of newlyUnlockedBadgeIds) {
+        const badge = getBadgeById(badgesContent, badgeId);
+        const icon = resolveIcon(badge?.icon, getIcon("badges"));
+        const badgeName = badge?.name ?? badgeId;
+        results.push(`${icon} **Badge unlocked:** ${badgeName}`);
+      }
+
+      const bowlLedgerCompletedAfter = new Set(p?.collections?.progress?.bowl_ledger?.completed_entries ?? []);
+      const newlyCompletedBowls = [...bowlLedgerCompletedAfter]
+        .filter((entry) => !bowlLedgerCompletedBefore.has(entry))
+        .map((entry) => Number(entry))
+        .filter((value) => Number.isFinite(value))
+        .sort((a, b) => a - b);
+      for (const threshold of newlyCompletedBowls) {
+        results.push(`${getIcon("serve")} **Bowl milestone reached:** ${threshold.toLocaleString()} bowls served.`);
+      }
+
+      const collectionNameById = new Map((collectionsContent?.collections ?? [])
+        .filter((entry) => entry?.collection_id)
+        .map((entry) => [entry.collection_id, entry.name ?? entry.collection_id]));
+      const newlyCompletedCollectionIds = (p?.collections?.completed ?? [])
+        .filter((collectionId) => !completedCollectionsBefore.has(collectionId));
+      for (const collectionId of newlyCompletedCollectionIds) {
+        const collectionName = collectionNameById.get(collectionId) ?? collectionId;
+        results.push(`${getIcon("collections")} **Collection completed:** ${collectionName}`);
+      }
     }
+
+    emitTelemetry("order_serve_commit", {
+      requestId: interaction.id,
+      serverId,
+      userId,
+      ordersDay: p.orders_day ?? dayKeyUTC(),
+      house247Active: hasHouse247Perk(p),
+      results: serveCommitResults,
+      consumedCountBefore: consumedBeforeServe,
+      consumedCountAfter: Array.isArray(p.orders_consumed_indices)
+        ? p.orders_consumed_indices.length
+        : 0
+    });
 
     const state = ensureSpecializationState(p);
     const bowlsServedAfter = p.lifetime.bowls_served_total;
     const newlyUnlockedSpecs = (specializationsContent?.specializations ?? []).filter((spec) => {
-      if (!spec?.hidden_until_unlocked) return false;
+      if (!spec?.spec_id) return false;
       const req = spec?.requirements?.bowls_served_total;
       if (!req || bowlsServedAfter < req) return false;
       return !state.unlocked_spec_ids.includes(spec.spec_id);

--- a/src/commands/noodle.js
+++ b/src/commands/noodle.js
@@ -6207,9 +6207,9 @@ if (sub === "profile_edit") {
       "• You unlock specializations as your shop levels up. Changing your active specialization updates your shop decor.",
       "",
       "• Check out the **Store** to browse all premium options:",
-      "  - Premium Shop Specializations",
-      "  - Coin Packs",
-      `  - ${getTakeoutCounterLabel()} Subscription Perk`
+      "• Premium Shop Specializations",
+      "• Coin Packs",
+      `• ${getTakeoutCounterLabel()} Subscription Perk`
     ].join("\n"),
     user: interaction.member ?? interaction.user
   });
@@ -7513,16 +7513,6 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
         p.lifetime.coins_earned = (p.lifetime.coins_earned ?? 0) + rewards.coins;
         leveledUp = applySxpLevelUp(p) || leveledUp;
 
-        const levelBeforeCollection = Number(p.shop_level || 1);
-        applyCollectionProgressOnServe(p, collectionsContent, content, {
-          npcArchetype: null,
-          recipeId: selectedRecipeId,
-          quality: bowlQuality
-        });
-        if (Number(p.shop_level || 1) > levelBeforeCollection) {
-          leveledUp = true;
-        }
-
         totalCoins += rewards.coins;
         totalRep += rewards.rep;
         totalSxp += rewards.sxp;
@@ -7573,6 +7563,16 @@ if (sub === "takeout" || sub === "takeout_menu" || sub === "takeout_open" || sub
       ];
 
       if (servedCount > 0) {
+        const levelBeforeCollection = Number(p.shop_level || 1);
+        applyCollectionProgressOnServe(p, collectionsContent, content, {
+          npcArchetype: null,
+          recipeId: selectedRecipeId,
+          quality: null
+        });
+        if (Number(p.shop_level || 1) > levelBeforeCollection) {
+          leveledUp = true;
+        }
+
         applyQuestProgress(
           p,
           questsContent,
@@ -11004,18 +11004,18 @@ ${lines.join("\n")}`;
 
       const consumedOrderIndex = resolveConsumedOrderIndex(fullOrderId, accepted.order, order);
       const consumedBeforeMark = Array.isArray(p.orders_consumed_indices)
-        ? new Set(p.orders_consumed_indices)
-        : new Set();
+        ? p.orders_consumed_indices
+        : [];
       const consumedAlreadyContainedBefore = Number.isFinite(Number(consumedOrderIndex))
-        ? consumedBeforeMark.has(Number(consumedOrderIndex))
+        ? consumedBeforeMark.includes(Number(consumedOrderIndex))
         : false;
       delete acceptedMap[fullOrderId];
       markOrderConsumed(p, consumedOrderIndex);
       const consumedAfterMark = Array.isArray(p.orders_consumed_indices)
-        ? new Set(p.orders_consumed_indices)
-        : new Set();
+        ? p.orders_consumed_indices
+        : [];
       const consumedContainsAfter = Number.isFinite(Number(consumedOrderIndex))
-        ? consumedAfterMark.has(Number(consumedOrderIndex))
+        ? consumedAfterMark.includes(Number(consumedOrderIndex))
         : false;
       serveCommitResults.push({
         fullOrderId,

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -184,16 +184,24 @@ export const noodleDevCommand = {
 
     const customId = String(interaction.customId || "");
     const parts = customId.split(":");
+    if (parts[0] === "noodle-dev" && parts[1] === "status" && parts[2] === "refresh") {
+      const ownerUserId = parts[3] ?? "";
+      if (ownerUserId && ownerUserId !== interaction.user.id) {
+        return denyOwnerMismatch("That status panel isn’t for you.");
+      }
+      return runNoodle(interaction, { sub: "status", group: "dev" });
+    }
+
     // Legacy: noodle-dev:dashboard:page:<ownerUserId>:<tabPage>
     // New:    noodle-dev:dashboard:nav:<ownerUserId>:<tabPage>:<serverPage>
     if (parts[0] !== "noodle-dev" || parts[1] !== "dashboard") return null;
 
     const mode = parts[2] ?? "";
-    if (mode !== "page" && mode !== "nav") return null;
+    if (mode !== "page" && mode !== "nav" && mode !== "refresh") return null;
 
     const ownerUserId = parts[3] ?? "";
     const page = Number(parts[4] ?? 0);
-    const serverPage = mode === "nav" ? Number(parts[5] ?? 0) : 0;
+    const serverPage = mode === "nav" || mode === "refresh" ? Number(parts[5] ?? 0) : 0;
     if (ownerUserId && ownerUserId !== interaction.user.id) {
       return denyOwnerMismatch("That dashboard isn’t for you.");
     }

--- a/src/commands/noodleDev.js
+++ b/src/commands/noodleDev.js
@@ -194,6 +194,7 @@ export const noodleDevCommand = {
 
     // Legacy: noodle-dev:dashboard:page:<ownerUserId>:<tabPage>
     // New:    noodle-dev:dashboard:nav:<ownerUserId>:<tabPage>:<serverPage>
+    // Also:   noodle-dev:dashboard:refresh:<ownerUserId>:<tabPage>:<serverPage>
     if (parts[0] !== "noodle-dev" || parts[1] !== "dashboard") return null;
 
     const mode = parts[2] ?? "";

--- a/src/jobs/dailyRewardReminders.js
+++ b/src/jobs/dailyRewardReminders.js
@@ -3,6 +3,7 @@ import discordPkg from "discord.js";
 import { openDb, getPlayer, getLatestServerIdForUser, upsertPlayer } from "../db/index.js";
 import { dayKeyUTC, nowTs } from "../util/time.js";
 import { hasDailyRewardAvailable } from "../game/daily.js";
+import { hasUnlimitedMarketStock } from "../game/subscriptions.js";
 import { theme } from "../ui/theme.js";
 import { getIcon, getButtonEmoji } from "../ui/icons.js";
 
@@ -53,11 +54,14 @@ function buildDmReminderComponents({ userId, serverId, channelUrl, optOut }) {
   return [row];
 }
 
-function buildReminderEmbed({ guildName, channelLine, claimLine, user }) {
+function buildReminderEmbed({ guildName, channelLine, claimLine, user, hasHouse247Active = false }) {
+  const openerLine = hasHouse247Active
+    ? `Your ${getIcon("perk_house_247", getIcon("sparkle"))} 24/7 House is active. Vote again in **/noodle quests_vote** to extend it.`
+    : `New orders are on the board today, come back to serve your regulars! ${getIcon("regulars")}`;
   return new EmbedBuilder()
     .setTitle(`Daily Noodle Mail ${getIcon("mail")}`)
     .setDescription([
-      `New orders are on the board today, come back to serve your regulars! ${getIcon("regulars")}`,
+      openerLine,
       `\nYour daily reward is also ready!`,
       channelLine ? `${channelLine}` : null,
       claimLine,
@@ -139,7 +143,8 @@ async function sendDailyRewardReminders(client, getKnownServerIds) {
         : null;
       const channelLine = channelId ? `<#${channelId}>` : null;
       const claimLine = `Use /noodle quests_daily to claim your daily reward.`;
-      const embed = buildReminderEmbed({ guildName, channelLine, claimLine, user });
+      const hasHouse247Active = hasUnlimitedMarketStock(player, now);
+      const embed = buildReminderEmbed({ guildName, channelLine, claimLine, user, hasHouse247Active });
       const components = buildDmReminderComponents({
         userId,
         serverId: lastGuildId || preferredServerId,


### PR DESCRIPTION
## Summary
- Fix dev refresh interactions so `/noodle-dev status` and dashboard refresh buttons rerender correctly.
- Align takeout and normal serve progression messaging:
- badge unlock notices
- bowl milestone notices
- collection completion notices for any newly completed collection
- specialization unlock notices for any newly unlocked specialization (not only hidden specs)
- Align takeout serve formatting with normal serve style (including level-up line/emoji parity and compact spacing).
- Daily reminder DM now switches copy when 24/7 House is active: instead of "new orders on the board," it prompts voting again in `/noodle quests_vote` to extend 24/7 House.
- Preserve and include prior order-lifecycle telemetry additions in the same focused command-surface change set.

## Target Branch (Required)
- [ ] Target is develop (feature/integration testing)
- [x] Target is main (release/hotfix only)

Only one box should be checked.

## Scope
- [x] This PR contains one focused change only (no unrelated refactors/files).
- [x] Branch was started/synced from the correct upstream target (`cleanstart` / `syncmain`).

## Core Hygiene Checklist (Required For All PRs)
- [x] I reviewed staged changes before commit (review).
- [x] Each commit is a logical unit with a clear conventional message.
- [x] I checked branch divergence (ready) and confirmed no accidental extra commits.
- [x] I cleaned up commit history (cleanup / squash) before requesting review.

## Conditional Checklist: If Target Is develop
- [ ] I rebased this branch on latest origin/develop.
- [ ] This PR is intended for integration/QA testing, not direct production release.
- [ ] Any release notes or rollout impact are captured for later promotion to main.

## Conditional Checklist: If Target Is main
- [x] I rebased this branch on latest origin/main.
- [x] This change is release-ready and already validated at appropriate level.
- [x] Merge plan keeps main history clean (prefer squash merge unless intentionally preserving a small curated commit set).

## Validation
- [x] Tests were run locally and pass.
- [x] Lint/type checks pass (if applicable).

Commands run:
```bash
node scripts/pre-review-guard.js
npm test -- test/takeout.test.js test/takeout-menu-season-guard.test.js test/major-actions-regression.test.js
npm test -- test/takeout.test.js test/major-actions-regression.test.js
npm run lint
git rev-list --left-right --count origin/main...HEAD  # 0 1
```

## Risk & Rollback
- [x] I assessed risk for this change.
- [x] Rollback is straightforward (revert PR commit/squash commit).

## Reviewer Notes
- Areas to focus on:
- `src/commands/noodle.js` serve/takeout_serve parity logic and messaging output order.
- `src/commands/noodleDev.js` customId parsing for status/dashboard refresh.
- Known limitations:
- This PR does not add snapshot tests for message text; coverage is behavioral regression tests.
- Follow-up work (if any):
- Consider dedicated tests for specialization/collection unlock message emission in both serve routes.

---

### Review Gate
Do not request review until all required checkboxes are complete.
If any box is intentionally unchecked, explain why in this PR description.

